### PR TITLE
Add zipkin span benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist/
 venv
 tags
 *.swp
+.pytest_cache
+.benchmarks

--- a/tests/profiling/zipkin_span_benchmark_test.py
+++ b/tests/profiling/zipkin_span_benchmark_test.py
@@ -1,121 +1,134 @@
 import pytest
 import mock
-import socket
 import py_zipkin.zipkin as zipkin
 
 
-class UDPTransportHandler(object):
-
-    def __init__(self):
-        self.send_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        self.recv_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        self.recv_socket.bind(('', 0))
-
-    def __bool__(self):
-        return True
-
-    def __nonzero__(self):
-        return True
-
-    def __call__(self, message):
-        self.send_socket.sendto(message, self.recv_socket.getsockname())
-
-
-class TCPTransportHandler(object):
-
-    def __init__(self):
-        self.send_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.recv_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.recv_socket.bind(('', 0))
-        self.recv_socket.listen(1)
-        self.send_socket.connect(self.recv_socket.getsockname())
-
-    def __bool__(self):
-        return True
-
-    def __nonzero__(self):
-        return True
-
-    def __call__(self, message):
-        self.send_socket.send(message)
-
-
-@pytest.mark.parametrize('transport_handler', [
-    mock.Mock(),
-    UDPTransportHandler(),
-    TCPTransportHandler(),
-])
-@pytest.mark.parametrize('firehose_handler', [
-    None,
-    UDPTransportHandler(),
-    TCPTransportHandler(),
-])
-@pytest.mark.parametrize('sample_rate', [0.15, 100])
-def test_zipkin_span_thread_local(
-    benchmark,
-    transport_handler,
-    firehose_handler,
-    sample_rate,
-):
-    def benchmark_zipkin_span():
-        context = zipkin.zipkin_span(
+def _create_root_span(is_sampled, firehose_enabled):
+    return (), {
+        'root_span': zipkin.zipkin_span(
             service_name='my_service',
             span_name='my_span_name',
-            transport_handler=transport_handler,
-            firehose_handler=firehose_handler,
+            transport_handler=mock.Mock(),
+            firehose_handler=mock.Mock() if firehose_enabled else None,
             port=42,
-            sample_rate=sample_rate,
+            sample_rate=0 if not is_sampled else 100,
         )
-        context.start()
-
-    benchmark(benchmark_zipkin_span)
+    }
 
 
-@pytest.mark.parametrize('transport_handler', [
-    mock.Mock(),
-    UDPTransportHandler(),
-    TCPTransportHandler(),
-])
-@pytest.mark.parametrize('firehose_handler', [
-    None,
-    UDPTransportHandler(),
-    TCPTransportHandler(),
-])
-@pytest.mark.parametrize('sample_rate', [0.15, 100])
-@pytest.mark.parametrize('num_spans', [1, 100, 1000])
-def test_zipkin_span_logging(
-    benchmark,
-    transport_handler,
-    firehose_handler,
-    sample_rate,
-    num_spans,
-):
-    def build_trace():
-        context = zipkin.zipkin_span(
+def _start_zipkin_trace(is_sampled, firehose_enabled, num_child_spans):
+    _, args = _create_root_span(is_sampled, firehose_enabled)
+    args['root_span'].start()
+    for _ in range(num_child_spans):
+        with zipkin.zipkin_span(
             service_name='my_service',
-            span_name='my_span_name',
-            transport_handler=transport_handler,
-            firehose_handler=firehose_handler,
-            port=42,
-            sample_rate=sample_rate,
-        )
-        context.start()
-        for _ in range(num_spans):
-            with zipkin.zipkin_span(
-                service_name='my_service',
-                span_name='my_span_name',
-            ):
-                pass
+            span_name='my_child_span_name',
+        ):
+            pass
 
-        return (), {'context': context}
-
-    def benchmark_zipkin_span(context):
-        context.stop()
-
-    benchmark.pedantic(benchmark_zipkin_span, setup=build_trace, rounds=100)
+    return (), args
 
 
-@pytest.mark.parametrize('use_128', [False, True])
+def _start_and_stop_zipkin_trace(is_sampled, firehose_enabled, num_child_spans):
+    _, args = _start_zipkin_trace(is_sampled, firehose_enabled, num_child_spans)
+    args['root_span'].stop()
+
+
+@pytest.mark.parametrize(
+    'firehose_enabled',
+    [False, True],
+    ids=["firehose_enabled=False", "firehose_enabled=True"],
+)
+@pytest.mark.parametrize(
+    'is_sampled',
+    [False, True],
+    ids=["is_sampled=False", "is_sampled=True"],
+)
+def test_creating_span(benchmark, firehose_enabled, is_sampled):
+    benchmark(
+        _create_root_span,
+        firehose_enabled=firehose_enabled,
+        is_sampled=is_sampled,
+    )
+
+
+@pytest.mark.parametrize(
+    'firehose_enabled',
+    [False, True],
+    ids=["firehose_enabled=False", "firehose_enabled=True"],
+)
+@pytest.mark.parametrize(
+    'is_sampled',
+    [False, True],
+    ids=["is_sampled=False", "is_sampled=True"],
+)
+def test_starting_span_context(benchmark, firehose_enabled, is_sampled):
+    benchmark.pedantic(
+        lambda root_span: root_span.start(),
+        setup=lambda: _create_root_span(
+            is_sampled=is_sampled,
+            firehose_enabled=firehose_enabled,
+        ),
+        rounds=50,
+    )
+
+
+@pytest.mark.parametrize(
+    'firehose_enabled',
+    [False, True],
+    ids=["firehose_enabled=False", "firehose_enabled=True"],
+)
+@pytest.mark.parametrize(
+    'num_child_spans',
+    [100, 1000],
+    ids=["num_child_spans=100", "num_child_spans=1000"],
+)
+@pytest.mark.parametrize(
+    'is_sampled',
+    [False, True],
+    ids=["is_sampled=False", "is_sampled=True"],
+)
+def test_logging_spans(benchmark, firehose_enabled, num_child_spans, is_sampled):
+    benchmark.pedantic(
+        lambda root_span: root_span.stop(),
+        setup=lambda: _start_zipkin_trace(
+            is_sampled=is_sampled,
+            firehose_enabled=firehose_enabled,
+            num_child_spans=num_child_spans,
+        ),
+        rounds=50,
+    )
+
+
+@pytest.mark.parametrize(
+    'firehose_enabled',
+    [False, True],
+    ids=["firehose_enabled=False", "firehose_enabled=True"],
+)
+@pytest.mark.parametrize(
+    'num_child_spans',
+    [100, 1000],
+    ids=["num_child_spans=100", "num_child_spans=1000"],
+)
+@pytest.mark.parametrize(
+    'is_sampled',
+    [False, True],
+    ids=["is_sampled=False", "is_sampled=True"],
+)
+def test_zipkin_span(benchmark, firehose_enabled, num_child_spans, is_sampled):
+    benchmark(
+        _start_and_stop_zipkin_trace,
+        is_sampled=is_sampled,
+        firehose_enabled=firehose_enabled,
+        num_child_spans=num_child_spans,
+    )
+
+
+@pytest.mark.parametrize(
+    'use_128',
+    [False, True],
+    ids=["use_128=False", "use_128=True"],
+)
 def test_create_attrs_for_span(benchmark, use_128):
     benchmark(
         zipkin.create_attrs_for_span,

--- a/tests/profiling/zipkin_span_benchmark_test.py
+++ b/tests/profiling/zipkin_span_benchmark_test.py
@@ -1,6 +1,118 @@
 import pytest
-
+import mock
+import socket
 import py_zipkin.zipkin as zipkin
+
+
+class UDPTransportHandler(object):
+
+    def __init__(self):
+        self.send_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.recv_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.recv_socket.bind(('', 0))
+
+    def __bool__(self):
+        return True
+
+    def __nonzero__(self):
+        return True
+
+    def __call__(self, message):
+        self.send_socket.sendto(message, self.recv_socket.getsockname())
+
+
+class TCPTransportHandler(object):
+
+    def __init__(self):
+        self.send_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.recv_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.recv_socket.bind(('', 0))
+        self.recv_socket.listen(1)
+        self.send_socket.connect(self.recv_socket.getsockname())
+
+    def __bool__(self):
+        return True
+
+    def __nonzero__(self):
+        return True
+
+    def __call__(self, message):
+        self.send_socket.send(message)
+
+
+@pytest.mark.parametrize('transport_handler', [
+    mock.Mock(),
+    UDPTransportHandler(),
+    TCPTransportHandler(),
+])
+@pytest.mark.parametrize('firehose_handler', [
+    None,
+    UDPTransportHandler(),
+    TCPTransportHandler(),
+])
+@pytest.mark.parametrize('sample_rate', [0.15, 100])
+def test_zipkin_span_thread_local(
+    benchmark,
+    transport_handler,
+    firehose_handler,
+    sample_rate,
+):
+    def benchmark_zipkin_span():
+        context = zipkin.zipkin_span(
+            service_name='my_service',
+            span_name='my_span_name',
+            transport_handler=transport_handler,
+            firehose_handler=firehose_handler,
+            port=42,
+            sample_rate=sample_rate,
+        )
+        context.start()
+
+    benchmark(benchmark_zipkin_span)
+
+
+@pytest.mark.parametrize('transport_handler', [
+    mock.Mock(),
+    UDPTransportHandler(),
+    TCPTransportHandler(),
+])
+@pytest.mark.parametrize('firehose_handler', [
+    None,
+    UDPTransportHandler(),
+    TCPTransportHandler(),
+])
+@pytest.mark.parametrize('sample_rate', [0.15, 100])
+@pytest.mark.parametrize('num_spans', [1, 10, 100])
+def test_zipkin_span_logging(
+    benchmark,
+    transport_handler,
+    firehose_handler,
+    sample_rate,
+    num_spans,
+):
+    def build_trace():
+        context = zipkin.zipkin_span(
+            service_name='my_service',
+            span_name='my_span_name',
+            transport_handler=transport_handler,
+            firehose_handler=firehose_handler,
+            port=42,
+            sample_rate=sample_rate,
+        )
+        context.start()
+        for _ in range(num_spans):
+            with zipkin.zipkin_span(
+                service_name='my_service',
+                span_name='my_span_name',
+            ):
+                pass
+
+        return (), {'context': context}
+
+    def benchmark_zipkin_span(context):
+        context.stop()
+
+    benchmark.pedantic(benchmark_zipkin_span, setup=build_trace)
 
 
 @pytest.mark.parametrize('use_128', [False, True])

--- a/tests/profiling/zipkin_span_benchmark_test.py
+++ b/tests/profiling/zipkin_span_benchmark_test.py
@@ -112,7 +112,7 @@ def test_zipkin_span_logging(
     def benchmark_zipkin_span(context):
         context.stop()
 
-    benchmark.pedantic(benchmark_zipkin_span, setup=build_trace)
+    benchmark.pedantic(benchmark_zipkin_span, setup=build_trace, rounds=100)
 
 
 @pytest.mark.parametrize('use_128', [False, True])

--- a/tests/profiling/zipkin_span_benchmark_test.py
+++ b/tests/profiling/zipkin_span_benchmark_test.py
@@ -82,7 +82,7 @@ def test_zipkin_span_thread_local(
     TCPTransportHandler(),
 ])
 @pytest.mark.parametrize('sample_rate', [0.15, 100])
-@pytest.mark.parametrize('num_spans', [1, 10, 100])
+@pytest.mark.parametrize('num_spans', [1, 100, 1000])
 def test_zipkin_span_logging(
     benchmark,
     transport_handler,


### PR DESCRIPTION
Added benchmarks for creating Zipkin spans with py_zipkin. These benchmarks take into account creating spans, starting a new span context, and logging spans with varying parameters (e.g the number of spans in the trace, whether or not it is sampled, and if firehose mode is enabled) 

_UPDATE: To make things more clear, I added labels and removed a few dimensions including benchmarking different transport handlers._

The `test_zipkin_span` benchmark is the end-to-end, cumulative benchmark. This is intended to give a *rough* idea of the distribution in timings and should be supplemented with more accurate profiling in the future.

Looking at the mean and median timings, when the trace is sampled and firehose mode is enabled, roughly ~50-60us is spent creating a zipkin_span context manager and another 200us is spent starting the context. The bottle neck is presumably logging the spans, which was also between 200 and 400 us when logging 100 and 1000 spans respectively.

```
--------------------------------------------------------------------------------------------- benchmark 'test_creating_span': 4 tests ---------------------------------------------------------------------------------------------
Name (time in us)                                              Min                   Max               Mean             StdDev             Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
creating_span[is_sampled=True-firehose_enabled=False]      29.9616 (1.0)        341.5979 (1.0)      32.7132 (1.0)      13.3016 (1.0)      30.9851 (1.0)      0.6054 (1.0)      365;1740       30.5687 (1.0)       16699           1
creating_span[is_sampled=False-firehose_enabled=False]     29.9709 (1.00)       859.8324 (2.52)     32.8470 (1.00)     15.7951 (1.19)     31.0056 (1.00)     0.6165 (1.02)      157;856       30.4442 (1.00)       7263           1
creating_span[is_sampled=False-firehose_enabled=True]      52.9429 (1.77)       424.1923 (1.24)     58.1509 (1.78)     19.2230 (1.45)     54.8856 (1.77)     0.9574 (1.58)     385;1070       17.1966 (0.56)      10978           1
creating_span[is_sampled=True-firehose_enabled=True]       53.0798 (1.77)     9,005.7179 (26.36)    58.8158 (1.80)     86.9799 (6.54)     54.7683 (1.77)     0.8289 (1.37)      90;1239       17.0022 (0.56)      11097           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


--------------------------------------------------------------------------------------------------------- benchmark 'test_logging_span': 8 tests --------------------------------------------------------------------------------------------------------
Name (time in us)                                                                   Min                 Max                Mean             StdDev              Median                IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
logging_spans[is_sampled=False-num_child_spans=100-firehose_enabled=False]        2.9299 (1.0)        4.1835 (1.0)        3.2051 (1.0)       0.1970 (1.0)        3.1805 (1.0)       0.1760 (1.0)           8;2      311.9982 (1.0)          50           1
logging_spans[is_sampled=False-num_child_spans=1000-firehose_enabled=False]       3.3928 (1.16)       4.9770 (1.19)       4.1273 (1.29)      0.3431 (1.74)       4.0601 (1.28)      0.4601 (2.61)         19;0      242.2899 (0.78)         50           1
logging_spans[is_sampled=True-num_child_spans=100-firehose_enabled=False]       224.4469 (76.60)    362.4735 (86.64)    237.7314 (74.17)    27.6896 (140.54)   229.3997 (72.13)     5.3477 (30.38)         3;6        4.2064 (0.01)         50           1
logging_spans[is_sampled=False-num_child_spans=100-firehose_enabled=True]       224.5726 (76.65)    362.4056 (86.63)    237.8025 (74.19)    27.1184 (137.65)   230.1764 (72.37)     5.8440 (33.20)         3;5        4.2052 (0.01)         50           1
logging_spans[is_sampled=True-num_child_spans=1000-firehose_enabled=False]      240.6202 (82.12)    412.9214 (98.70)    286.1208 (89.27)    40.3596 (204.85)   273.7986 (86.09)    70.5905 (401.04)       18;0        3.4950 (0.01)         50           1
logging_spans[is_sampled=False-num_child_spans=1000-firehose_enabled=True]      252.7479 (86.26)    398.7504 (95.32)    310.5901 (96.90)    35.4312 (179.84)   312.4219 (98.23)    56.6738 (321.97)       17;0        3.2197 (0.01)         50           1
logging_spans[is_sampled=True-num_child_spans=100-firehose_enabled=True]        401.5379 (137.05)   761.1923 (181.95)   428.3968 (133.66)   50.6635 (257.15)   416.1340 (130.84)   12.4443 (70.70)         1;9        2.3343 (0.01)         50           1
logging_spans[is_sampled=True-num_child_spans=1000-firehose_enabled=True]       423.7806 (144.64)   602.3562 (143.98)   492.8129 (153.76)   43.4524 (220.55)   494.5616 (155.50)   62.0959 (352.78)       17;0        2.0292 (0.01)         50           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------------------------- benchmark 'test_starting_span_context': 4 tests -----------------------------------------------------------------------------------------------
Name (time in us)                                                       Min                   Max                Mean              StdDev              Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
starting_span_context[is_sampled=False-firehose_enabled=False]       8.5812 (1.0)         38.4049 (1.0)        9.7037 (1.0)        4.2064 (1.0)        8.9309 (1.0)      0.3334 (1.0)           1;5      103.0538 (1.0)          50           1
starting_span_context[is_sampled=False-firehose_enabled=True]      214.3960 (24.98)    2,490.7850 (64.86)    265.2584 (27.34)    321.2441 (76.37)    218.0161 (24.41)    3.5698 (10.71)         1;5        3.7699 (0.04)         50           1
starting_span_context[is_sampled=True-firehose_enabled=False]      215.7707 (25.14)      263.3426 (6.86)     220.8418 (22.76)      8.7626 (2.08)     218.1698 (24.43)    3.4627 (10.39)         4;5        4.5281 (0.04)         50           1
starting_span_context[is_sampled=True-firehose_enabled=True]       218.9511 (25.52)      291.2870 (7.58)     226.7061 (23.36)     12.3941 (2.95)     222.5386 (24.92)    5.4510 (16.35)         6;7        4.4110 (0.04)         50           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------------------------------- benchmark 'test_zipkin_span': 8 tests -----------------------------------------------------------------------------------------------------
Name (time in ms)                                                                 Min                 Max               Mean             StdDev             Median               IQR            Outliers       OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
zipkin_span[is_sampled=False-num_child_spans=100-firehose_enabled=False]       1.8766 (1.0)      107.1862 (24.39)     2.2006 (1.0)       4.7760 (20.72)     1.9428 (1.0)      0.0460 (1.0)          1;45  454.4163 (1.0)         486           1
zipkin_span[is_sampled=True-num_child_spans=100-firehose_enabled=False]        2.3595 (1.26)       4.3945 (1.0)       2.4966 (1.13)      0.2305 (1.0)       2.4448 (1.26)     0.0557 (1.21)        29;31  400.5406 (0.88)        385           1
zipkin_span[is_sampled=False-num_child_spans=100-firehose_enabled=True]        2.3820 (1.27)     131.4281 (29.91)     2.8767 (1.31)      6.7317 (29.20)     2.4796 (1.28)     0.0645 (1.40)         1;32  347.6188 (0.76)        367           1
zipkin_span[is_sampled=True-num_child_spans=100-firehose_enabled=True]         2.5766 (1.37)     201.8795 (45.94)     3.2710 (1.49)     10.4120 (45.17)     2.6724 (1.38)     0.0651 (1.42)         1;40  305.7138 (0.67)        366           1
zipkin_span[is_sampled=False-num_child_spans=1000-firehose_enabled=False]     18.4236 (9.82)      28.2721 (6.43)     19.1248 (8.69)      1.6019 (6.95)     18.7302 (9.64)     0.3591 (7.81)          4;4   52.2881 (0.12)         54           1
zipkin_span[is_sampled=False-num_child_spans=1000-firehose_enabled=True]      19.0193 (10.14)    177.0192 (40.28)    22.6413 (10.29)    21.8415 (94.75)    19.4458 (10.01)    0.4541 (9.88)          1;4   44.1671 (0.10)         52           1
zipkin_span[is_sampled=True-num_child_spans=1000-firehose_enabled=False]      19.0710 (10.16)     24.1397 (5.49)     19.8503 (9.02)      0.9761 (4.23)     19.5930 (10.08)    0.4798 (10.44)         5;5   50.3771 (0.11)         51           1
zipkin_span[is_sampled=True-num_child_spans=1000-firehose_enabled=True]       19.3077 (10.29)    263.6458 (59.99)    24.7471 (11.25)    33.7986 (146.62)   19.7303 (10.16)    0.4556 (9.91)          1;7   40.4087 (0.09)         52           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
