### PR TITLE
Add support for adding a 'sa' binary annotation to spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,29 @@ def some_function(a, b):
         zipkin_context.update_binary_annotations({'result': result})
 ```
 
+`zipkin_span.add_sa_binary_annotation()` can be used to add a binary annotation
+to the current span with the key 'sa'. This function allows the user to specify the
+destination address of the service being called (useful if the destination doesn't
+support zipkin). See http://zipkin.io/pages/data_model.html for more information on the
+'sa' binary annotation.
+
+```python
+def some_function():
+    with zipkin_span(
+        service_name='my_service',
+        span_name='some_function',
+        transport_handler=some_handler,
+        port=42,
+        sample_rate=0.05,
+    ) as zipkin_context:
+        make_call_to_non_instrumented_service()
+        zipkin_context.add_sa_binary_annotation(
+            port=123,
+            service_name='non_instrumented_service',
+            host='12.34.56.78',
+        )
+```
+
 `create_http_headers_for_new_span()` creates a set of HTTP headers that can be forwarded
 in a request to another service.
 

--- a/py_zipkin/logging_helper.py
+++ b/py_zipkin/logging_helper.py
@@ -56,6 +56,7 @@ class ZipkinLoggingContext(object):
         self.response_status_code = 0
         self.report_root_timestamp = report_root_timestamp
         self.binary_annotations_dict = binary_annotations or {}
+        self.sa_binary_annotation = None
         self.add_logging_annotation = add_logging_annotation
 
     def start(self):
@@ -126,6 +127,8 @@ class ZipkinLoggingContext(object):
                 thrift_binary_annotations = binary_annotation_list_builder(
                     binary_annotations, endpoint
                 )
+                if 'sa_binary_annotation' in span and span['sa_binary_annotation']:
+                    thrift_binary_annotations.append(span['sa_binary_annotation'])
 
                 log_span(
                     span_id=span_id,
@@ -166,6 +169,8 @@ class ZipkinLoggingContext(object):
                 self.binary_annotations_dict,
                 self.thrift_endpoint,
             )
+            if self.sa_binary_annotation:
+                thrift_binary_annotations.append(self.sa_binary_annotation)
 
             if self.report_root_timestamp:
                 timestamp = self.start_timestamp
@@ -219,6 +224,7 @@ class ZipkinLoggerHandler(logging.StreamHandler, object):
         service_name,
         annotations,
         binary_annotations,
+        sa_binary_annotation=None,
         span_id=None,
     ):
         """Convenience method for storing a local child span (a zipkin_span
@@ -232,6 +238,7 @@ class ZipkinLoggerHandler(logging.StreamHandler, object):
             'span_id': span_id,
             'annotations': annotations,
             'binary_annotations': binary_annotations,
+            'sa_binary_annotation': sa_binary_annotation,
         })
 
     def emit(self, record):

--- a/py_zipkin/logging_helper.py
+++ b/py_zipkin/logging_helper.py
@@ -56,7 +56,7 @@ class ZipkinLoggingContext(object):
         self.response_status_code = 0
         self.report_root_timestamp = report_root_timestamp
         self.binary_annotations_dict = binary_annotations or {}
-        self.sa_binary_annotation = None
+        self.sa_binary_annotations = []
         self.add_logging_annotation = add_logging_annotation
 
     def start(self):
@@ -127,8 +127,8 @@ class ZipkinLoggingContext(object):
                 thrift_binary_annotations = binary_annotation_list_builder(
                     binary_annotations, endpoint
                 )
-                if 'sa_binary_annotation' in span and span['sa_binary_annotation']:
-                    thrift_binary_annotations.append(span['sa_binary_annotation'])
+                if span.get('sa_binary_annotations'):
+                    thrift_binary_annotations += span['sa_binary_annotations']
 
                 log_span(
                     span_id=span_id,
@@ -169,8 +169,8 @@ class ZipkinLoggingContext(object):
                 self.binary_annotations_dict,
                 self.thrift_endpoint,
             )
-            if self.sa_binary_annotation:
-                thrift_binary_annotations.append(self.sa_binary_annotation)
+            if self.sa_binary_annotations:
+                thrift_binary_annotations += self.sa_binary_annotations
 
             if self.report_root_timestamp:
                 timestamp = self.start_timestamp
@@ -224,7 +224,7 @@ class ZipkinLoggerHandler(logging.StreamHandler, object):
         service_name,
         annotations,
         binary_annotations,
-        sa_binary_annotation=None,
+        sa_binary_annotations=None,
         span_id=None,
     ):
         """Convenience method for storing a local child span (a zipkin_span
@@ -238,7 +238,7 @@ class ZipkinLoggerHandler(logging.StreamHandler, object):
             'span_id': span_id,
             'annotations': annotations,
             'binary_annotations': binary_annotations,
-            'sa_binary_annotation': sa_binary_annotation,
+            'sa_binary_annotations': sa_binary_annotations,
         })
 
     def emit(self, record):

--- a/py_zipkin/thrift/__init__.py
+++ b/py_zipkin/thrift/__init__.py
@@ -13,6 +13,7 @@ from py_zipkin.util import unsigned_hex_to_signed_int
 thrift_filepath = os.path.join(os.path.dirname(__file__), 'zipkinCore.thrift')
 zipkin_core = thriftpy.load(thrift_filepath, module_name="zipkinCore_thrift")
 
+SERVER_ADDR_VAL = '\x01'
 
 dummy_endpoint = zipkin_core.Endpoint()
 

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -174,10 +174,10 @@ class zipkin_span(object):
         self.use_128bit_trace_id = use_128bit_trace_id
         self.host = host
 
-        # Spans that log a 'cs' timestamp can additionally record a
-        # 'sa' binary annotation that shows where the request is going.
-        # This holds the 'sa' binary annotation if one is to be set.
-        self.sa_binary_annotation = None
+        # Spans that log a 'cs' timestamp can additionally record
+        # 'sa' binary annotations that show where the request is going.
+        # This holds a list of 'sa' binary annotations.
+        self.sa_binary_annotations = []
 
         # Validation checks
         if self.zipkin_attrs or self.sample_rate is not None:
@@ -361,7 +361,7 @@ class zipkin_span(object):
             service_name=self.service_name,
             annotations=self.annotations,
             binary_annotations=self.binary_annotations,
-            sa_binary_annotation=self.sa_binary_annotation,
+            sa_binary_annotations=self.sa_binary_annotations,
             span_id=self.zipkin_attrs.span_id,
         )
 
@@ -417,15 +417,15 @@ class zipkin_span(object):
             host=host,
         )
         sa_binary_annotation = create_binary_annotation(
-            key='sa',
+            key=zipkin_core.SERVER_ADDR,
             value='1',
             annotation_type=zipkin_core.AnnotationType.BOOL,
             host=sa_endpoint,
         )
         if not self.logging_context:
-            self.sa_binary_annotation = sa_binary_annotation
+            self.sa_binary_annotations.append(sa_binary_annotation)
         else:
-            self.logging_context.sa_binary_annotation = sa_binary_annotation
+            self.logging_context.sa_binary_annotations.append(sa_binary_annotation)
 
 
 def _validate_args(kwargs):

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -11,6 +11,7 @@ from py_zipkin.logging_helper import ZipkinLoggingContext
 from py_zipkin.thread_local import get_zipkin_attrs
 from py_zipkin.thread_local import pop_zipkin_attrs
 from py_zipkin.thread_local import push_zipkin_attrs
+from py_zipkin.thrift import SERVER_ADDR_VAL
 from py_zipkin.thrift import create_binary_annotation
 from py_zipkin.thrift import create_endpoint
 from py_zipkin.thrift import zipkin_core
@@ -418,7 +419,7 @@ class zipkin_span(object):
         )
         sa_binary_annotation = create_binary_annotation(
             key=zipkin_core.SERVER_ADDR,
-            value='1',
+            value=SERVER_ADDR_VAL,
             annotation_type=zipkin_core.AnnotationType.BOOL,
             host=sa_endpoint,
         )

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -11,7 +11,9 @@ from py_zipkin.logging_helper import ZipkinLoggingContext
 from py_zipkin.thread_local import get_zipkin_attrs
 from py_zipkin.thread_local import pop_zipkin_attrs
 from py_zipkin.thread_local import push_zipkin_attrs
+from py_zipkin.thrift import create_binary_annotation
 from py_zipkin.thrift import create_endpoint
+from py_zipkin.thrift import zipkin_core
 from py_zipkin.util import generate_random_64bit_string
 from py_zipkin.util import generate_random_128bit_string
 
@@ -171,6 +173,11 @@ class zipkin_span(object):
         self.report_root_timestamp_override = report_root_timestamp
         self.use_128bit_trace_id = use_128bit_trace_id
         self.host = host
+
+        # Spans that log a 'cs' timestamp can additionally record a
+        # 'sa' binary annotation that shows where the request is going.
+        # This holds the 'sa' binary annotation if one is to be set.
+        self.sa_binary_annotation = None
 
         # Validation checks
         if self.zipkin_attrs or self.sample_rate is not None:
@@ -354,6 +361,7 @@ class zipkin_span(object):
             service_name=self.service_name,
             annotations=self.annotations,
             binary_annotations=self.binary_annotations,
+            sa_binary_annotation=self.sa_binary_annotation,
             span_id=self.zipkin_attrs.span_id,
         )
 
@@ -374,6 +382,41 @@ class zipkin_span(object):
             # Otherwise, we're in the context of the root span, so just update
             # the binary annotations for the logging context directly.
             self.logging_context.binary_annotations_dict.update(extra_annotations)
+
+    def add_sa_binary_annotation(self, port=0, service_name='unknown', host='127.0.0.1'):
+        """Adds a 'sa' binary annotation to the current span.
+
+        'sa' binary annotations are useful for situations where you need to log where
+        a request is going but the destination doesn't support zipkin.
+
+        Note that the span must have 'cs'/'cr' annotations.
+
+        :param port: The port number of the destination
+        :type port: int
+        :param service_name: The name of the destination service
+        :type service_name: str
+        :param host: Host address of the destination
+        :type host: str
+        """
+        if not self.zipkin_attrs or not self.zipkin_attrs.is_sampled:
+            return
+
+        if 'client' not in self.include:
+            # TODO: trying to set a sa binary annotation for a non-client span
+            # should result in a logged error
+            return
+
+        sa_endpoint = create_endpoint(port=port, service_name=service_name, host=host)
+        sa_binary_annotation = create_binary_annotation(
+            key='sa',
+            value=str(True),
+            annotation_type=zipkin_core.AnnotationType.BOOL,
+            host=sa_endpoint,
+        )
+        if not self.logging_context:
+            self.sa_binary_annotation = sa_binary_annotation
+        else:
+            self.logging_context.sa_binary_annotation = sa_binary_annotation
 
 
 def _validate_args(kwargs):

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -418,7 +418,7 @@ class zipkin_span(object):
         )
         sa_binary_annotation = create_binary_annotation(
             key='sa',
-            value=str(True),
+            value='1',
             annotation_type=zipkin_core.AnnotationType.BOOL,
             host=sa_endpoint,
         )

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -383,11 +383,16 @@ class zipkin_span(object):
             # the binary annotations for the logging context directly.
             self.logging_context.binary_annotations_dict.update(extra_annotations)
 
-    def add_sa_binary_annotation(self, port=0, service_name='unknown', host='127.0.0.1'):
+    def add_sa_binary_annotation(
+        self,
+        port=0,
+        service_name='unknown',
+        host='127.0.0.1',
+    ):
         """Adds a 'sa' binary annotation to the current span.
 
-        'sa' binary annotations are useful for situations where you need to log where
-        a request is going but the destination doesn't support zipkin.
+        'sa' binary annotations are useful for situations where you need to log
+        where a request is going but the destination doesn't support zipkin.
 
         Note that the span must have 'cs'/'cr' annotations.
 
@@ -406,7 +411,11 @@ class zipkin_span(object):
             # should result in a logged error
             return
 
-        sa_endpoint = create_endpoint(port=port, service_name=service_name, host=host)
+        sa_endpoint = create_endpoint(
+            port=port,
+            service_name=service_name,
+            host=host,
+        )
         sa_binary_annotation = create_binary_annotation(
             key='sa',
             value=str(True),

--- a/tests/logging_helper_test.py
+++ b/tests/logging_helper_test.py
@@ -211,7 +211,7 @@ def test_handler_stores_client_span_on_emit(sampled_zipkin_attr):
         'span_id': None,
         'annotations': 'ann1',
         'binary_annotations': 'bann1',
-        'sa_binary_annotation': None,
+        'sa_binary_annotations': None,
     }]
 
 

--- a/tests/logging_helper_test.py
+++ b/tests/logging_helper_test.py
@@ -211,6 +211,7 @@ def test_handler_stores_client_span_on_emit(sampled_zipkin_attr):
         'span_id': None,
         'annotations': 'ann1',
         'binary_annotations': 'bann1',
+        'sa_binary_annotation': None,
     }]
 
 

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -426,7 +426,7 @@ def test_span_context(
         'span_id': '1',
         'annotations': {'something': 1},
         'binary_annotations': {'foo': 'bar'},
-        'sa_binary_annotation': None,
+        'sa_binary_annotations': [],
     }
     assert client_span == expected_client_span
 
@@ -600,7 +600,7 @@ def test_add_sa_binary_annotation():
     )
 
     with context:
-        assert context.logging_context.sa_binary_annotation is None
+        assert context.logging_context.sa_binary_annotations == []
         context.add_sa_binary_annotation(
             port=123,
             service_name='test_service',
@@ -608,7 +608,7 @@ def test_add_sa_binary_annotation():
         )
         expected_sa_binary_annotation = create_binary_annotation(
             key='sa',
-            value=str(True),
+            value='1',
             annotation_type=zipkin_core.AnnotationType.BOOL,
             host=create_endpoint(
                 port=123,
@@ -616,7 +616,7 @@ def test_add_sa_binary_annotation():
                 host='1.2.3.4',
             ),
         )
-        assert context.logging_context.sa_binary_annotation == \
+        assert context.logging_context.sa_binary_annotations[0] == \
             expected_sa_binary_annotation
 
         nested_context = zipkin.zipkin_span(
@@ -631,7 +631,7 @@ def test_add_sa_binary_annotation():
             )
             expected_nested_sa_binary_annotation = create_binary_annotation(
                 key='sa',
-                value=str(True),
+                value='1',
                 annotation_type=zipkin_core.AnnotationType.BOOL,
                 host=create_endpoint(
                     port=456,
@@ -639,7 +639,7 @@ def test_add_sa_binary_annotation():
                     host='5.6.7.8',
                 ),
             )
-            assert nested_context.sa_binary_annotation == \
+            assert nested_context.sa_binary_annotations[0] == \
                 expected_nested_sa_binary_annotation
 
 
@@ -673,7 +673,7 @@ def test_adding_sa_binary_annotation_for_non_client_spans():
             service_name='test_service',
             host='1.2.3.4',
         )
-        assert context.logging_context.sa_binary_annotation is None
+        assert context.logging_context.sa_binary_annotations == []
 
 
 @mock.patch('py_zipkin.zipkin.generate_random_128bit_string', autospec=True)

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -5,6 +5,7 @@ import py_zipkin.zipkin as zipkin
 from py_zipkin.exception import ZipkinError
 from py_zipkin.logging_helper import ZipkinLoggerHandler
 from py_zipkin.thread_local import get_zipkin_attrs
+from py_zipkin.thrift import SERVER_ADDR_VAL
 from py_zipkin.thrift import create_binary_annotation
 from py_zipkin.thrift import create_endpoint
 from py_zipkin.thrift import zipkin_core
@@ -607,8 +608,8 @@ def test_add_sa_binary_annotation():
             host='1.2.3.4',
         )
         expected_sa_binary_annotation = create_binary_annotation(
-            key='sa',
-            value='1',
+            key=zipkin_core.SERVER_ADDR,
+            value=SERVER_ADDR_VAL,
             annotation_type=zipkin_core.AnnotationType.BOOL,
             host=create_endpoint(
                 port=123,
@@ -630,8 +631,8 @@ def test_add_sa_binary_annotation():
                 host='5.6.7.8',
             )
             expected_nested_sa_binary_annotation = create_binary_annotation(
-                key='sa',
-                value='1',
+                key=zipkin_core.SERVER_ADDR,
+                value=SERVER_ADDR_VAL,
                 annotation_type=zipkin_core.AnnotationType.BOOL,
                 host=create_endpoint(
                     port=456,

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -601,28 +601,46 @@ def test_add_sa_binary_annotation():
 
     with context:
         assert context.logging_context.sa_binary_annotation is None
-        context.add_sa_binary_annotation(port=123, service_name='test_service', host='1.2.3.4')
+        context.add_sa_binary_annotation(
+            port=123,
+            service_name='test_service',
+            host='1.2.3.4',
+        )
         expected_sa_binary_annotation = create_binary_annotation(
             key='sa',
             value=str(True),
             annotation_type=zipkin_core.AnnotationType.BOOL,
-            host=create_endpoint(port=123, service_name='test_service', host='1.2.3.4'),
+            host=create_endpoint(
+                port=123,
+                service_name='test_service',
+                host='1.2.3.4',
+            ),
         )
-        assert context.logging_context.sa_binary_annotation == expected_sa_binary_annotation
+        assert context.logging_context.sa_binary_annotation == \
+            expected_sa_binary_annotation
 
         nested_context = zipkin.zipkin_span(
             service_name='my_service',
             span_name='nested_span',
         )
         with nested_context:
-            nested_context.add_sa_binary_annotation(port=456, service_name='nested_service', host='5.6.7.8')
+            nested_context.add_sa_binary_annotation(
+                port=456,
+                service_name='nested_service',
+                host='5.6.7.8',
+            )
             expected_nested_sa_binary_annotation = create_binary_annotation(
                 key='sa',
                 value=str(True),
                 annotation_type=zipkin_core.AnnotationType.BOOL,
-                host=create_endpoint(port=456, service_name='nested_service', host='5.6.7.8'),
+                host=create_endpoint(
+                    port=456,
+                    service_name='nested_service',
+                    host='5.6.7.8',
+                ),
             )
-            assert nested_context.sa_binary_annotation == expected_nested_sa_binary_annotation
+            assert nested_context.sa_binary_annotation == \
+                expected_nested_sa_binary_annotation
 
 
 def test_adding_sa_binary_annotation_without_sampling():
@@ -633,7 +651,11 @@ def test_adding_sa_binary_annotation_without_sampling():
         sample_rate=0.0,
     )
     with context:
-        context.add_sa_binary_annotation(port=123, service_name='test_service', host='1.2.3.4')
+        context.add_sa_binary_annotation(
+            port=123,
+            service_name='test_service',
+            host='1.2.3.4',
+        )
         assert context.logging_context is None
 
 
@@ -646,7 +668,11 @@ def test_adding_sa_binary_annotation_for_non_client_spans():
         sample_rate=100.0,
     )
     with context:
-        context.add_sa_binary_annotation(port=123, service_name='test_service', host='1.2.3.4')
+        context.add_sa_binary_annotation(
+            port=123,
+            service_name='test_service',
+            host='1.2.3.4',
+        )
         assert context.logging_context.sa_binary_annotation is None
 
 


### PR DESCRIPTION
This resolves #33.

Note that I chose to save the 'sa' binary annotation as its own unique property instead of putting it into the zipkin_span.binary_annotations property (because that property only supports dicts of str -> str right now). #41 will require a change in zipkin_span.binary_annotations, so I'm holding off on that work for now.