### PR TITLE
Speed up id generation

### DIFF
--- a/py_zipkin/util.py
+++ b/py_zipkin/util.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import random
 import struct
+import time
 
 
 def generate_random_64bit_string():
@@ -17,9 +18,15 @@ def generate_random_128bit_string():
     """Returns a 128 bit UTF-8 encoded string. Follows the same conventions
     as generate_random_64bit_string().
 
-    :returns: random 32-character string
+    The upper 32 bits are the current time in epoch seconds, and the
+    lower 96 bits are random. This allows for AWS X-Ray `interop
+    <https://github.com/openzipkin/zipkin/issues/1754>`_
+
+    :returns: 32-character hex string
     """
-    return '{:032x}'.format(random.getrandbits(128))
+    t = int(time.time())
+    lower_96 = random.getrandbits(96)
+    return '{:032x}'.format((t << 96) | lower_96)
 
 
 def unsigned_hex_to_signed_int(hex_string):

--- a/py_zipkin/util.py
+++ b/py_zipkin/util.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-import codecs
-import os
+import random
 import struct
 
 
@@ -11,7 +10,7 @@ def generate_random_64bit_string():
 
     :returns: random 16-character string
     """
-    return str(codecs.encode(os.urandom(8), 'hex_codec').decode('utf-8'))
+    return '{:016x}'.format(random.getrandbits(64))
 
 
 def generate_random_128bit_string():
@@ -20,7 +19,7 @@ def generate_random_128bit_string():
 
     :returns: random 32-character string
     """
-    return str(codecs.encode(os.urandom(16), 'hex_codec').decode('utf-8'))
+    return '{:032x}'.format(random.getrandbits(128))
 
 
 def unsigned_hex_to_signed_int(hex_string):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ coverage
 mock
 ordereddict
 pytest
+pytest-benchmark[histogram]

--- a/tests/profiling/zipkin_span_benchmark_test.py
+++ b/tests/profiling/zipkin_span_benchmark_test.py
@@ -1,0 +1,11 @@
+import pytest
+
+import py_zipkin.zipkin as zipkin
+
+
+@pytest.mark.parametrize('use_128', [False, True])
+def test_create_attrs_for_span(benchmark, use_128):
+    benchmark(
+        zipkin.create_attrs_for_span,
+        use_128bit_trace_id=use_128,
+    )

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -15,11 +15,14 @@ def test_generate_random_64bit_string(rand):
     assert isinstance(random_string, str)
 
 
+@mock.patch('py_zipkin.util.time.time', autospec=True)
 @mock.patch('py_zipkin.util.random.getrandbits', autospec=True)
-def test_generate_random_128bit_string(rand):
-    rand.return_value = 0x17133d482ba4f60517133d482ba4f605
+def test_generate_random_128bit_string(rand, mock_time):
+    rand.return_value = 0x2ba4f60517133d482ba4f605
+    mock_time.return_value = float(0x17133d48)
     random_string = util.generate_random_128bit_string()
     assert random_string == '17133d482ba4f60517133d482ba4f605'
+    rand.assert_called_once_with(96)  # 96 bits
     # This acts as a contract test of sorts. This should return a str
     # in both py2 and py3. IOW, no unicode objects.
     assert isinstance(random_string, str)

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -5,9 +5,9 @@ import mock
 from py_zipkin import util
 
 
-@mock.patch('py_zipkin.util.codecs.encode', autospec=True)
+@mock.patch('py_zipkin.util.random.getrandbits', autospec=True)
 def test_generate_random_64bit_string(rand):
-    rand.return_value = b'17133d482ba4f605'
+    rand.return_value = 0x17133d482ba4f605
     random_string = util.generate_random_64bit_string()
     assert random_string == '17133d482ba4f605'
     # This acts as a contract test of sorts. This should return a str
@@ -15,9 +15,9 @@ def test_generate_random_64bit_string(rand):
     assert isinstance(random_string, str)
 
 
-@mock.patch('py_zipkin.util.codecs.encode', autospec=True)
+@mock.patch('py_zipkin.util.random.getrandbits', autospec=True)
 def test_generate_random_128bit_string(rand):
-    rand.return_value = b'17133d482ba4f60517133d482ba4f605'
+    rand.return_value = 0x17133d482ba4f60517133d482ba4f605
     random_string = util.generate_random_128bit_string()
     assert random_string == '17133d482ba4f60517133d482ba4f605'
     # This acts as a contract test of sorts. This should return a str

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = pre-commit, py27, py34, py35, py36, flake8
 deps = -rrequirements-dev.txt
 commands =
     coverage erase
-    coverage run --source=py_zipkin/ -m pytest -vv {posargs:tests}
+    coverage run --source=py_zipkin/ -m pytest -vv --benchmark-skip {posargs:tests}
     coverage report -m --show-missing --fail-under 100
 
 [testenv:pre-commit]
@@ -18,6 +18,17 @@ basepython = /usr/bin/python2.7
 deps = flake8
 commands =
     flake8 py_zipkin tests
+
+[testenv:benchmark]
+basepython = python3.6
+deps =
+    -rrequirements-dev.txt
+commands =
+    python -m pytest -vv --capture=no {posargs:tests/profiling} \
+        --benchmark-only --benchmark-min-rounds=15 \
+        --benchmark-group-by func --benchmark-name short \
+        --benchmark-save=benchmark --benchmark-save-data \
+        --benchmark-histogram=.benchmarks/benchmark
 
 [flake8]
 exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,docs,python_zipkin/thrift/zipkinCore


### PR DESCRIPTION
For traces with lots of spans, generating span ids can add up. This branch changes `generate_random_{64,128}bit_string` from using `os.urandom` to using `random.getrandbits`, which is faster. It also adds benchmarking which shows a speedup of over 2x. The boolean is whether to use 128bit ids. I'm also not sure why the max is so high, maybe a gc pause?:

```
old:
------------------------------------------------------------------------- benchmark 'test_create_attrs_for_span': 2 tests -------------------------------------------------------------------------
Name (time in us)                   Min                 Max              Mean            StdDev            Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
create_attrs_for_span[False]     7.7169 (1.0)      198.1538 (1.12)     9.0767 (1.0)      6.3648 (2.03)     8.1807 (1.0)      0.2161 (1.33)       54;113      110.1723 (1.0)        1423           1
create_attrs_for_span[True]      8.5458 (1.11)     177.1487 (1.0)      9.3490 (1.03)     3.1416 (1.0)      9.0655 (1.11)     0.1621 (1.0)      473;1897      106.9628 (0.97)      36254           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

new:
------------------------------------------------------------------------- benchmark 'test_create_attrs_for_span': 2 tests -------------------------------------------------------------------------
Name (time in us)                   Min                 Max              Mean            StdDev            Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
create_attrs_for_span[False]     2.7791 (1.0)      158.6787 (1.0)      3.3887 (1.0)      1.8108 (1.08)     3.2373 (1.0)      0.1006 (1.08)     406;1377      295.0969 (1.0)       23452           1
create_attrs_for_span[True]      3.0342 (1.09)     163.6483 (1.03)     3.5856 (1.06)     1.6776 (1.0)      3.4552 (1.07)     0.0931 (1.0)     1024;4203      278.8915 (0.95)      73384           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```