### PR TITLE
handle socket exception in create_endpoint

### DIFF
--- a/py_zipkin/thrift/__init__.py
+++ b/py_zipkin/thrift/__init__.py
@@ -61,7 +61,10 @@ def create_endpoint(port=0, service_name='unknown', host=None):
     :returns: zipkin Endpoint object
     """
     if host is None:
-        host = socket.gethostbyname(socket.gethostname())
+        try:
+            host = socket.gethostbyname(socket.gethostname())
+        except socket.gaierror:
+            host = '127.0.0.1'
     # Convert ip address to network byte order
     ipv4 = struct.unpack('!i', socket.inet_aton(host))[0]
     # Zipkin passes unsigned values in signed types because Thrift has no

--- a/tests/thrift/thrift_test.py
+++ b/tests/thrift/thrift_test.py
@@ -1,5 +1,6 @@
 import mock
 import pytest
+import socket
 
 from py_zipkin import thrift
 
@@ -115,6 +116,20 @@ def test_copy_endpoint_with_new_service_name(gethostbyname):
     assert new_endpoint.service_name == 'blargh'
     # An IP address of 0.0.0.0 unpacks to just 0
     assert endpoint.ipv4 == 0
+
+
+@mock.patch('socket.gethostbyname', autospec=True)
+def test_create_endpoint_defaults_localhost(gethostbyname):
+    gethostbyname.side_effect = socket.gaierror
+
+    endpoint = thrift.create_endpoint(
+        port=8080,
+        service_name='foo',
+    )
+    assert endpoint.service_name == 'foo'
+    assert endpoint.port == 8080
+    # An IP address of 127.0.0.1 unpacks to 2130706433
+    assert endpoint.ipv4 == 2130706433
 
 
 def test_create_annotation():


### PR DESCRIPTION
This fixes #37 by catching `socket.gaierror` (the exception for an unresolvable name) and defaults to `127.0.0.1`.

I didn't add any logging for the error, but i think it might be nice. @kaisen, is there currently a preferred way to log warnings?