### PR TITLE
Decorators now create new zipkin_span instances instead of using itself

### DIFF
--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -145,6 +145,7 @@ class zipkin_span(object):
         self.port = port
         self.logging_context = None
         self.sample_rate = sample_rate
+        self.include = include
 
         # Validation checks
         if self.zipkin_attrs or self.sample_rate is not None:
@@ -169,7 +170,17 @@ class zipkin_span(object):
     def __call__(self, f):
         @functools.wraps(f)
         def decorated(*args, **kwargs):
-            with self:
+            with zipkin_span(
+                service_name=self.service_name,
+                span_name=self.span_name,
+                zipkin_attrs=self.zipkin_attrs,
+                transport_handler=self.transport_handler,
+                annotations=self.annotations,
+                binary_annotations=self.binary_annotations,
+                port=self.port,
+                sample_rate=self.sample_rate,
+                include=self.include,
+            ):
                 return f(*args, **kwargs)
         return decorated
 

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -458,6 +458,25 @@ def test_zipkin_span_decorator(
     pop_zipkin_attrs_mock.assert_called_once_with()
 
 
+@mock.patch('py_zipkin.zipkin.create_endpoint', wraps=zipkin.create_endpoint)
+def test_zipkin_span_decorator_many(create_endpoint_mock):
+    @zipkin.zipkin_span(service_name='decorator')
+    def test_func(a, b):
+        return a + b
+
+    assert test_func(1, 2) == 3
+    assert create_endpoint_mock.call_count == 0
+    with zipkin.zipkin_span(
+            service_name='context_manager',
+            transport_handler=mock.Mock(),
+            sample_rate=100.0,
+    ):
+        assert test_func(1, 2) == 3
+    assert create_endpoint_mock.call_count == 1
+    assert test_func(1, 2) == 3
+    assert create_endpoint_mock.call_count == 1
+
+
 def test_update_binary_annotations_for_root_span():
     zipkin_attrs = ZipkinAttrs(
         trace_id='0',


### PR DESCRIPTION
This fixes #20
I believe the work around implemented in #19 is no longer needed