### PR TITLE
Add 128-bit trace id support

### DIFF
--- a/py_zipkin/thrift/__init__.py
+++ b/py_zipkin/thrift/__init__.py
@@ -143,7 +143,7 @@ def create_span(
     trace_id_high = None
     if trace_id_length > 16:
         assert trace_id_length == 32
-        trace_id, trace_id_high = trace_id[:16], trace_id[16:]
+        trace_id, trace_id_high = trace_id[16:], trace_id[:16]
 
     span_dict = {
         'trace_id': unsigned_hex_to_signed_int(trace_id),

--- a/py_zipkin/thrift/__init__.py
+++ b/py_zipkin/thrift/__init__.py
@@ -153,8 +153,8 @@ def create_span(
         'binary_annotations': binary_annotations,
         'timestamp': int(timestamp_s * 1000000) if timestamp_s else None,
         'duration': int(duration_s * 1000000) if duration_s else None,
-        'trace_id_high': unsigned_hex_to_signed_int(trace_id_high) \
-            if trace_id_high else None,
+        'trace_id_high': unsigned_hex_to_signed_int(trace_id_high)
+        if trace_id_high else None,
     }
     if parent_span_id:
         span_dict['parent_id'] = unsigned_hex_to_signed_int(parent_span_id)

--- a/py_zipkin/thrift/__init__.py
+++ b/py_zipkin/thrift/__init__.py
@@ -138,6 +138,13 @@ def create_span(
     of the span. Timestamps passed in are in seconds, they're converted to
     microseconds before thrift encoding.
     """
+    # Check if trace_id is 128-bit. If so, record trace_id_high separately.
+    trace_id_length = len(trace_id)
+    trace_id_high = None
+    if trace_id_length > 16:
+        assert trace_id_length == 32
+        trace_id, trace_id_high = trace_id[:16], trace_id[16:]
+
     span_dict = {
         'trace_id': unsigned_hex_to_signed_int(trace_id),
         'name': span_name,
@@ -146,6 +153,8 @@ def create_span(
         'binary_annotations': binary_annotations,
         'timestamp': int(timestamp_s * 1000000) if timestamp_s else None,
         'duration': int(duration_s * 1000000) if duration_s else None,
+        'trace_id_high': unsigned_hex_to_signed_int(trace_id_high) \
+            if trace_id_high else None,
     }
     if parent_span_id:
         span_dict['parent_id'] = unsigned_hex_to_signed_int(parent_span_id)

--- a/py_zipkin/thrift/__init__.py
+++ b/py_zipkin/thrift/__init__.py
@@ -145,6 +145,9 @@ def create_span(
         assert trace_id_length == 32
         trace_id, trace_id_high = trace_id[16:], trace_id[:16]
 
+    if trace_id_high:
+        trace_id_high = unsigned_hex_to_signed_int(trace_id_high)
+
     span_dict = {
         'trace_id': unsigned_hex_to_signed_int(trace_id),
         'name': span_name,
@@ -153,8 +156,7 @@ def create_span(
         'binary_annotations': binary_annotations,
         'timestamp': int(timestamp_s * 1000000) if timestamp_s else None,
         'duration': int(duration_s * 1000000) if duration_s else None,
-        'trace_id_high': unsigned_hex_to_signed_int(trace_id_high)
-        if trace_id_high else None,
+        'trace_id_high': trace_id_high,
     }
     if parent_span_id:
         span_dict['parent_id'] = unsigned_hex_to_signed_int(parent_span_id)

--- a/py_zipkin/util.py
+++ b/py_zipkin/util.py
@@ -14,6 +14,15 @@ def generate_random_64bit_string():
     return str(codecs.encode(os.urandom(8), 'hex_codec').decode('utf-8'))
 
 
+def generate_random_128bit_string():
+    """Returns a 128 bit UTF-8 encoded string. Follows the same conventions
+    as generate_random_64bit_string().
+
+    :returns: random 32-character string
+    """
+    return str(codecs.encode(os.urandom(16), 'hex_codec').decode('utf-8'))
+
+
 def unsigned_hex_to_signed_int(hex_string):
     """Converts a 64-bit hex string to a signed int value.
 

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -417,7 +417,7 @@ def create_attrs_for_span(
     sample_rate=100.0,
     trace_id=None,
     span_id=None,
-    use_128bit_trace_id=False
+    use_128bit_trace_id=False,
 ):
     """Creates a set of zipkin attributes for a span.
 

--- a/tests/thrift/thrift_test.py
+++ b/tests/thrift/thrift_test.py
@@ -32,14 +32,14 @@ def test_create_span_with_128_bit_trace_ids():
     span = thrift.create_span(
         span_id='0000000000000001',
         parent_span_id='0000000000000002',
-        trace_id='000000000000000f000000000000000f',
+        trace_id='000000000000000f000000000000000e',
         span_name='foo',
         annotations='ann',
         binary_annotations='binary_ann',
         timestamp_s=1485920381.2,
         duration_s=2.0,
     )
-    assert span.trace_id == 15
+    assert span.trace_id == 14
     assert span.trace_id_high == 15
 
 

--- a/tests/thrift/thrift_test.py
+++ b/tests/thrift/thrift_test.py
@@ -25,7 +25,7 @@ def test_create_span():
     assert span.binary_annotations == 'binary_ann'
     assert span.timestamp == 1485920381.2 * 1000000
     assert span.duration == 2.0 * 1000000
-    assert span.trace_id_high == None
+    assert span.trace_id_high is None
 
 
 def test_create_span_with_128_bit_trace_ids():
@@ -45,7 +45,7 @@ def test_create_span_with_128_bit_trace_ids():
 
 def test_create_span_fails_with_wrong_128_bit_trace_id_length():
     with pytest.raises(AssertionError):
-        span = thrift.create_span(
+        thrift.create_span(
             span_id='0000000000000001',
             parent_span_id='0000000000000002',
             trace_id='000000000000000f000000000000000',
@@ -57,7 +57,7 @@ def test_create_span_fails_with_wrong_128_bit_trace_id_length():
         )
 
     with pytest.raises(AssertionError):
-        span = thrift.create_span(
+        thrift.create_span(
             span_id='0000000000000001',
             parent_span_id='0000000000000002',
             trace_id='000000000000000f000000000000000f0',

--- a/tests/thrift/thrift_test.py
+++ b/tests/thrift/thrift_test.py
@@ -1,4 +1,5 @@
 import mock
+import pytest
 
 from py_zipkin import thrift
 
@@ -24,6 +25,48 @@ def test_create_span():
     assert span.binary_annotations == 'binary_ann'
     assert span.timestamp == 1485920381.2 * 1000000
     assert span.duration == 2.0 * 1000000
+    assert span.trace_id_high == None
+
+
+def test_create_span_with_128_bit_trace_ids():
+    span = thrift.create_span(
+        span_id='0000000000000001',
+        parent_span_id='0000000000000002',
+        trace_id='000000000000000f000000000000000f',
+        span_name='foo',
+        annotations='ann',
+        binary_annotations='binary_ann',
+        timestamp_s=1485920381.2,
+        duration_s=2.0,
+    )
+    assert span.trace_id == 15
+    assert span.trace_id_high == 15
+
+
+def test_create_span_fails_with_wrong_128_bit_trace_id_length():
+    with pytest.raises(AssertionError):
+        span = thrift.create_span(
+            span_id='0000000000000001',
+            parent_span_id='0000000000000002',
+            trace_id='000000000000000f000000000000000',
+            span_name='foo',
+            annotations='ann',
+            binary_annotations='binary_ann',
+            timestamp_s=1485920381.2,
+            duration_s=2.0,
+        )
+
+    with pytest.raises(AssertionError):
+        span = thrift.create_span(
+            span_id='0000000000000001',
+            parent_span_id='0000000000000002',
+            trace_id='000000000000000f000000000000000f0',
+            span_name='foo',
+            annotations='ann',
+            binary_annotations='binary_ann',
+            timestamp_s=1485920381.2,
+            duration_s=2.0,
+        )
 
 
 @mock.patch('socket.gethostbyname', autospec=True)

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -15,6 +15,16 @@ def test_generate_random_64bit_string(rand):
     assert isinstance(random_string, str)
 
 
+@mock.patch('py_zipkin.util.codecs.encode', autospec=True)
+def test_generate_random_128bit_string(rand):
+    rand.return_value = b'17133d482ba4f60517133d482ba4f605'
+    random_string = util.generate_random_128bit_string()
+    assert random_string == '17133d482ba4f60517133d482ba4f605'
+    # This acts as a contract test of sorts. This should return a str
+    # in both py2 and py3. IOW, no unicode objects.
+    assert isinstance(random_string, str)
+
+
 def test_unsigned_hex_to_signed_int():
     assert util.unsigned_hex_to_signed_int('17133d482ba4f605') == \
         1662740067609015813


### PR DESCRIPTION
#28 

A `use_128bit_trace_id` flag on zipkin_span will control whether or not 128-bit (32 char hext string) trace ids are generated. Default is False.