### PR TITLE
Zipkin firehose

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,21 @@ By default, py_zipkin uses a thread local storage for the attributes, which is
 defined in `py_zipkin.stack.ThreadLocalStack`.
 
 
+Firehose mode [EXPERIMENTAL]
+----------------------------
+
+"Firehose mode" records 100% of the spans, regardless of
+sampling rate. This is useful if you want to treat these spans
+differently, e.g. send them to a different backend that has limited
+retention. It works in tandem with normal operation, however there may
+be additional overhead. In order to use this, you add a
+`firehose_handler` just like you add a `transport_handler`.
+
+This feature should be considered experimental and may be removed at
+any time without warning. If you do use this, be sure to send
+asynchronously to avoid excess overhead for every request.
+
+
 License
 -------
 

--- a/py_zipkin/logging_helper.py
+++ b/py_zipkin/logging_helper.py
@@ -92,6 +92,7 @@ class ZipkinLoggingContext(object):
 
         # FIXME: Should have a single aggregate handler
         if self.firehose_handler:
+            # FIXME: We need to allow different batching settings per handler
             self._log_spans_with_span_sender(
                 ZipkinBatchSender(self.firehose_handler,
                                   self.max_span_batch_size)

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -288,7 +288,7 @@ class zipkin_span(object):
 
         if self.perform_logging:
             # Don't set up any logging if we're not sampling
-            if not self.zipkin_attrs.is_sampled:
+            if not self.zipkin_attrs.is_sampled and not self.firehose_handler:
                 return self
             endpoint = create_endpoint(self.port, self.service_name, self.host)
             client_context = set(self.include) == {'client'}

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -11,12 +11,12 @@ from py_zipkin.logging_helper import ZipkinLoggingContext
 from py_zipkin.thread_local import get_zipkin_attrs
 from py_zipkin.thread_local import pop_zipkin_attrs
 from py_zipkin.thread_local import push_zipkin_attrs
-from py_zipkin.thrift import SERVER_ADDR_VAL
 from py_zipkin.thrift import create_binary_annotation
 from py_zipkin.thrift import create_endpoint
+from py_zipkin.thrift import SERVER_ADDR_VAL
 from py_zipkin.thrift import zipkin_core
-from py_zipkin.util import generate_random_64bit_string
 from py_zipkin.util import generate_random_128bit_string
+from py_zipkin.util import generate_random_64bit_string
 
 
 """
@@ -113,7 +113,8 @@ class zipkin_span(object):
         add_logging_annotation=False,
         report_root_timestamp=False,
         use_128bit_trace_id=False,
-        host=None
+        host=None,
+        firehose_handler=None
     ):
         """Logs a zipkin span. If this is the root span, then a zipkin
         trace is started as well.
@@ -179,6 +180,7 @@ class zipkin_span(object):
         self.report_root_timestamp_override = report_root_timestamp
         self.use_128bit_trace_id = use_128bit_trace_id
         self.host = host
+        self.firehose_handler = firehose_handler
         self.logging_configured = False
 
         # Spans that log a 'cs' timestamp can additionally record
@@ -219,7 +221,8 @@ class zipkin_span(object):
                 port=self.port,
                 sample_rate=self.sample_rate,
                 include=self.include,
-                host=self.host
+                host=self.host,
+                firehose_handler=self.firehose_handler
             ):
                 return f(*args, **kwargs)
         return decorated
@@ -301,6 +304,7 @@ class zipkin_span(object):
                 add_logging_annotation=self.add_logging_annotation,
                 client_context=client_context,
                 max_span_batch_size=self.max_span_batch_size,
+                firehose_handler=self.firehose_handler,
             )
             self.logging_context.start()
             self.logging_configured = True

--- a/tests/integration/zipkin_integration_test.py
+++ b/tests/integration/zipkin_integration_test.py
@@ -1,11 +1,11 @@
 import pytest
-from thriftpy.protocol.binary import TBinaryProtocol
 from thriftpy.protocol.binary import read_list_begin
+from thriftpy.protocol.binary import TBinaryProtocol
 from thriftpy.transport import TMemoryBuffer
 
 from py_zipkin import zipkin
-from py_zipkin.logging_helper import zipkin_logger
 from py_zipkin.logging_helper import LOGGING_END_KEY
+from py_zipkin.logging_helper import zipkin_logger
 from py_zipkin.thrift import zipkin_core
 from py_zipkin.zipkin import ZipkinAttrs
 
@@ -17,7 +17,6 @@ def default_annotations():
     ])
 
 
-@pytest.fixture
 def mock_logger():
     mock_logs = []
 
@@ -44,10 +43,10 @@ def _decode_binary_thrift_objs(obj):
 
 
 def test_starting_zipkin_trace_with_sampling_rate(
-    mock_logger,
     default_annotations,
 ):
-    mock_transport_handler, mock_logs = mock_logger
+    mock_transport_handler, mock_logs = mock_logger()
+    mock_firehose_handler, mock_firehose_logs = mock_logger()
     with zipkin.zipkin_span(
         service_name='test_service_name',
         span_name='test_span_name',
@@ -55,28 +54,31 @@ def test_starting_zipkin_trace_with_sampling_rate(
         sample_rate=100.0,
         binary_annotations={'some_key': 'some_value'},
         add_logging_annotation=True,
+        firehose_handler=mock_firehose_handler,
     ):
         pass
 
-    span = _decode_binary_thrift_obj(mock_logs[0])
+    def check_span(span):
+        assert span.name == 'test_span_name'
+        assert span.annotations[0].host.service_name == 'test_service_name'
+        assert span.parent_id is None
+        assert span.trace_id_high is None
+        # timestamp and duration are microsecond conversions of time.time()
+        assert span.timestamp is not None
+        assert span.duration is not None
+        assert span.binary_annotations[0].key == 'some_key'
+        assert span.binary_annotations[0].value == 'some_value'
+        assert set([ann.value for ann in span.annotations]) == default_annotations
 
-    assert span.name == 'test_span_name'
-    assert span.annotations[0].host.service_name == 'test_service_name'
-    assert span.parent_id is None
-    assert span.trace_id_high is None
-    # timestamp and duration are microsecond conversions of time.time()
-    assert span.timestamp is not None
-    assert span.duration is not None
-    assert span.binary_annotations[0].key == 'some_key'
-    assert span.binary_annotations[0].value == 'some_value'
-    assert set([ann.value for ann in span.annotations]) == default_annotations
+    check_span(_decode_binary_thrift_obj(mock_logs[0]))
+    check_span(_decode_binary_thrift_obj(mock_firehose_logs[0]))
 
 
 def test_starting_zipkin_trace_with_128bit_trace_id(
-    mock_logger,
     default_annotations,
 ):
-    mock_transport_handler, mock_logs = mock_logger
+    mock_transport_handler, mock_logs = mock_logger()
+    mock_firehose_handler, mock_firehose_logs = mock_logger()
     with zipkin.zipkin_span(
         service_name='test_service_name',
         span_name='test_span_name',
@@ -85,23 +87,28 @@ def test_starting_zipkin_trace_with_128bit_trace_id(
         binary_annotations={'some_key': 'some_value'},
         add_logging_annotation=True,
         use_128bit_trace_id=True,
+        firehose_handler=mock_firehose_handler
     ):
         pass
 
-    span = _decode_binary_thrift_obj(mock_logs[0])
+    def check_span(span):
+        assert span.trace_id is not None
+        assert span.trace_id_high is not None
 
-    assert span.trace_id is not None
-    assert span.trace_id_high is not None
+    check_span(_decode_binary_thrift_obj(mock_logs[0]))
+    check_span(_decode_binary_thrift_obj(mock_firehose_logs[0]))
 
 
-def test_span_inside_trace(mock_logger):
-    mock_transport_handler, mock_logs = mock_logger
+def test_span_inside_trace():
+    mock_transport_handler, mock_logs = mock_logger()
+    mock_firehose_handler, mock_firehose_logs = mock_logger()
     with zipkin.zipkin_span(
         service_name='test_service_name',
         span_name='test_span_name',
         transport_handler=mock_transport_handler,
         sample_rate=100.0,
         binary_annotations={'some_key': 'some_value'},
+        firehose_handler=mock_firehose_handler,
     ):
         with zipkin.zipkin_span(
             service_name='nested_service',
@@ -111,23 +118,26 @@ def test_span_inside_trace(mock_logger):
         ):
             pass
 
-    spans = _decode_binary_thrift_objs(mock_logs[0])
-    nested_span = spans[0]
-    root_span = spans[1]
-    assert nested_span.name == 'nested_span'
-    assert nested_span.annotations[0].host.service_name == 'nested_service'
-    assert nested_span.parent_id == root_span.id
-    assert nested_span.binary_annotations[0].key == 'nested_key'
-    assert nested_span.binary_annotations[0].value == 'nested_value'
-    # Local nested spans report timestamp and duration
-    assert nested_span.timestamp is not None
-    assert nested_span.duration is not None
-    assert len(nested_span.annotations) == 5
-    assert set([ann.value for ann in nested_span.annotations]) == set([
-        'ss', 'sr', 'cs', 'cr', 'nested_annotation'])
-    for ann in nested_span.annotations:
-        if ann.value == 'nested_annotation':
-            assert ann.timestamp == 43000000
+    def check_spans(spans):
+        nested_span = spans[0]
+        root_span = spans[1]
+        assert nested_span.name == 'nested_span'
+        assert nested_span.annotations[0].host.service_name == 'nested_service'
+        assert nested_span.parent_id == root_span.id
+        assert nested_span.binary_annotations[0].key == 'nested_key'
+        assert nested_span.binary_annotations[0].value == 'nested_value'
+        # Local nested spans report timestamp and duration
+        assert nested_span.timestamp is not None
+        assert nested_span.duration is not None
+        assert len(nested_span.annotations) == 5
+        assert set([ann.value for ann in nested_span.annotations]) == set([
+            'ss', 'sr', 'cs', 'cr', 'nested_annotation'])
+        for ann in nested_span.annotations:
+            if ann.value == 'nested_annotation':
+                assert ann.timestamp == 43000000
+
+    check_spans(_decode_binary_thrift_objs(mock_logs[0]))
+    check_spans(_decode_binary_thrift_objs(mock_firehose_logs[0]))
 
 
 def _verify_service_span(span, annotations):
@@ -142,8 +152,9 @@ def _verify_service_span(span, annotations):
     assert set([ann.value for ann in span.annotations]) == annotations
 
 
-def test_service_span(mock_logger, default_annotations):
-    mock_transport_handler, mock_logs = mock_logger
+def test_service_span(default_annotations):
+    mock_transport_handler, mock_logs = mock_logger()
+    mock_firehose_handler, mock_firehose_logs = mock_logger()
     zipkin_attrs = ZipkinAttrs(
         trace_id='0',
         span_id='1',
@@ -158,11 +169,15 @@ def test_service_span(mock_logger, default_annotations):
         transport_handler=mock_transport_handler,
         binary_annotations={'some_key': 'some_value'},
         add_logging_annotation=True,
+        firehose_handler=mock_firehose_handler,
     ):
         pass
 
     span = _decode_binary_thrift_obj(mock_logs[0])
+    firehose_span = _decode_binary_thrift_obj(mock_firehose_logs[0])
     _verify_service_span(span, default_annotations)
+    _verify_service_span(firehose_span, default_annotations)
+
     # Spans continued on the server don't log timestamp/duration, as it's
     # assumed the client part of the pair will log them.
     assert span.timestamp is None
@@ -170,10 +185,9 @@ def test_service_span(mock_logger, default_annotations):
 
 
 def test_service_span_report_timestamp_override(
-    mock_logger,
     default_annotations,
 ):
-    mock_transport_handler, mock_logs = mock_logger
+    mock_transport_handler, mock_logs = mock_logger()
     zipkin_attrs = ZipkinAttrs(
         trace_id='0',
         span_id='1',
@@ -199,10 +213,10 @@ def test_service_span_report_timestamp_override(
 
 
 def test_service_span_that_is_independently_sampled(
-    mock_logger,
     default_annotations,
 ):
-    mock_transport_handler, mock_logs = mock_logger
+    mock_transport_handler, mock_logs = mock_logger()
+    mock_firehose_handler, mock_firehose_logs = mock_logger()
     zipkin_attrs = ZipkinAttrs(
         trace_id='0',
         span_id='1',
@@ -219,24 +233,29 @@ def test_service_span_that_is_independently_sampled(
         sample_rate=100.0,
         binary_annotations={'some_key': 'some_value'},
         add_logging_annotation=True,
+        firehose_handler=mock_firehose_handler,
     ):
         pass
 
-    span = _decode_binary_thrift_obj(mock_logs[0])
-    assert span.name == 'service_span'
-    assert span.annotations[0].host.service_name == 'test_service_name'
-    assert span.parent_id is None
-    assert span.binary_annotations[0].key == 'some_key'
-    assert span.binary_annotations[0].value == 'some_value'
-    # Spans that are part of an unsampled trace which start their own sampling
-    # should report timestamp/duration, as they're acting as root spans.
-    assert span.timestamp is not None
-    assert span.duration is not None
-    assert set([ann.value for ann in span.annotations]) == default_annotations
+    def check_span(span):
+        assert span.name == 'service_span'
+        assert span.annotations[0].host.service_name == 'test_service_name'
+        assert span.parent_id is None
+        assert span.binary_annotations[0].key == 'some_key'
+        assert span.binary_annotations[0].value == 'some_value'
+        # Spans that are part of an unsampled trace which start their own sampling
+        # should report timestamp/duration, as they're acting as root spans.
+        assert span.timestamp is not None
+        assert span.duration is not None
+        assert set([ann.value for ann in span.annotations]) == default_annotations
+
+    check_span(_decode_binary_thrift_obj(mock_logs[0]))
+    check_span(_decode_binary_thrift_obj(mock_firehose_logs[0]))
 
 
-def test_log_debug_for_new_span(mock_logger):
-    mock_transport_handler, mock_logs = mock_logger
+def test_log_debug_for_new_span():
+    mock_transport_handler, mock_logs = mock_logger()
+    mock_firehose_handler, mock_firehose_logs = mock_logger()
     with zipkin.zipkin_span(
         service_name='test_service_name',
         span_name='test_span_name',
@@ -244,6 +263,7 @@ def test_log_debug_for_new_span(mock_logger):
         sample_rate=100.0,
         binary_annotations={'some_key': 'some_value'},
         add_logging_annotation=True,
+        firehose_handler=mock_firehose_handler,
     ):
         zipkin_logger.debug({
             'annotations': {
@@ -258,19 +278,26 @@ def test_log_debug_for_new_span(mock_logger):
         })
         pass
 
-    spans = _decode_binary_thrift_objs(mock_logs[0])
-    logged_span = spans[0]
-    root_span = spans[1]
-    assert logged_span.name == 'logged_name'
-    assert logged_span.annotations[0].host.service_name == 'logged_service_name'
-    assert logged_span.parent_id == root_span.id
-    assert logged_span.binary_annotations[0].key == 'logged_binary_annotation'
-    assert logged_span.binary_annotations[0].value == 'logged_value'
-    assert set([ann.value for ann in logged_span.annotations]) == set(['cs', 'cr'])
+    def check_spans(spans):
+        logged_span = spans[0]
+        root_span = spans[1]
+        assert logged_span.name == 'logged_name'
+        assert logged_span.annotations[0] \
+                          .host.service_name == 'logged_service_name'
+        assert logged_span.parent_id == root_span.id
+        assert logged_span.binary_annotations[0].key == 'logged_binary_annotation'
+        assert logged_span.binary_annotations[0].value == 'logged_value'
+        assert set(
+            [ann.value for ann in logged_span.annotations]
+        ) == set(['cs', 'cr'])
+
+    check_spans(_decode_binary_thrift_objs(mock_logs[0]))
+    check_spans(_decode_binary_thrift_objs(mock_firehose_logs[0]))
 
 
-def test_log_debug_for_existing_span(mock_logger, default_annotations):
-    mock_transport_handler, mock_logs = mock_logger
+def test_log_debug_for_existing_span(default_annotations):
+    mock_transport_handler, mock_logs = mock_logger()
+    mock_firehose_handler, mock_firehose_logs = mock_logger()
     with zipkin.zipkin_span(
         service_name='test_service_name',
         span_name='test_span_name',
@@ -278,6 +305,7 @@ def test_log_debug_for_existing_span(mock_logger, default_annotations):
         sample_rate=100.0,
         binary_annotations={'some_key': 'some_value'},
         add_logging_annotation=True,
+        firehose_handler=mock_firehose_handler,
     ):
         zipkin_logger.debug({
             'annotations': {
@@ -289,21 +317,24 @@ def test_log_debug_for_existing_span(mock_logger, default_annotations):
         })
         pass
 
+    def check_span(span):
+        assert span.name == 'test_span_name'
+        assert span.annotations[0].host.service_name == 'test_service_name'
+        assert span.parent_id is None
+        assert len(span.annotations) == 4
+        annotations = sorted(span.annotations, key=lambda ann: ann.value)
+        assert annotations[3].value == 'test_annotation'
+        assert annotations[3].timestamp == 42000000
+        default_annotations.add('test_annotation')
+        assert set([ann.value for ann in annotations]) == default_annotations
+        assert len(span.binary_annotations) == 2
+        binary_annotations = sorted(
+            span.binary_annotations, key=lambda bin_ann: bin_ann.key)
+        assert binary_annotations[0].key == 'extra_binary_annotation'
+        assert binary_annotations[0].value == 'extra_value'
+        assert binary_annotations[1].key == 'some_key'
+        assert binary_annotations[1].value == 'some_value'
+
     assert len(mock_logs) == 1
-    span = _decode_binary_thrift_obj(mock_logs[0])
-    assert span.name == 'test_span_name'
-    assert span.annotations[0].host.service_name == 'test_service_name'
-    assert span.parent_id is None
-    assert len(span.annotations) == 4
-    annotations = sorted(span.annotations, key=lambda ann: ann.value)
-    assert annotations[3].value == 'test_annotation'
-    assert annotations[3].timestamp == 42000000
-    default_annotations.add('test_annotation')
-    assert set([ann.value for ann in annotations]) == default_annotations
-    assert len(span.binary_annotations) == 2
-    binary_annotations = sorted(
-        span.binary_annotations, key=lambda bin_ann: bin_ann.key)
-    assert binary_annotations[0].key == 'extra_binary_annotation'
-    assert binary_annotations[0].value == 'extra_value'
-    assert binary_annotations[1].key == 'some_key'
-    assert binary_annotations[1].value == 'some_value'
+    check_span(_decode_binary_thrift_obj(mock_logs[0]))
+    check_span(_decode_binary_thrift_obj(mock_firehose_logs[0]))

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -6,9 +6,9 @@ from py_zipkin.exception import ZipkinError
 from py_zipkin.logging_helper import null_handler
 from py_zipkin.logging_helper import ZipkinLoggerHandler
 from py_zipkin.thread_local import get_zipkin_attrs
-from py_zipkin.thrift import SERVER_ADDR_VAL
 from py_zipkin.thrift import create_binary_annotation
 from py_zipkin.thrift import create_endpoint
+from py_zipkin.thrift import SERVER_ADDR_VAL
 from py_zipkin.thrift import zipkin_core
 from py_zipkin.util import generate_random_64bit_string
 from py_zipkin.zipkin import ZipkinAttrs
@@ -58,6 +58,7 @@ def test_zipkin_span_for_new_trace(
         add_logging_annotation=False,
         client_context=False,
         max_span_batch_size=None,
+        firehose_handler=None,
     )
     pop_zipkin_attrs_mock.assert_called_once_with()
 
@@ -112,6 +113,7 @@ def test_zipkin_span_passed_sampled_attrs(
         add_logging_annotation=False,
         client_context=False,
         max_span_batch_size=None,
+        firehose_handler=None
     )
     pop_zipkin_attrs_mock.assert_called_once_with()
 
@@ -492,6 +494,7 @@ def test_zipkin_server_span_decorator(
         add_logging_annotation=False,
         client_context=False,
         max_span_batch_size=None,
+        firehose_handler=None,
     )
     pop_zipkin_attrs_mock.assert_called_once_with()
 
@@ -548,6 +551,7 @@ def test_zipkin_client_span_decorator(
         add_logging_annotation=False,
         client_context=True,
         max_span_batch_size=None,
+        firehose_handler=None,
     )
     pop_zipkin_attrs_mock.assert_called_once_with()
 


### PR DESCRIPTION
This is a quick and dirty implementation of the "firehose mode" (openzipkin/zipkin#1869). The full specification for firehose mode is to come, but the basic idea is that there is a second handler that emits spans regardless of sampling decision.

@msindwan @drolando