### PR TITLE
update_binary_annotations() now handles both root and non-root spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ def tween(request):
         port=22,
     ) as zipkin_context:
         response = handler(request)
-        zipkin_context.update_binary_annotations_for_root_span(
+        zipkin_context.update_binary_annotations(
             some_binary_annotations)
         return response
 ```
@@ -76,8 +76,8 @@ def some_function(a, b):
 
 #### Other utilities
 
-`zipkin_span.update_binary_annotations_for_root_span()` can be used inside a zipkin trace
-to add to the existing set of binary annotations for the root span.
+`zipkin_span.update_binary_annotations()` can be used inside a zipkin trace
+to add to the existing set of binary annotations.
 
 ```python
 def some_function(a, b):
@@ -89,7 +89,7 @@ def some_function(a, b):
         sample_rate=0.05,
     ) as zipkin_context:
         result = do_stuff(a, b)
-        zipkin_context.update_binary_annotations_for_root_span({'result': result})
+        zipkin_context.update_binary_annotations({'result': result})
 ```
 
 `create_http_headers_for_new_span()` creates a set of HTTP headers that can be forwarded

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -533,7 +533,7 @@ def test_update_binary_annotations():
             assert 'two' not in context.logging_context.binary_annotations_dict
 
 
-def test_update_binary_annotations_errors():
+def test_update_binary_annotations_should_not_error_if_not_tracing():
     zipkin_attrs = ZipkinAttrs(
         trace_id='0',
         span_id='1',

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -500,7 +500,7 @@ def test_zipkin_span_add_logging_annotation(mock_context):
     assert kwargs['add_logging_annotation']
 
 
-def test_update_binary_annotations_for_root_span():
+def test_update_binary_annotations():
     zipkin_attrs = ZipkinAttrs(
         trace_id='0',
         span_id='1',
@@ -518,11 +518,22 @@ def test_update_binary_annotations_for_root_span():
 
     with context:
         assert 'test' not in context.logging_context.binary_annotations_dict
-        context.update_binary_annotations_for_root_span({'test': 'hi'})
+        context.update_binary_annotations({'test': 'hi'})
         assert context.logging_context.binary_annotations_dict['test'] == 'hi'
 
+        nested_context = zipkin.zipkin_span(
+            service_name='my_service',
+            span_name='nested_span',
+            binary_annotations={'one': 'one'},
+        )
+        with nested_context:
+            assert 'one' not in context.logging_context.binary_annotations_dict
+            nested_context.update_binary_annotations({'two': 'two'})
+            assert 'two' in nested_context.binary_annotations
+            assert 'two' not in context.logging_context.binary_annotations_dict
 
-def test_update_binary_annotations_for_root_span_errors():
+
+def test_update_binary_annotations_errors():
     zipkin_attrs = ZipkinAttrs(
         trace_id='0',
         span_id='1',
@@ -540,25 +551,7 @@ def test_update_binary_annotations_for_root_span_errors():
 
     with context:
         # A non-sampled request should result in a no-op
-        context.update_binary_annotations_for_root_span({'test': 'hi'})
-
-    zipkin_attrs = ZipkinAttrs(
-        trace_id='0',
-        span_id='1',
-        parent_span_id=None,
-        flags='0',
-        is_sampled=True,
-    )
-    context = zipkin.zipkin_span(
-        service_name='my_service',
-        span_name='span_name',
-        zipkin_attrs=zipkin_attrs,
-        transport_handler=mock.Mock(),
-        port=5,
-    )
-    # Updating binary annotations without logging set up should error
-    with pytest.raises(ZipkinError):
-        context.update_binary_annotations_for_root_span({'test': 'hi'})
+        context.update_binary_annotations({'test': 'hi'})
 
 
 @mock.patch('py_zipkin.zipkin.generate_random_64bit_string', autospec=True)


### PR DESCRIPTION
Previously, zipkin_span had a method called update_binary_annotations_for_root_span which only worked if it was called on a zipkin_span that represented the root span of a trace. In all other cases, it would fail because there would be no logging context associated with the zipkin_span.

It turns out that all one has to do to add binary_annotations to a non-root span is to just update the self.binary_annotations dictionary directly, but it's not immediately obvious. By changing the update function to be called update_binary_annotations() and making it handle both root and non-root spans, you can now just call it on a span context and expect it to work correctly

This will require a pyramid_zipkin change as well.



To clarify the before/after effects of this PR...

BEFORE:
```python
with zipkin_span(
    service_name='some_service',
    span_name='a_root_span',
    sample_rate=100.0,
) as zipkin_context:
    # can use update_binary_annotations_for_root_span() to add annotations to the root span
    zipkin_context.update_binary_annotations_for_root_span({'some_key': 'some_val'})

    with zipkin_span(
        service_name='some_service',
        span_name='nested_span',
    ) as nested_zipkin_span:
        # have to update binary annotations directly
        nested_zipkin_span.binary_annotations.update({'some_key': 'some_val'})
```

Having 2 different methods of updating binary annotations based on whether the span is a root span or not is confusing. This PR just consolidates both methods into a single update_binary_annotations method.