### PR TITLE
Don't overwrite passed in annotations

### DIFF
--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -398,13 +398,12 @@ class zipkin_span(object):
             'ss': end_timestamp,
             'cr': end_timestamp,
         }
-        # But we filter down if we only want to emit some of the annotations
-        filtered_annotations = {
-            k: v for k, v in full_annotations.items()
-            if k in self.annotation_filter
-        }
 
-        self.annotations.update(filtered_annotations)
+        # Update the the annotations if they aren't already set
+        # This prevents overwriting user-defined annotations
+        for annotation, timestamp in full_annotations.items():
+            if annotation in self.annotation_filter:
+                self.annotations.setdefault(annotation, timestamp)
 
         self.log_handler.store_local_span(
             span_name=self.span_name,


### PR DESCRIPTION
Currently, if you pass in an annotation like `cr` or `sr`, then it will be overwritten when the span closes. The only time you are really going to do this is when you create spans after the fact instead of using the normal start/stop or context manager API.

Internally, we do this and use the `zipkin_logger.debug` API. But since we're trying to get rid of that API, we need to support this. Ideally, this isn't needed and we can actually just switch to the start/stop API, but for now this will do.