### PR TITLE
Handle when zipkin_attrs are passed in and sampled correctly

### DIFF
--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -116,8 +116,12 @@ class zipkin_span(object):
         :type binary_annotations: dict of str -> str
         :param port: The port number of the service. Defaults to 0.
         :type port: int
-        :param sample_rate: Custom sampling rate (between 100.0 and 0.0) if
-                            this is the root of the trace
+        :param sample_rate: Rate at which to sample; 0.0 - 100.0. If passed-in
+            zipkin_attrs have is_sampled=False and the sample_rate param is > 0,
+            a new span will be generated at this rate. This means that if you
+            propagate sampling decisions to downstream services, but still have
+            sample_rate > 0 in those services, the actual rate of generated
+            spans for those services will be > sampling_rate.
         :type sample_rate: float
         """
         self.service_name = service_name


### PR DESCRIPTION
When sampled zipkin_attrs are passed into `zipkin_span` along with a sample_rate param, new zipkin_attrs are generated, even when they shouldn't be. This fixes that. 

I also renamed the 'is_root' to 'perform_logging' and moved the logic around a bit. I can't recall if we've discussed this before, but I still find the 'is_root' variable name to be confusing. I'm open to changing that part back if anyone feels strongly.

Finally, added a regression test for the correct zipkin_attrs + sampling logic.