### PR TITLE
Change server send timing to logging_start

### DIFF
--- a/py_zipkin/logging_helper.py
+++ b/py_zipkin/logging_helper.py
@@ -151,7 +151,7 @@ class ZipkinLoggingContext(object):
             server_end_time = time.time()
             annotations = dict(
                 sr=self.start_timestamp,
-                ss=server_end_time,
+                ss=logging_start,
                 **extra_annotations
             )
             if self.add_logging_annotation:

--- a/py_zipkin/logging_helper.py
+++ b/py_zipkin/logging_helper.py
@@ -24,7 +24,7 @@ zipkin_logger = logging.getLogger('py_zipkin.logger')
 zipkin_logger.addHandler(null_handler)
 zipkin_logger.setLevel(logging.DEBUG)
 
-LOGGING_START_KEY = 'py_zipkin.logging_start'
+LOGGING_END_KEY = 'py_zipkin.logging_end'
 
 
 class ZipkinLoggingContext(object):
@@ -84,7 +84,7 @@ class ZipkinLoggingContext(object):
         a success. It also logs the service `ss` and `sr` annotations.
         """
         if self.zipkin_attrs.is_sampled:
-            logging_start = time.time()
+            server_end_time = time.time()
             # Collect additional annotations from the logging handler
             annotations_by_span_id = defaultdict(dict)
             binary_annotations_by_span_id = defaultdict(dict)
@@ -148,14 +148,14 @@ class ZipkinLoggingContext(object):
             extra_binary_annotations = binary_annotations_by_span_id[
                 self.zipkin_attrs.span_id
             ]
-            server_end_time = time.time()
+            logging_end = time.time()
             annotations = dict(
                 sr=self.start_timestamp,
-                ss=logging_start,
+                ss=server_end_time,
                 **extra_annotations
             )
             if self.add_logging_annotation:
-                annotations[LOGGING_START_KEY] = logging_start
+                annotations[LOGGING_END_KEY] = logging_end
 
             thrift_annotations = annotation_list_builder(
                 annotations,

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -143,8 +143,8 @@ class zipkin_span(object):
             can be one of {'client', 'server'}
             corresponding to ('cs', 'cr') and ('ss', 'sr') respectively
         :type include: iterable
-        :param add_logging_annotation: Whether to add a 'start_logging'
-            annotation when py_zipkin starts logging spans
+        :param add_logging_annotation: Whether to add a 'logging_end'
+            annotation when py_zipkin finishes logging spans
         :type add_logging_annotation: boolean
         :param report_root_timestamp: Whether the span should report timestamp
             and duration. Only applies to "root" spans in this local context,

--- a/tests/integration/zipkin_integration_test.py
+++ b/tests/integration/zipkin_integration_test.py
@@ -4,7 +4,7 @@ from thriftpy.transport import TMemoryBuffer
 
 from py_zipkin import zipkin
 from py_zipkin.logging_helper import zipkin_logger
-from py_zipkin.logging_helper import LOGGING_START_KEY
+from py_zipkin.logging_helper import LOGGING_END_KEY
 from py_zipkin.thrift import zipkin_core
 from py_zipkin.zipkin import ZipkinAttrs
 
@@ -12,7 +12,7 @@ from py_zipkin.zipkin import ZipkinAttrs
 @pytest.fixture
 def default_annotations():
     return set([
-        'ss', 'sr', LOGGING_START_KEY,
+        'ss', 'sr', LOGGING_END_KEY,
     ])
 
 


### PR DESCRIPTION
Issue Link: https://github.com/Yelp/py_zipkin/issues/42

Fixes server send timing to more accurately reflect when server send actually occurs.

Removed the `logging_start` annotation (since it'll be the same as Server Send) and added a `logging_end` annotation