### PR TITLE
[#15] add host param for thrift create_endpoint

### DIFF
--- a/py_zipkin/thrift/__init__.py
+++ b/py_zipkin/thrift/__init__.py
@@ -49,16 +49,19 @@ def create_binary_annotation(key, value, annotation_type, host):
     )
 
 
-def create_endpoint(port=0, service_name='unknown'):
+def create_endpoint(port=0, service_name='unknown', host=None):
     """Create a zipkin Endpoint object.
 
     An Endpoint object holds information about the network context of a span.
 
     :param port: int value of the port. Defaults to 0
     :param service_name: service name as a str. Defaults to 'unknown'
+    :param host: string containing ipv4 value of the host, if not provided,
+    host is determined automatically
     :returns: zipkin Endpoint object
     """
-    host = socket.gethostbyname(socket.gethostname())
+    if host is None:
+        host = socket.gethostbyname(socket.gethostname())
     # Convert ip address to network byte order
     ipv4 = struct.unpack('!i', socket.inet_aton(host))[0]
     # Zipkin passes unsigned values in signed types because Thrift has no

--- a/tests/thrift/thrift_test.py
+++ b/tests/thrift/thrift_test.py
@@ -47,6 +47,16 @@ def test_create_endpoint_defaults_service_name(gethostbyname):
 
 
 @mock.patch('socket.gethostbyname', autospec=True)
+def test_create_endpoint_correct_host_ip(gethostbyname):
+    gethostbyname.return_value = '1.2.3.4'
+    endpoint = thrift.create_endpoint(host='0.0.0.0')
+    assert endpoint.service_name == 'unknown'
+    assert endpoint.port == 0
+    # An IP address of 0.0.0.0 unpacks to just 0
+    assert endpoint.ipv4 == 0
+
+
+@mock.patch('socket.gethostbyname', autospec=True)
 def test_copy_endpoint_with_new_service_name(gethostbyname):
     gethostbyname.return_value = '0.0.0.0'
     endpoint = thrift.create_endpoint(


### PR DESCRIPTION
overrides behaviour of determining host ip
backwards compatible with previous interface
unit test for host parameter in create_endpoint