### PR TITLE
Properly report timestamp and duration

### DIFF
--- a/py_zipkin/thrift/__init__.py
+++ b/py_zipkin/thrift/__init__.py
@@ -131,19 +131,24 @@ def create_span(
     span_name,
     annotations,
     binary_annotations,
+    timestamp_s,
+    duration_s,
 ):
     """Takes a bunch of span attributes and returns a thriftpy representation
-    of the span.
+    of the span. Timestamps passed in are in seconds, they're converted to
+    microseconds before thrift encoding.
     """
     span_dict = {
-        "trace_id": unsigned_hex_to_signed_int(trace_id),
-        "name": span_name,
-        "id": unsigned_hex_to_signed_int(span_id),
-        "annotations": annotations,
-        "binary_annotations": binary_annotations,
+        'trace_id': unsigned_hex_to_signed_int(trace_id),
+        'name': span_name,
+        'id': unsigned_hex_to_signed_int(span_id),
+        'annotations': annotations,
+        'binary_annotations': binary_annotations,
+        'timestamp': timestamp_s * 1000000 if timestamp_s else None,
+        'duration': duration_s * 1000000 if duration_s else None,
     }
     if parent_span_id:
-        span_dict["parent_id"] = unsigned_hex_to_signed_int(parent_span_id)
+        span_dict['parent_id'] = unsigned_hex_to_signed_int(parent_span_id)
     return zipkin_core.Span(**span_dict)
 
 

--- a/py_zipkin/thrift/__init__.py
+++ b/py_zipkin/thrift/__init__.py
@@ -144,8 +144,8 @@ def create_span(
         'id': unsigned_hex_to_signed_int(span_id),
         'annotations': annotations,
         'binary_annotations': binary_annotations,
-        'timestamp': timestamp_s * 1000000 if timestamp_s else None,
-        'duration': duration_s * 1000000 if duration_s else None,
+        'timestamp': int(timestamp_s * 1000000) if timestamp_s else None,
+        'duration': int(duration_s * 1000000) if duration_s else None,
     }
     if parent_span_id:
         span_dict['parent_id'] = unsigned_hex_to_signed_int(parent_span_id)

--- a/tests/logging_helper_test.py
+++ b/tests/logging_helper_test.py
@@ -282,7 +282,8 @@ def test_log_span_defensive_about_transport_handler(
     thrift_obj,
     create_sp
 ):
-    """Make sure log_span doesn't try to call the transport handler if it's None."""
+    """Make sure log_span doesn't try to call the transport handler if it's
+    None."""
     logging_helper.log_span(
         span_id='0000000000000002',
         parent_span_id='0000000000000001',

--- a/tests/thrift/thrift_test.py
+++ b/tests/thrift/thrift_test.py
@@ -3,24 +3,27 @@ import mock
 from py_zipkin import thrift
 
 
-@mock.patch('py_zipkin.thrift.zipkin_core.Span', autospec=True)
-def test_create_span(Span):
+def test_create_span():
     # Not much logic here so this is just a smoke test. The only
     # substantive thing is that hex IDs get converted to ints.
-    thrift.create_span(
+    span = thrift.create_span(
         span_id='0000000000000001',
         parent_span_id='0000000000000002',
         trace_id='000000000000000f',
         span_name='foo',
         annotations='ann',
         binary_annotations='binary_ann',
+        timestamp_s=1485920381.2,
+        duration_s=2.0,
     )
-    Span.assert_called_once_with(**{
-        'id': 1, 'parent_id': 2,
-        'name': 'foo', 'trace_id': 15,
-        'name': 'foo', 'annotations': 'ann',
-        'binary_annotations': 'binary_ann',
-    })
+    assert span.id == 1
+    assert span.parent_id == 2
+    assert span.trace_id == 15
+    assert span.name == 'foo'
+    assert span.annotations == 'ann'
+    assert span.binary_annotations == 'binary_ann'
+    assert span.timestamp == 1485920381.2 * 1000000
+    assert span.duration == 2.0 * 1000000
 
 
 @mock.patch('socket.gethostbyname', autospec=True)

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -45,8 +45,9 @@ def test_zipkin_span_for_new_trace(
         logger_handler_cls_mock.return_value,
         'span_name',
         transport_handler,
-        {},
-        False,
+        report_root_timestamp=True,
+        binary_annotations={},
+        add_logging_annotation=False,
     )
     pop_zipkin_attrs_mock.assert_called_once_with()
 
@@ -88,14 +89,17 @@ def test_zipkin_span_passed_sampled_attrs(
     push_zipkin_attrs_mock.assert_called_once_with(zipkin_attrs)
     create_endpoint_mock.assert_called_once_with(5, 'some_service_name')
     logger_handler_cls_mock.assert_called_once_with(zipkin_attrs)
+    # Logging context should not report timestamp/duration for the server span,
+    # since it's assumed that the client part of this span will do that.
     logging_context_cls_mock.assert_called_once_with(
         zipkin_attrs,
         create_endpoint_mock.return_value,
         logger_handler_cls_mock.return_value,
         'span_name',
         transport_handler,
-        {},
-        False,
+        report_root_timestamp=False,
+        binary_annotations={},
+        add_logging_annotation=False,
     )
     pop_zipkin_attrs_mock.assert_called_once_with()
 
@@ -449,14 +453,17 @@ def test_zipkin_span_decorator(
     create_endpoint_mock.assert_called_once_with(5, 'some_service_name')
     logger_handler_cls_mock.assert_called_once_with(
         create_attrs_for_span_mock.return_value)
+    # The decorator was passed a sample rate and no Zipkin attrs, so it's
+    # assumed to be the root of a trace and it should report timestamp/duration
     logging_context_cls_mock.assert_called_once_with(
         create_attrs_for_span_mock.return_value,
         create_endpoint_mock.return_value,
         logger_handler_cls_mock.return_value,
         'span_name',
         transport_handler,
-        {},
-        False,
+        report_root_timestamp=True,
+        binary_annotations={},
+        add_logging_annotation=False,
     )
     pop_zipkin_attrs_mock.assert_called_once_with()
 


### PR DESCRIPTION
Reporting timestamp and duration fields as per http://zipkin.io/pages/instrumenting.html#timestamps-and-duration.

I tried to update stale docstrings and remove unnecessary comments as I went. I also tried to change some (what I thought were, at least) confusing references to a "root" span, as all spans that were called this in the comments weren't truly root spans, in that they weren't the outermost span in a trace. They were simple the outermost span in _the local python process_.

This *may* cause backwards compatibility issues, because the serialized spans are encoded with a different version of the thrift spec. The public python API (i.e. `zipkin_span`) didn't change. 