### PR TITLE
Added parameter for explicit context

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,16 @@ def transport_handler(message):
     producer.send_messages('kafka_topic_name', message)
 ```
 
+Using in multithreading evironments
+-----------------------------------
+
+If you want to use py_zipkin in a cooperative multithreading environment,
+e.g. asyncio, you need to explicitly pass an instance of `py_zipkin.stack.Stack`
+as parameter `context_stack` for `zipkin_span` and `create_http_headers_for_new_span`.
+By default, py_zipkin uses a thread local storage for the attributes, which is
+defined in `py_zipkin.stack.ThreadLocalStack`.
+
+
 License
 -------
 

--- a/py_zipkin/stack.py
+++ b/py_zipkin/stack.py
@@ -1,0 +1,42 @@
+from py_zipkin import thread_local
+
+
+class Stack(object):
+    """
+    Stack is a simple stack class.
+
+    It offers the operations push, pop and get.
+    The latter two return None if the stack is empty.
+    """
+
+    def __init__(self, storage):
+        self._storage = storage
+
+    def push(self, item):
+        self._storage.append(item)
+
+    def pop(self):
+        if self._storage:
+            return self._storage.pop()
+
+    def get(self):
+        if self._storage:
+            return self._storage[-1]
+
+
+class ThreadLocalStack(Stack):
+    """
+    ThreadLocalStack is variant of Stack that uses a thread local storage.
+
+    The thread local storage is accessed lazily in every method call,
+    so the thread that calls the method matters, not the thread that
+    instantiated the class.
+    Every instance shares the same thread local data.
+    """
+
+    def __init__(self):
+        pass
+
+    @property
+    def _storage(self):
+        return thread_local.get_thread_local_zipkin_attrs()

--- a/py_zipkin/thread_local.py
+++ b/py_zipkin/thread_local.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import threading
+import warnings
 
 _thread_local = threading.local()
 
@@ -21,9 +22,12 @@ def get_zipkin_attrs():
     :returns: tuple containing zipkin attrs
     :rtype: :class:`zipkin.ZipkinAttrs`
     """
-    zipkin_attrs = get_thread_local_zipkin_attrs()
-    if zipkin_attrs:
-        return zipkin_attrs[-1]
+    from py_zipkin.stack import ThreadLocalStack
+    warnings.warn(
+        'Use py_zipkin.stack.ThreadLocalStack().get',
+        DeprecationWarning,
+    )
+    return ThreadLocalStack().get()
 
 
 def pop_zipkin_attrs():
@@ -32,9 +36,12 @@ def pop_zipkin_attrs():
     :returns: tuple containing zipkin attrs
     :rtype: :class:`zipkin.ZipkinAttrs`
     """
-    zipkin_attrs = get_thread_local_zipkin_attrs()
-    if zipkin_attrs:
-        return zipkin_attrs.pop()
+    from py_zipkin.stack import ThreadLocalStack
+    warnings.warn(
+        'Use py_zipkin.stack.ThreadLocalStack().pop',
+        DeprecationWarning,
+    )
+    return ThreadLocalStack().pop()
 
 
 def push_zipkin_attrs(zipkin_attr):
@@ -43,4 +50,9 @@ def push_zipkin_attrs(zipkin_attr):
     :param zipkin_attr: tuple containing zipkin related attrs
     :type zipkin_attr: :class:`zipkin.ZipkinAttrs`
     """
-    get_thread_local_zipkin_attrs().append(zipkin_attr)
+    from py_zipkin.stack import ThreadLocalStack
+    warnings.warn(
+        'Use py_zipkin.stack.ThreadLocalStack().push',
+        DeprecationWarning,
+    )
+    return ThreadLocalStack().push(zipkin_attr)

--- a/tests/stack_test.py
+++ b/tests/stack_test.py
@@ -1,0 +1,59 @@
+import mock
+
+import py_zipkin.stack
+
+
+@mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', [])
+def test_get_zipkin_attrs_returns_none_if_no_zipkin_attrs():
+    assert not py_zipkin.stack.ThreadLocalStack().get()
+    assert not py_zipkin.stack.ThreadLocalStack().get()
+
+
+def test_get_zipkin_attrs_with_context_returns_none_if_no_zipkin_attrs():
+    assert not py_zipkin.stack.Stack([]).get()
+
+
+@mock.patch('py_zipkin.stack.thread_local._thread_local.zipkin_attrs', ['foo'])
+def test_get_zipkin_attrs_returns_the_last_of_the_list():
+    assert 'foo' == py_zipkin.stack.ThreadLocalStack().get()
+
+
+def test_get_zipkin_attrs_with_context_returns_the_last_of_the_list():
+    assert 'foo' == py_zipkin.stack.Stack(['bar', 'foo']).get()
+
+
+@mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', [])
+def test_pop_zipkin_attrs_does_nothing_if_no_requests():
+    assert not py_zipkin.stack.ThreadLocalStack().pop()
+
+
+def test_pop_zipkin_attrs_with_context_does_nothing_if_no_requests():
+    assert not py_zipkin.stack.Stack([]).pop()
+
+
+@mock.patch(
+    'py_zipkin.thread_local._thread_local.zipkin_attrs', ['foo', 'bar']
+)
+def test_pop_zipkin_attrs_removes_the_last_zipkin_attrs():
+    assert 'bar' == py_zipkin.stack.ThreadLocalStack().pop()
+    assert 'foo' == py_zipkin.stack.ThreadLocalStack().get()
+
+
+def test_pop_zipkin_attrs_with_context_removes_the_last_zipkin_attrs():
+    context_stack = py_zipkin.stack.Stack(['foo', 'bar'])
+    assert 'bar' == context_stack.pop()
+    assert 'foo' == context_stack.get()
+
+
+@mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', ['foo'])
+def test_push_zipkin_attrs_adds_new_zipkin_attrs_to_list():
+    assert 'foo' == py_zipkin.stack.ThreadLocalStack().get()
+    py_zipkin.stack.ThreadLocalStack().push('bar')
+    assert 'bar' == py_zipkin.stack.ThreadLocalStack().get()
+
+
+def test_push_zipkin_attrs_with_context_adds_new_zipkin_attrs_to_list():
+    stack = py_zipkin.stack.Stack(['foo'])
+    assert 'foo' == stack.get()
+    stack.push('bar')
+    assert 'bar' == stack.get()

--- a/tests/thread_local_test.py
+++ b/tests/thread_local_test.py
@@ -18,19 +18,9 @@ def test_get_thread_local_zipkin_attrs_creates_empty_list_if_not_attached():
     assert hasattr(thread_local._thread_local, "zipkin_attrs")
 
 
-@mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', [])
-def test_get_zipkin_attrs_returns_none_if_no_zipkin_attrs():
-    assert not thread_local.get_zipkin_attrs()
-
-
 @mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', ['foo'])
 def test_get_zipkin_attrs_returns_the_last_of_the_list():
     assert 'foo' == thread_local.get_zipkin_attrs()
-
-
-@mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', [])
-def test_pop_zipkin_attrs_does_nothing_if_no_requests():
-    assert not thread_local.pop_zipkin_attrs()
 
 
 @mock.patch(


### PR DESCRIPTION
A parameter `context_stack` is added to every function of the call stack.
If not provided (default value is `None`), py_zipkin will use the thread local storage
and work as expected.