### PR TITLE
Check for no zipkin_attrs when updating binary annotations

### DIFF
--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -350,6 +350,8 @@ class zipkin_span(object):
 
         If this trace is not being sampled then this is a no-op.
         """
+        if not self.zipkin_attrs:
+            return
         if not self.zipkin_attrs.is_sampled:
             return
         if not self.logging_context:

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -554,6 +554,17 @@ def test_update_binary_annotations_should_not_error_if_not_tracing():
         context.update_binary_annotations({'test': 'hi'})
 
 
+def test_update_binary_annotations_should_not_error_for_child_spans():
+    non_tracing_context = zipkin.zipkin_span(
+        service_name='my_service',
+        span_name='span_name',
+    )
+    with non_tracing_context:
+        # Updating the binary annotations for a non-tracing child span
+        # should result in a no-op
+        non_tracing_context.update_binary_annotations({'test': 'hi'})
+
+
 @mock.patch('py_zipkin.zipkin.generate_random_64bit_string', autospec=True)
 def test_create_attrs_for_span(random_mock):
     random_mock.return_value = '0000000000000042'


### PR DESCRIPTION
Calling update_binary_annotations on a context that doesn't have zipkin_attrs (which occurs when the span is a child span in a trace that is not being sampled) results in an attribute error. This fixes the bug by also checking for the existence of zipkin_attrs inside update_binary_annotations.