### PR TITLE
Added batch spans sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ your Zipkin collector is running at localhost:9411.
 import requests
 
 def http_transport(encoded_span):
+    # The collector expects a thrift-encoded list of spans.
     requests.post(
         'http://localhost:9411/api/v1/spans',
         data=encoded_span,

--- a/README.md
+++ b/README.md
@@ -142,13 +142,9 @@ your Zipkin collector is running at localhost:9411.
 import requests
 
 def http_transport(encoded_span):
-    # The collector expects a thrift-encoded list of spans. Instead of
-    # decoding and re-encoding the already thrift-encoded message, we can just
-    # add header bytes that specify that what follows is a list of length 1.
-    body = '\x0c\x00\x00\x00\x01' + encoded_span
     requests.post(
         'http://localhost:9411/api/v1/spans',
-        data=body,
+        data=encoded_span,
         headers={'Content-Type': 'application/x-thrift'},
     )
 ```

--- a/py_zipkin/thrift/__init__.py
+++ b/py_zipkin/thrift/__init__.py
@@ -4,7 +4,8 @@ import socket
 import struct
 
 import thriftpy
-from thriftpy.protocol.binary import TBinaryProtocol, write_list_begin
+from thriftpy.protocol.binary import TBinaryProtocol
+from thriftpy.protocol.binary import write_list_begin
 from thriftpy.thrift import TType
 from thriftpy.transport import TMemoryBuffer
 

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -104,6 +104,7 @@ class zipkin_span(object):
         span_name='span',
         zipkin_attrs=None,
         transport_handler=None,
+        max_span_portion_size=None,
         annotations=None,
         binary_annotations=None,
         port=0,
@@ -126,6 +127,9 @@ class zipkin_span(object):
         :param transport_handler: Callback function that takes a message parameter
             and handles logging it
         :type transport_handler: function
+        :param max_span_portion_size: Spans in a trace are sent in batches,
+        max_span_portion_size defines max size of one batch
+        :type max_span_portion_size: int
         :param annotations: Optional dict of str -> timestamp annotations
         :type annotations: dict of str -> int
         :param binary_annotations: Optional dict of str -> str span attrs
@@ -164,6 +168,7 @@ class zipkin_span(object):
         self.span_name = span_name
         self.zipkin_attrs = zipkin_attrs
         self.transport_handler = transport_handler
+        self.max_span_portion_size = max_span_portion_size
         self.annotations = annotations or {}
         self.binary_annotations = binary_annotations or {}
         self.port = port
@@ -293,7 +298,8 @@ class zipkin_span(object):
                 report_root_timestamp or self.report_root_timestamp_override,
                 binary_annotations=self.binary_annotations,
                 add_logging_annotation=self.add_logging_annotation,
-                client_context=client_context
+                client_context=client_context,
+                max_span_portion_size = self.max_span_portion_size,
             )
             self.logging_context.start()
             self.logging_configured = True

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -299,7 +299,7 @@ class zipkin_span(object):
                 binary_annotations=self.binary_annotations,
                 add_logging_annotation=self.add_logging_annotation,
                 client_context=client_context,
-                max_span_portion_size = self.max_span_portion_size,
+                max_span_portion_size=self.max_span_portion_size,
             )
             self.logging_context.start()
             self.logging_configured = True

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -104,7 +104,7 @@ class zipkin_span(object):
         span_name='span',
         zipkin_attrs=None,
         transport_handler=None,
-        max_span_portion_size=None,
+        max_span_batch_size=None,
         annotations=None,
         binary_annotations=None,
         port=0,
@@ -127,9 +127,9 @@ class zipkin_span(object):
         :param transport_handler: Callback function that takes a message parameter
             and handles logging it
         :type transport_handler: function
-        :param max_span_portion_size: Spans in a trace are sent in batches,
-        max_span_portion_size defines max size of one batch
-        :type max_span_portion_size: int
+        :param max_span_batch_size: Spans in a trace are sent in batches,
+        max_span_batch_size defines max size of one batch
+        :type max_span_batch_size: int
         :param annotations: Optional dict of str -> timestamp annotations
         :type annotations: dict of str -> int
         :param binary_annotations: Optional dict of str -> str span attrs
@@ -168,7 +168,7 @@ class zipkin_span(object):
         self.span_name = span_name
         self.zipkin_attrs = zipkin_attrs
         self.transport_handler = transport_handler
-        self.max_span_portion_size = max_span_portion_size
+        self.max_span_batch_size = max_span_batch_size
         self.annotations = annotations or {}
         self.binary_annotations = binary_annotations or {}
         self.port = port
@@ -299,7 +299,7 @@ class zipkin_span(object):
                 binary_annotations=self.binary_annotations,
                 add_logging_annotation=self.add_logging_annotation,
                 client_context=client_context,
-                max_span_portion_size=self.max_span_portion_size,
+                max_span_batch_size=self.max_span_batch_size,
             )
             self.logging_context.start()
             self.logging_configured = True

--- a/tests/integration/zipkin_integration_test.py
+++ b/tests/integration/zipkin_integration_test.py
@@ -1,5 +1,6 @@
 import pytest
-from thriftpy.protocol.binary import TBinaryProtocol, read_list_begin
+from thriftpy.protocol.binary import TBinaryProtocol
+from thriftpy.protocol.binary import read_list_begin
 from thriftpy.transport import TMemoryBuffer
 
 from py_zipkin import zipkin

--- a/tests/logging_helper_test.py
+++ b/tests/logging_helper_test.py
@@ -392,7 +392,7 @@ def test_batch_sender_defensive_about_transport_handler(
 ):
     """Make sure log_span doesn't try to call the transport handler if it's
     None."""
-    sender = logging_helper.ZipkinBatchSender(None)
+    sender = logging_helper.ZipkinBatchSender(transport_handler=None)
     with sender:
         sender.add_span(
             span_id='0000000000000002',
@@ -404,8 +404,8 @@ def test_batch_sender_defensive_about_transport_handler(
             timestamp_s=None,
             duration_s=None,
         )
+    assert create_sp.call_count == 1
     assert thrift_obj.call_count == 0
-    assert create_sp.call_count == 0
 
 
 def test_get_local_span_timestamp_and_duration_client():

--- a/tests/logging_helper_test.py
+++ b/tests/logging_helper_test.py
@@ -164,7 +164,6 @@ def test_zipkin_logging_server_context_log_spans(
     assert flush_mock.call_count == 1
 
 
-
 @mock.patch('py_zipkin.logging_helper.time.time', autospec=True)
 @mock.patch('py_zipkin.logging_helper.ZipkinBatchSender.flush',
             autospec=True)

--- a/tests/logging_helper_test.py
+++ b/tests/logging_helper_test.py
@@ -57,7 +57,10 @@ def test_zipkin_logging_context(time_mock, mock_logger, context):
 
 
 @mock.patch('py_zipkin.logging_helper.time.time', autospec=True)
-@mock.patch('py_zipkin.logging_helper.log_span', autospec=True)
+@mock.patch('py_zipkin.logging_helper.ZipkinBatchSender.flush',
+            autospec=True)
+@mock.patch('py_zipkin.logging_helper.ZipkinBatchSender.add_span',
+            autospec=True)
 @mock.patch('py_zipkin.logging_helper.annotation_list_builder',
             autospec=True)
 @mock.patch('py_zipkin.logging_helper.binary_annotation_list_builder',
@@ -66,7 +69,7 @@ def test_zipkin_logging_context(time_mock, mock_logger, context):
             autospec=True)
 def test_zipkin_logging_server_context_log_spans(
     copy_endpoint_mock, bin_ann_list_builder, ann_list_builder,
-    log_span_mock, time_mock
+    add_span_mock, flush_mock, time_mock
 ):
     # This lengthy function tests that the logging context properly
     # logs both client and server spans, while attaching extra annotations
@@ -137,7 +140,7 @@ def test_zipkin_logging_server_context_log_spans(
     expected_client_bin_annotations = {'bann1': 'aww', 'bann2': 'yiss'}
 
     context.log_spans()
-    client_log_call, server_log_call = log_span_mock.call_args_list
+    client_log_call, server_log_call = add_span_mock.call_args_list
     assert server_log_call[1] == {
         'span_id': server_span_id,
         'parent_span_id': parent_span_id,
@@ -145,7 +148,6 @@ def test_zipkin_logging_server_context_log_spans(
         'span_name': 'GET /foo',
         'annotations': expected_server_annotations,
         'binary_annotations': expected_server_bin_annotations,
-        'transport_handler': transport_handler,
         'duration_s': 18,
         'timestamp_s': 24,
     }
@@ -156,14 +158,18 @@ def test_zipkin_logging_server_context_log_spans(
         'span_name': client_span_name,
         'annotations': expected_client_annotations,
         'binary_annotations': expected_client_bin_annotations,
-        'transport_handler': transport_handler,
         'duration_s': 4,
         'timestamp_s': 26,
     }
+    assert flush_mock.call_count == 1
+
 
 
 @mock.patch('py_zipkin.logging_helper.time.time', autospec=True)
-@mock.patch('py_zipkin.logging_helper.log_span', autospec=True)
+@mock.patch('py_zipkin.logging_helper.ZipkinBatchSender.flush',
+            autospec=True)
+@mock.patch('py_zipkin.logging_helper.ZipkinBatchSender.add_span',
+            autospec=True)
 @mock.patch('py_zipkin.logging_helper.annotation_list_builder',
             autospec=True)
 @mock.patch('py_zipkin.logging_helper.binary_annotation_list_builder',
@@ -172,7 +178,7 @@ def test_zipkin_logging_server_context_log_spans(
             autospec=True)
 def test_zipkin_logging_client_context_log_spans(
     copy_endpoint_mock, bin_ann_list_builder, ann_list_builder,
-    log_span_mock, time_mock
+    add_span_mock, flush_mock, time_mock
 ):
     # This lengthy function tests that the logging context properly
     # logs root client span
@@ -215,7 +221,7 @@ def test_zipkin_logging_client_context_log_spans(
     expected_server_bin_annotations = {'k': 'v'}
 
     context.log_spans()
-    log_call = log_span_mock.call_args_list[0]
+    log_call = add_span_mock.call_args_list[0]
     assert log_call[1] == {
         'span_id': client_span_id,
         'parent_span_id': None,
@@ -223,14 +229,18 @@ def test_zipkin_logging_client_context_log_spans(
         'span_name': 'GET /foo',
         'annotations': expected_server_annotations,
         'binary_annotations': expected_server_bin_annotations,
-        'transport_handler': transport_handler,
         'duration_s': 18,
         'timestamp_s': 24,
     }
+    assert flush_mock.call_count == 1
 
 
-@mock.patch('py_zipkin.logging_helper.log_span', autospec=True)
-def test_log_span_not_called_if_not_sampled(log_span_mock):
+@mock.patch('py_zipkin.logging_helper.ZipkinBatchSender.flush',
+            autospec=True)
+@mock.patch('py_zipkin.logging_helper.ZipkinBatchSender.add_span',
+            autospec=True)
+def test_batch_sender_add_span_not_called_if_not_sampled(add_span_mock,
+                                                         flush_mock):
     attr = ZipkinAttrs(
         trace_id='0000000000000001',
         span_id='0000000000000002',
@@ -249,7 +259,8 @@ def test_log_span_not_called_if_not_sampled(log_span_mock):
         report_root_timestamp=False,
     )
     context.log_spans()
-    assert log_span_mock.call_count == 0
+    assert add_span_mock.call_count == 0
+    assert flush_mock.call_count == 0
 
 
 def test_zipkin_handler_init():
@@ -305,11 +316,11 @@ def test_zipkin_handler_raises_exception_if_ann_and_bann_not_provided(
             " for foo span" == str(excinfo.value))
 
 
-@mock.patch('py_zipkin.logging_helper.thrift_obj_in_bytes', autospec=True)
-def test_log_span(thrift_obj):
+@mock.patch('py_zipkin.logging_helper.thrift_objs_in_bytes', autospec=True)
+def test_batch_sender_add_span(thrift_objs):
     # Not much logic here, so this is basically a smoke test
-
-    logging_helper.log_span(
+    sender = logging_helper.ZipkinBatchSender(mock_transport_handler)
+    sender.add_span(
         span_id='0000000000000002',
         parent_span_id='0000000000000001',
         trace_id='000000000000000f',
@@ -318,19 +329,42 @@ def test_log_span(thrift_obj):
         binary_annotations='binary_ann',
         timestamp_s=None,
         duration_s=None,
-        transport_handler=mock_transport_handler,
     )
-    assert thrift_obj.call_count == 1
+    sender.flush()
+    assert thrift_objs.call_count == 1
+
+
+@mock.patch('py_zipkin.logging_helper.thrift_objs_in_bytes', autospec=True)
+def test_batch_sender_add_span_many_times(thrift_obj):
+    sender = logging_helper.ZipkinBatchSender(mock_transport_handler)
+    max_portion_size = logging_helper.ZipkinBatchSender.MAX_PORTION_SIZE
+    for _ in range(max_portion_size * 2 + 1):
+        sender.add_span(
+            span_id='0000000000000002',
+            parent_span_id='0000000000000001',
+            trace_id='000000000000000f',
+            span_name='span',
+            annotations='ann',
+            binary_annotations='binary_ann',
+            timestamp_s=None,
+            duration_s=None,
+        )
+    sender.flush()
+    assert thrift_obj.call_count == 3
+    assert len(thrift_obj.call_args_list[0][0][0]) == max_portion_size
+    assert len(thrift_obj.call_args_list[1][0][0]) == max_portion_size
+    assert len(thrift_obj.call_args_list[2][0][0]) == 1
 
 
 @mock.patch('py_zipkin.logging_helper.create_span', autospec=True)
-@mock.patch('py_zipkin.logging_helper.thrift_obj_in_bytes', autospec=True)
-def test_log_span_calls_transport_handler_with_correct_params(
-    thrift_obj,
+@mock.patch('py_zipkin.logging_helper.thrift_objs_in_bytes', autospec=True)
+def test_batch_sender_flush_calls_transport_handler_with_correct_params(
+    thrift_objs,
     create_sp
 ):
     transport_handler = mock.Mock()
-    logging_helper.log_span(
+    sender = logging_helper.ZipkinBatchSender(transport_handler)
+    sender.add_span(
         span_id='0000000000000002',
         parent_span_id='0000000000000001',
         trace_id='00000000000000015',
@@ -339,20 +373,21 @@ def test_log_span_calls_transport_handler_with_correct_params(
         binary_annotations='binary_ann',
         timestamp_s=None,
         duration_s=None,
-        transport_handler=transport_handler,
     )
-    transport_handler.assert_called_once_with(thrift_obj.return_value)
+    sender.flush()
+    transport_handler.assert_called_once_with(thrift_objs.return_value)
 
 
 @mock.patch('py_zipkin.logging_helper.create_span', autospec=True)
-@mock.patch('py_zipkin.logging_helper.thrift_obj_in_bytes', autospec=True)
-def test_log_span_defensive_about_transport_handler(
+@mock.patch('py_zipkin.logging_helper.thrift_objs_in_bytes', autospec=True)
+def test_batch_sender_defensive_about_transport_handler(
     thrift_obj,
     create_sp
 ):
     """Make sure log_span doesn't try to call the transport handler if it's
     None."""
-    logging_helper.log_span(
+    sender = logging_helper.ZipkinBatchSender(None)
+    sender.add_span(
         span_id='0000000000000002',
         parent_span_id='0000000000000001',
         trace_id='00000000000000015',
@@ -361,8 +396,8 @@ def test_log_span_defensive_about_transport_handler(
         binary_annotations='binary_ann',
         timestamp_s=None,
         duration_s=None,
-        transport_handler=None,
     )
+    sender.flush()
     assert thrift_obj.call_count == 0
     assert create_sp.call_count == 0
 

--- a/tests/logging_helper_test.py
+++ b/tests/logging_helper_test.py
@@ -333,6 +333,13 @@ def test_batch_sender_add_span(thrift_objs):
     assert thrift_objs.call_count == 1
 
 
+def test_batch_sender_with_error_on_exit():
+    sender = logging_helper.ZipkinBatchSender(mock_transport_handler)
+    with pytest.raises(ZipkinError):
+        with sender:
+            raise Exception('Error!')
+
+
 @mock.patch('py_zipkin.logging_helper.thrift_objs_in_bytes', autospec=True)
 def test_batch_sender_add_span_many_times(thrift_obj):
     sender = logging_helper.ZipkinBatchSender(mock_transport_handler)

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -57,7 +57,7 @@ def test_zipkin_span_for_new_trace(
         binary_annotations={},
         add_logging_annotation=False,
         client_context=False,
-        max_span_portion_size=None,
+        max_span_batch_size=None,
     )
     pop_zipkin_attrs_mock.assert_called_once_with()
 
@@ -111,7 +111,7 @@ def test_zipkin_span_passed_sampled_attrs(
         binary_annotations={},
         add_logging_annotation=False,
         client_context=False,
-        max_span_portion_size=None,
+        max_span_batch_size=None,
     )
     pop_zipkin_attrs_mock.assert_called_once_with()
 
@@ -491,7 +491,7 @@ def test_zipkin_server_span_decorator(
         binary_annotations={},
         add_logging_annotation=False,
         client_context=False,
-        max_span_portion_size=None,
+        max_span_batch_size=None,
     )
     pop_zipkin_attrs_mock.assert_called_once_with()
 
@@ -547,7 +547,7 @@ def test_zipkin_client_span_decorator(
         binary_annotations={},
         add_logging_annotation=False,
         client_context=True,
-        max_span_portion_size=None,
+        max_span_batch_size=None,
     )
     pop_zipkin_attrs_mock.assert_called_once_with()
 

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -57,6 +57,7 @@ def test_zipkin_span_for_new_trace(
         binary_annotations={},
         add_logging_annotation=False,
         client_context=False,
+        max_span_portion_size=None,
     )
     pop_zipkin_attrs_mock.assert_called_once_with()
 
@@ -110,6 +111,7 @@ def test_zipkin_span_passed_sampled_attrs(
         binary_annotations={},
         add_logging_annotation=False,
         client_context=False,
+        max_span_portion_size=None,
     )
     pop_zipkin_attrs_mock.assert_called_once_with()
 
@@ -489,6 +491,7 @@ def test_zipkin_server_span_decorator(
         binary_annotations={},
         add_logging_annotation=False,
         client_context=False,
+        max_span_portion_size=None,
     )
     pop_zipkin_attrs_mock.assert_called_once_with()
 
@@ -544,6 +547,7 @@ def test_zipkin_client_span_decorator(
         binary_annotations={},
         add_logging_annotation=False,
         client_context=True,
+        max_span_portion_size=None,
     )
     pop_zipkin_attrs_mock.assert_called_once_with()
 


### PR DESCRIPTION
This is a pr for https://github.com/Yelp/py_zipkin/issues/6

Guys, I have a question. I didn't provide a backward compatibility in this pull request. After my changes in thrift encoding code this example from the docs won't work:
```
import requests

def http_transport(encoded_span):
    # The collector expects a thrift-encoded list of spans. Instead of
    # decoding and re-encoding the already thrift-encoded message, we can just
    # add header bytes that specify that what follows is a list of length 1.
    body = '\x0c\x00\x00\x00\x01' + encoded_span
    requests.post(
        'http://localhost:9411/api/v1/spans',
        data=body,
        headers={'Content-Type': 'application/x-thrift'},
    )
```
I think here we breach encapsulation of thrift encoding logic by adding '\x0c\x00\x00\x00\x01'. In the pull request the count of thrift objects is defined automatically and can be hided from client. So the modified version of this example would be:
```
import requests

def http_transport(encoded_span):
    requests.post(
        'http://localhost:9411/api/v1/spans',
        data=encoded_span,
        headers={'Content-Type': 'application/x-thrift'},
    )
```

I can provide a backward compatibility by adding a 'batch' flag to zipkin_span constructor, but I prefer not to do it without your feedback. Please advise.
