### PR TITLE
Add FirehoseHandler from yelp_pyramid to py_zipkin

### DIFF
--- a/py_zipkin/transport/firehose_handler.py
+++ b/py_zipkin/transport/firehose_handler.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+import socket
+
+import clog
+import staticconf
+
+
+ZIPKIN_CONFIG_NAMESPACE = 'zipkin'
+ZIPKIN_CONFIG_FILE = '/nail/srv/configs/zipkin.yaml'
+ZIPKIN_CONFIG_MIN_RELOAD_INTERVAL = 5
+
+ZIPKIN_FIREHOSE_IP = '169.254.255.254'
+ZIPKIN_FIREHOSE_PORT = 20182
+
+ZIPKIN_DEFAULT_FIREHOSE_ENABLED = False
+
+
+class FirehoseHandler(object):
+    """A configurable transport handler for firehose mode (CEP935)
+
+    This handler implements truth value testing so that it can be enabled,
+    disabled, or removed, while keeping the py_zipkin logic simple.
+
+    When called with a thrift-encoded zipkin message (typically a
+    thrift-encoded list of spans), it will forward this message over UDP to a
+    proxy, which generally runs as a daemon on the local host.
+    """
+
+    def __init__(self):
+        self.zipkin_namespace = staticconf.NamespaceReaders(
+            ZIPKIN_CONFIG_NAMESPACE)
+        self.config_watcher = staticconf.ConfigFacade.load(
+            ZIPKIN_CONFIG_FILE,
+            ZIPKIN_CONFIG_NAMESPACE,
+            staticconf.YamlConfiguration,
+            min_interval=ZIPKIN_CONFIG_MIN_RELOAD_INTERVAL,
+        )
+        self.firehose_socket = socket.socket(socket.AF_INET,  # Internet
+                                             socket.SOCK_DGRAM)  # UDP
+
+    def __bool__(self):
+        # For python 3
+        return self.is_enabled()
+
+    def __nonzero__(self):
+        # For python 2
+        return self.is_enabled()
+
+    def is_enabled(self):
+        self.config_watcher.reload_if_changed()
+        firehose_enabled = self.zipkin_namespace.read_bool(
+            'enable_firehose',
+            default=ZIPKIN_DEFAULT_FIREHOSE_ENABLED,
+        )
+        return firehose_enabled
+
+    def __call__(self, message):
+        try:
+            self.firehose_socket.sendto(
+                message,
+                (
+                    ZIPKIN_FIREHOSE_IP,
+                    ZIPKIN_FIREHOSE_PORT,
+                ),
+            )
+        except Exception as e:
+            clog.log_line(
+                'tmp_zipkin_error',
+                'yelp_pyramid FirehoseHandler error: {}'.format(repr(e))
+            )

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     install_requires=[
         'six',
         'thriftpy',
+        'yelp-clog>=0.1.7',
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tests/transport/firehose_handler_test.py
+++ b/tests/transport/firehose_handler_test.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+import sys
+
+import mock
+
+from py_zipkin.transport.firehose_handler import FirehoseHandler
+
+
+@mock.patch('py_zipkin.transport.firehose_handler.staticconf', autospec=True)
+def test_firehose_disabled(staticconf):
+    firehose_handler = FirehoseHandler()
+
+    firehose_handler.zipkin_namespace.read_bool.return_value = False
+
+    # by simply saying "not firehose_handler", we are calling __bool__
+    # or __nonzero__
+    assert not firehose_handler
+    firehose_handler.zipkin_namespace.read_bool.assert_called_once_with(
+        'enable_firehose',
+        default=False,
+    )
+
+
+@mock.patch('py_zipkin.transport.firehose_handler.staticconf', autospec=True)
+def test_firehose_enabled(staticconf):
+    firehose_handler = FirehoseHandler()
+
+    firehose_handler.zipkin_namespace.read_bool.return_value = True
+
+    assert firehose_handler
+    firehose_handler.zipkin_namespace.read_bool.assert_called_once_with(
+        'enable_firehose',
+        default=False,
+    )
+
+
+@mock.patch('py_zipkin.transport.firehose_handler.socket')
+@mock.patch('py_zipkin.transport.firehose_handler.staticconf', autospec=True)
+def test_firehose_send(staticconf, mocket):
+    firehose_handler = FirehoseHandler()
+
+    firehose_handler('sploosh')
+
+    sock = mocket.socket.return_value
+    sock.sendto.assert_called_once_with(
+        'sploosh',
+        (mock.ANY, mock.ANY),
+    )
+
+
+@mock.patch('py_zipkin.transport.firehose_handler.clog.log_line')
+@mock.patch('py_zipkin.transport.firehose_handler.staticconf', autospec=True)
+def test_firehose_send_with_huge_payload(staticconf, mock_clog):
+    firehose_handler = FirehoseHandler()
+
+    # this string is longer than the UDP max packet size, so python will
+    # refuse to send it and throw a OSError
+    firehose_handler(('a' * 100000).encode('ascii'))
+
+    if sys.version_info >= (3, 0):
+        err = "OSError(90, 'Message too long')"
+    else:
+        err = "error(90, 'Message too long')"
+
+    assert mock_clog.call_args == mock.call(
+        'tmp_zipkin_error',
+        'yelp_pyramid FirehoseHandler error: {}'.format(err)
+    )
+
+
+@mock.patch('py_zipkin.transport.firehose_handler.clog.log_line')
+@mock.patch('py_zipkin.transport.firehose_handler.staticconf', autospec=True)
+def test_cover_magic_methods(staticconf, mock_clog):
+    """This is simply a test to ensure 100% coverage of magic methods."""
+    firehose_handler = FirehoseHandler()
+
+    assert firehose_handler.__nonzero__() == firehose_handler.is_enabled()
+    assert firehose_handler.__bool__() == firehose_handler.is_enabled()


### PR DESCRIPTION
I moved `class FirehoseHandler`, along with the related constants and tests from `yelp_pyramid` to here, without further changes.

Test coverage is still 100% and `make test` passes. I only had to add `test_cover_magic_methods()` because py2/py3 call different magic methods (either `__nonzero__()` or `__bool__()`) and the coverage was never 100% otherwise.

I've also transformed the `mock.patch` context managers into decorators purely because otherwise the lines were too long (>83 characters). All seems good for now.

For now nothing was removed from `yelp_pyramid`, and the "old" class is still being used.