### PR TITLE
add annotation filters, zipkin_client_span, and zipkin_server_span

### DIFF
--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -163,8 +163,8 @@ class zipkin_span(object):
             # get a list of all of the mapped annotations
             self.annotation_filter = {
                 annotation
-                for include_name, annotation_list in STANDARD_ANNOTATIONS.items()
-                for annotation in annotation_list
+                for include_name, annotation_set in STANDARD_ANNOTATIONS.items()
+                for annotation in annotation_set
                 if include_name in include
             }
 
@@ -323,14 +323,44 @@ class zipkin_span(object):
         self.logging_context.binary_annotations_dict.update(extra_annotations)
 
 
+def _validate_args(kwargs):
+    if 'include' in kwargs:
+        raise ValueError(
+            '"include" is not valid in this context.'
+            'You probably want to use zipkin_span()'
+        )
+
+
 class zipkin_client_span(zipkin_span):
+    """Logs a client-side zipkin span.
+
+    Subclass of :class:`zipkin_span` using only annotations relevant to clients
+    """
+
     def __init__(self, *args, **kwargs):
+        """Logs a zipkin span with client annotations.
+
+        See :class:`zipkin_span` for arguments
+        """
+        _validate_args(kwargs)
+
         kwargs['include'] = ('client',)
         super(zipkin_client_span, self).__init__(*args, **kwargs)
 
 
 class zipkin_server_span(zipkin_span):
+    """Logs a server-side zipkin span.
+
+    Subclass of :class:`zipkin_span` using only annotations relevant to servers
+    """
+
     def __init__(self, *args, **kwargs):
+        """Logs a zipkin span with server annotations.
+
+        See :class:`zipkin_span` for arguments
+        """
+        _validate_args(kwargs)
+
         kwargs['include'] = ('server',)
         super(zipkin_server_span, self).__init__(*args, **kwargs)
 

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -34,6 +34,7 @@ STANDARD_ANNOTATIONS = {
     'client': {'cs', 'cr'},
     'server': {'ss', 'sr'},
 }
+STANDARD_ANNOTATIONS_KEYS = frozenset(STANDARD_ANNOTATIONS.keys())
 
 
 class zipkin_span(object):
@@ -154,10 +155,10 @@ class zipkin_span(object):
         if self.sample_rate is not None and not (0.0 <= self.sample_rate <= 100.0):
             raise ZipkinError('Sample rate must be between 0.0 and 100.0')
 
-        if not set(include).issubset(set(STANDARD_ANNOTATIONS.keys())):
+        if not set(include).issubset(STANDARD_ANNOTATIONS_KEYS):
             raise ZipkinError(
                 'Only %s are supported as annotations' %
-                STANDARD_ANNOTATIONS.keys()
+                STANDARD_ANNOTATIONS_KEYS
             )
         else:
             # get a list of all of the mapped annotations

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -161,12 +161,9 @@ class zipkin_span(object):
             )
         else:
             # get a list of all of the mapped annotations
-            self.annotation_filter = {
-                annotation
-                for include_name, annotation_set in STANDARD_ANNOTATIONS.items()
-                for annotation in annotation_set
-                if include_name in include
-            }
+            self.annotation_filter = set()
+            for include_name in include:
+                self.annotation_filter.update(STANDARD_ANNOTATIONS[include_name])
 
     def __call__(self, f):
         @functools.wraps(f)
@@ -326,7 +323,7 @@ class zipkin_span(object):
 def _validate_args(kwargs):
     if 'include' in kwargs:
         raise ValueError(
-            '"include" is not valid in this context.'
+            '"include" is not valid in this context. '
             'You probably want to use zipkin_span()'
         )
 

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -180,6 +180,23 @@ def test_zipkin_invalid_include():
             pass
 
 
+@pytest.mark.parametrize('span_func', [
+    zipkin.zipkin_client_span,
+    zipkin.zipkin_server_span,
+])
+@mock.patch('py_zipkin.zipkin.zipkin_span', autospec=True)
+def test_zipkin_extraneous_include_raises(mock_zipkin_span, span_func):
+    with pytest.raises(ValueError):
+        with span_func(
+            service_name='some_service_name',
+            span_name='span_name',
+            transport_handler=mock.Mock(),
+            sample_rate=100.0,
+            include=('foobar',)
+        ):
+            assert mock_zipkin_span.__init__.call_count == 0
+
+
 @mock.patch('py_zipkin.zipkin.pop_zipkin_attrs', autospec=True)
 @mock.patch('py_zipkin.zipkin.push_zipkin_attrs', autospec=True)
 @mock.patch('py_zipkin.zipkin.create_attrs_for_span', autospec=True)
@@ -330,6 +347,11 @@ def test_span_context_sampled_no_handlers(
     assert get_zipkin_attrs() == zipkin_attrs
 
 
+@pytest.mark.parametrize('span_func, expected_annotations', [
+    (zipkin.zipkin_span, ('cs', 'cr', 'ss', 'sr')),
+    (zipkin.zipkin_client_span, ('cs', 'cr')),
+    (zipkin.zipkin_server_span, ('ss', 'sr')),
+])
 @mock.patch('py_zipkin.thread_local._thread_local', autospec=True)
 @mock.patch('py_zipkin.zipkin.generate_random_64bit_string', autospec=True)
 @mock.patch('py_zipkin.zipkin.zipkin_logger', autospec=True)
@@ -337,6 +359,8 @@ def test_span_context(
     zipkin_logger_mock,
     generate_string_mock,
     thread_local_mock,
+    span_func,
+    expected_annotations,
 ):
     zipkin_attrs = ZipkinAttrs(
         trace_id='1111111111111111',
@@ -353,7 +377,7 @@ def test_span_context(
     zipkin_logger_mock.handlers = [logging_handler]
     generate_string_mock.return_value = '1'
 
-    context = zipkin.zipkin_span(
+    context = span_func(
         service_name='svc',
         span_name='span',
         annotations={'something': 1},
@@ -375,7 +399,7 @@ def test_span_context(
     assert logging_handler.client_spans == []
     # These reserved annotations are based on timestamps so pop em.
     # This also acts as a check that they exist.
-    for annotation in ('cs', 'cr', 'ss', 'sr'):
+    for annotation in expected_annotations:
         client_span['annotations'].pop(annotation)
 
     expected_client_span = {
@@ -387,74 +411,6 @@ def test_span_context(
         'binary_annotations': {'foo': 'bar'},
     }
     assert client_span == expected_client_span
-
-
-@mock.patch('py_zipkin.thread_local._thread_local', autospec=True)
-@mock.patch('py_zipkin.zipkin.generate_random_64bit_string', autospec=True)
-@mock.patch('py_zipkin.zipkin.zipkin_logger', autospec=True)
-def test_client_span_context(
-    zipkin_logger_mock,
-    generate_string_mock,
-    thread_local_mock,
-):
-    zipkin_attrs = ZipkinAttrs(
-        trace_id='1111111111111111',
-        span_id='2222222222222222',
-        parent_span_id='3333333333333333',
-        flags='flags',
-        is_sampled=True,
-    )
-    thread_local_mock.zipkin_attrs = [zipkin_attrs]
-    logging_handler = ZipkinLoggerHandler(zipkin_attrs)
-    assert logging_handler.parent_span_id is None
-    assert logging_handler.client_spans == []
-
-    zipkin_logger_mock.handlers = [logging_handler]
-    generate_string_mock.return_value = '1'
-
-    context = zipkin.zipkin_client_span(
-        service_name='svc',
-        span_name='span',
-    )
-    with context:
-        pass
-
-    client_span = logging_handler.client_spans.pop()
-    assert set(client_span['annotations'].keys()) == {'cr', 'cs'}
-
-
-@mock.patch('py_zipkin.thread_local._thread_local', autospec=True)
-@mock.patch('py_zipkin.zipkin.generate_random_64bit_string', autospec=True)
-@mock.patch('py_zipkin.zipkin.zipkin_logger', autospec=True)
-def test_server_span_context(
-    zipkin_logger_mock,
-    generate_string_mock,
-    thread_local_mock,
-):
-    zipkin_attrs = ZipkinAttrs(
-        trace_id='1111111111111111',
-        span_id='2222222222222222',
-        parent_span_id='3333333333333333',
-        flags='flags',
-        is_sampled=True,
-    )
-    thread_local_mock.zipkin_attrs = [zipkin_attrs]
-    logging_handler = ZipkinLoggerHandler(zipkin_attrs)
-    assert logging_handler.parent_span_id is None
-    assert logging_handler.client_spans == []
-
-    zipkin_logger_mock.handlers = [logging_handler]
-    generate_string_mock.return_value = '1'
-
-    context = zipkin.zipkin_server_span(
-        service_name='svc',
-        span_name='span',
-    )
-    with context:
-        pass
-
-    client_span = logging_handler.client_spans.pop()
-    assert set(client_span['annotations'].keys()) == {'sr', 'ss'}
 
 
 @mock.patch('py_zipkin.zipkin.pop_zipkin_attrs', autospec=True)


### PR DESCRIPTION
This is a pretty rough attempt at adding support for client-only or server-only spans. I tried to base it loosely on how finagle does filtering (referenced in #13) - that is, have standard span subclasses that filter the annotations to collect. The big difference being that we still allow both client and server annotations in the span (the main case being method annotations or any annotations that are not inter-process)

It doesn't address error annotations or wire events. It also doesn't address the root span, which we currently still enforce to be `ss`/`sr` only.