### PR TITLE
Remove the zipkin_logger interface.

### DIFF
--- a/py_zipkin/logging_helper.py
+++ b/py_zipkin/logging_helper.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-import logging
 import time
-from collections import defaultdict
 
 from py_zipkin.exception import ZipkinError
 from py_zipkin.thrift import annotation_list_builder
@@ -10,19 +8,7 @@ from py_zipkin.thrift import copy_endpoint_with_new_service_name
 from py_zipkin.thrift import create_span
 from py_zipkin.thrift import thrift_objs_in_bytes
 from py_zipkin.util import generate_random_64bit_string
-
-
-try:  # Python 2.7+
-    from logging import NullHandler
-except ImportError:  # pragma: no cover
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
-
-null_handler = NullHandler()
-zipkin_logger = logging.getLogger('py_zipkin.logger')
-zipkin_logger.addHandler(null_handler)
-zipkin_logger.setLevel(logging.DEBUG)
+from py_zipkin.util import get_local_span_timestamp_and_duration
 
 LOGGING_END_KEY = 'py_zipkin.logging_end'
 
@@ -40,10 +26,10 @@ class ZipkinLoggingContext(object):
         self,
         zipkin_attrs,
         thrift_endpoint,
-        log_handler,
         span_name,
         transport_handler,
         report_root_timestamp,
+        annotations=None,
         binary_annotations=None,
         add_logging_annotation=False,
         client_context=False,
@@ -52,12 +38,12 @@ class ZipkinLoggingContext(object):
     ):
         self.zipkin_attrs = zipkin_attrs
         self.thrift_endpoint = thrift_endpoint
-        self.log_handler = log_handler
         self.span_name = span_name
         self.transport_handler = transport_handler
         self.response_status_code = 0
         self.report_root_timestamp = report_root_timestamp
-        self.binary_annotations_dict = binary_annotations or {}
+        self.annotations = annotations or {}
+        self.binary_annotations = binary_annotations or {}
         self.sa_binary_annotations = []
         self.add_logging_annotation = add_logging_annotation
         self.client_context = client_context
@@ -65,23 +51,11 @@ class ZipkinLoggingContext(object):
         self.firehose_handler = firehose_handler
 
     def start(self):
-        """Actions to be taken before request is handled.
-        1) Attach `zipkin_logger` to :class:`ZipkinLoggerHandler` object.
-        2) Record the start timestamp.
-        """
-        zipkin_logger.removeHandler(null_handler)
-        zipkin_logger.addHandler(self.log_handler)
         self.start_timestamp = time.time()
         return self
 
     def stop(self):
-        """Actions to be taken post request handling.
-        1) Log the service annotations to scribe.
-        2) Detach `zipkin_logger` handler.
-        """
         self.log_spans()
-        zipkin_logger.removeHandler(self.log_handler)
-        zipkin_logger.addHandler(null_handler)
 
     def log_spans(self):
         """Main function to log all the annotations stored during the entire
@@ -109,19 +83,9 @@ class ZipkinLoggingContext(object):
     def _log_spans_with_span_sender(self, span_sender):
         with span_sender:
             end_timestamp = time.time()
-            # Collect additional annotations from the logging handler
-            annotations_by_span_id = defaultdict(dict)
-            binary_annotations_by_span_id = defaultdict(dict)
-            for msg in self.log_handler.extra_annotations:
-                span_id = msg['parent_span_id'] or self.zipkin_attrs.span_id
-                # This should check if these are non-None
-                annotations_by_span_id[span_id].update(msg['annotations'])
-                binary_annotations_by_span_id[span_id].update(
-                    msg['binary_annotations']
-                )
 
             # Collect, annotate, and log client spans from the logging handler
-            for span in self.log_handler.client_spans:
+            for span in self.zipkin_attrs.client_spans:
                 # The parent_span_id is either the parent ID set in the
                 # logging handler or the current Zipkin context's span ID.
                 parent_span_id = (
@@ -136,11 +100,7 @@ class ZipkinLoggingContext(object):
                 # Collect annotations both logged with the new spans and
                 # logged in separate log messages.
                 annotations = span['annotations']
-                annotations.update(annotations_by_span_id[span_id])
                 binary_annotations = span['binary_annotations']
-                binary_annotations.update(
-                    binary_annotations_by_span_id[span_id])
-
                 timestamp, duration = get_local_span_timestamp_and_duration(
                     annotations
                 )
@@ -165,31 +125,25 @@ class ZipkinLoggingContext(object):
                     duration_s=duration,
                 )
 
-            extra_annotations = annotations_by_span_id[
-                self.zipkin_attrs.span_id]
-            extra_binary_annotations = binary_annotations_by_span_id[
-                self.zipkin_attrs.span_id
-            ]
-
-            k1, k2 = ('sr', 'ss')
             if self.client_context:
                 k1, k2 = ('cs', 'cr')
-            annotations = {k1: self.start_timestamp, k2: end_timestamp}
-            annotations.update(extra_annotations)
+            else:
+                k1, k2 = ('sr', 'ss')
+
+            self.annotations.update({k1: self.start_timestamp, k2: end_timestamp})
 
             if self.add_logging_annotation:
-                annotations[LOGGING_END_KEY] = time.time()
+                self.annotations[LOGGING_END_KEY] = time.time()
 
             thrift_annotations = annotation_list_builder(
-                annotations,
+                self.annotations,
                 self.thrift_endpoint,
             )
 
             # Binary annotations can be set through debug messages or the
             # set_extra_binary_annotations registry setting.
-            self.binary_annotations_dict.update(extra_binary_annotations)
             thrift_binary_annotations = binary_annotation_list_builder(
-                self.binary_annotations_dict,
+                self.binary_annotations,
                 self.thrift_endpoint,
             )
             if self.sa_binary_annotations:
@@ -211,117 +165,6 @@ class ZipkinLoggingContext(object):
                 timestamp_s=timestamp,
                 duration_s=duration,
             )
-
-
-def get_local_span_timestamp_and_duration(annotations):
-    if 'cs' in annotations and 'cr' in annotations:
-        return annotations['cs'], annotations['cr'] - annotations['cs']
-    elif 'sr' in annotations and 'ss' in annotations:
-        return annotations['sr'], annotations['ss'] - annotations['sr']
-    return None, None
-
-
-class ZipkinLoggerHandler(logging.StreamHandler, object):
-    """Logger Handler to log span annotations or additional client spans to
-    scribe. To connect to the handler, logger name must be
-    'py_zipkin.logger'.
-
-    :param zipkin_attrs: ZipkinAttrs namedtuple object
-    """
-
-    def __init__(self, zipkin_attrs):
-        super(ZipkinLoggerHandler, self).__init__()
-        # If parent_span_id is set, the application is in a logging context
-        # where each additional client span logged has this span as its parent.
-        # This is to allow logging of hierarchies of spans instead of just
-        # single client spans. See the SpanContext class.
-        self.parent_span_id = None
-        self.zipkin_attrs = zipkin_attrs
-        self.client_spans = []
-        self.extra_annotations = []
-
-    def store_local_span(
-        self,
-        span_name,
-        service_name,
-        annotations,
-        binary_annotations,
-        sa_binary_annotations=None,
-        span_id=None,
-    ):
-        """Convenience method for storing a local child span (a zipkin_span
-        inside other zipkin_spans) to be logged when the outermost zipkin_span
-        exits.
-        """
-        self.client_spans.append({
-            'span_name': span_name,
-            'service_name': service_name,
-            'parent_span_id': self.parent_span_id,
-            'span_id': span_id,
-            'annotations': annotations,
-            'binary_annotations': binary_annotations,
-            'sa_binary_annotations': sa_binary_annotations,
-        })
-
-    def emit(self, record):
-        """Handle each record message. This function is called whenever
-        zipkin_logger.debug() is called.
-
-        :param record: object containing the `msg` object.
-            Structure of record.msg should be the following:
-            ::
-
-            {
-                "annotations": {
-                    "cs": ts1,
-                    "cr": ts2,
-                },
-                "binary_annotations": {
-                    "http.uri": "/foo/bar",
-                },
-                "name": "foo_span",
-                "service_name": "myService",
-            }
-
-            Keys:
-            - annotations: str -> timestamp annotations
-            - binary_annotations: str -> str binary annotations
-              (One of either annotations or binary_annotations is required)
-            - name: str of new span name; only used if service-name is also
-              specified.
-            - service_name: str of new client span's service name.
-
-            If service_name is specified, this log msg is considered to
-            represent a new client span. If service_name is omitted, this is
-            considered additional annotation for the currently active
-            "parent span" (either the server span or the parent client span
-            inside a SpanContext).
-        """
-        if not self.zipkin_attrs.is_sampled:
-            return
-        span_name = record.msg.get('name', 'span')
-        annotations = record.msg.get('annotations', {})
-        binary_annotations = record.msg.get('binary_annotations', {})
-        if not annotations and not binary_annotations:
-            raise ZipkinError(
-                "At least one of annotation/binary annotation has"
-                " to be provided for {0} span".format(span_name)
-            )
-        service_name = record.msg.get('service_name', None)
-        # Presence of service_name means this is to be a new local span.
-        if service_name is not None:
-            self.store_local_span(
-                span_name=span_name,
-                service_name=service_name,
-                annotations=annotations,
-                binary_annotations=binary_annotations,
-            )
-        else:
-            self.extra_annotations.append({
-                'annotations': annotations,
-                'binary_annotations': binary_annotations,
-                'parent_span_id': self.parent_span_id,
-            })
 
 
 class ZipkinBatchSender(object):

--- a/py_zipkin/util.py
+++ b/py_zipkin/util.py
@@ -58,3 +58,17 @@ def signed_int_to_unsigned_hex(signed_int):
     if hex_string.endswith('L'):
         return hex_string[:-1]
     return hex_string
+
+
+def get_local_span_timestamp_and_duration(annotations):
+    """Returns the timestamp and duration provided a set of client or
+    server annotations.
+
+    :param annotations: a list of annotations
+    :returns: timestamp, duration (as integers)
+    """
+    if 'cs' in annotations and 'cr' in annotations:
+        return annotations['cs'], annotations['cr'] - annotations['cs']
+    elif 'sr' in annotations and 'ss' in annotations:
+        return annotations['sr'], annotations['ss'] - annotations['sr']
+    return None, None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ def zipkin_attributes():
         'span_id': '27133d482ba4f605',
         'parent_span_id': '37133d482ba4f605',
         'flags': '45',
+        'client_spans': [],
     }
 
 

--- a/tests/integration/zipkin_integration_test.py
+++ b/tests/integration/zipkin_integration_test.py
@@ -5,7 +5,6 @@ from thriftpy.transport import TMemoryBuffer
 
 from py_zipkin import zipkin
 from py_zipkin.logging_helper import LOGGING_END_KEY
-from py_zipkin.logging_helper import zipkin_logger
 from py_zipkin.thrift import zipkin_core
 from py_zipkin.zipkin import ZipkinAttrs
 
@@ -161,6 +160,7 @@ def test_service_span(default_annotations):
         parent_span_id='2',
         flags='0',
         is_sampled=True,
+        client_spans=[],
     )
     with zipkin.zipkin_span(
         service_name='test_service_name',
@@ -194,6 +194,7 @@ def test_service_span_report_timestamp_override(
         parent_span_id='2',
         flags='0',
         is_sampled=True,
+        client_spans=[],
     )
     with zipkin.zipkin_span(
         service_name='test_service_name',
@@ -223,6 +224,7 @@ def test_service_span_that_is_independently_sampled(
         parent_span_id='2',
         flags='0',
         is_sampled=False,
+        client_spans=[],
     )
     with zipkin.zipkin_span(
         service_name='test_service_name',
@@ -249,93 +251,6 @@ def test_service_span_that_is_independently_sampled(
         assert span.duration is not None
         assert set([ann.value for ann in span.annotations]) == default_annotations
 
-    check_span(_decode_binary_thrift_obj(mock_logs[0]))
-    check_span(_decode_binary_thrift_obj(mock_firehose_logs[0]))
-
-
-def test_log_debug_for_new_span():
-    mock_transport_handler, mock_logs = mock_logger()
-    mock_firehose_handler, mock_firehose_logs = mock_logger()
-    with zipkin.zipkin_span(
-        service_name='test_service_name',
-        span_name='test_span_name',
-        transport_handler=mock_transport_handler,
-        sample_rate=100.0,
-        binary_annotations={'some_key': 'some_value'},
-        add_logging_annotation=True,
-        firehose_handler=mock_firehose_handler,
-    ):
-        zipkin_logger.debug({
-            'annotations': {
-                'cs': 7,
-                'cr': 8,
-            },
-            'binary_annotations': {
-                'logged_binary_annotation': 'logged_value',
-            },
-            'name': 'logged_name',
-            'service_name': 'logged_service_name',
-        })
-        pass
-
-    def check_spans(spans):
-        logged_span = spans[0]
-        root_span = spans[1]
-        assert logged_span.name == 'logged_name'
-        assert logged_span.annotations[0] \
-                          .host.service_name == 'logged_service_name'
-        assert logged_span.parent_id == root_span.id
-        assert logged_span.binary_annotations[0].key == 'logged_binary_annotation'
-        assert logged_span.binary_annotations[0].value == 'logged_value'
-        assert set(
-            [ann.value for ann in logged_span.annotations]
-        ) == set(['cs', 'cr'])
-
-    check_spans(_decode_binary_thrift_objs(mock_logs[0]))
-    check_spans(_decode_binary_thrift_objs(mock_firehose_logs[0]))
-
-
-def test_log_debug_for_existing_span(default_annotations):
-    mock_transport_handler, mock_logs = mock_logger()
-    mock_firehose_handler, mock_firehose_logs = mock_logger()
-    with zipkin.zipkin_span(
-        service_name='test_service_name',
-        span_name='test_span_name',
-        transport_handler=mock_transport_handler,
-        sample_rate=100.0,
-        binary_annotations={'some_key': 'some_value'},
-        add_logging_annotation=True,
-        firehose_handler=mock_firehose_handler,
-    ):
-        zipkin_logger.debug({
-            'annotations': {
-                'test_annotation': 42,
-            },
-            'binary_annotations': {
-                'extra_binary_annotation': 'extra_value',
-            }
-        })
-        pass
-
-    def check_span(span):
-        assert span.name == 'test_span_name'
-        assert span.annotations[0].host.service_name == 'test_service_name'
-        assert span.parent_id is None
-        assert len(span.annotations) == 4
-        annotations = sorted(span.annotations, key=lambda ann: ann.value)
-        assert annotations[3].value == 'test_annotation'
-        assert annotations[3].timestamp == 42000000
-        default_annotations.add('test_annotation')
-        assert set([ann.value for ann in annotations]) == default_annotations
-        assert len(span.binary_annotations) == 2
-        binary_annotations = sorted(
-            span.binary_annotations, key=lambda bin_ann: bin_ann.key)
-        assert binary_annotations[0].key == 'extra_binary_annotation'
-        assert binary_annotations[0].value == 'extra_value'
-        assert binary_annotations[1].key == 'some_key'
-        assert binary_annotations[1].value == 'some_value'
-
-    assert len(mock_logs) == 1
     check_span(_decode_binary_thrift_obj(mock_logs[0]))
     check_span(_decode_binary_thrift_obj(mock_firehose_logs[0]))
 

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -3,9 +3,6 @@ import pytest
 
 import py_zipkin.zipkin as zipkin
 from py_zipkin.exception import ZipkinError
-from py_zipkin.logging_helper import null_handler
-from py_zipkin.logging_helper import ZipkinLoggerHandler
-from py_zipkin.stack import ThreadLocalStack
 from py_zipkin.thread_local import get_zipkin_attrs
 from py_zipkin.thrift import create_binary_annotation
 from py_zipkin.thrift import create_endpoint
@@ -25,11 +22,9 @@ def mock_context_stack():
 
 @mock.patch('py_zipkin.zipkin.create_attrs_for_span', autospec=True)
 @mock.patch('py_zipkin.zipkin.create_endpoint')
-@mock.patch('py_zipkin.zipkin.ZipkinLoggerHandler', autospec=True)
 @mock.patch('py_zipkin.zipkin.ZipkinLoggingContext', autospec=True)
 def test_zipkin_span_for_new_trace(
     logging_context_cls_mock,
-    logger_handler_cls_mock,
     create_endpoint_mock,
     create_attrs_for_span_mock,
     mock_context_stack,
@@ -55,16 +50,14 @@ def test_zipkin_span_for_new_trace(
         create_attrs_for_span_mock.return_value,
     )
     create_endpoint_mock.assert_called_once_with(5, 'some_service_name', None)
-    logger_handler_cls_mock.assert_called_once_with(
-        create_attrs_for_span_mock.return_value)
     logging_context_cls_mock.assert_called_once_with(
         create_attrs_for_span_mock.return_value,
         create_endpoint_mock.return_value,
-        logger_handler_cls_mock.return_value,
         'span_name',
         transport_handler,
         report_root_timestamp=True,
         binary_annotations={},
+        annotations={},
         add_logging_annotation=False,
         client_context=False,
         max_span_batch_size=None,
@@ -75,11 +68,9 @@ def test_zipkin_span_for_new_trace(
 
 @mock.patch('py_zipkin.zipkin.create_attrs_for_span', autospec=True)
 @mock.patch('py_zipkin.zipkin.create_endpoint')
-@mock.patch('py_zipkin.zipkin.ZipkinLoggerHandler', autospec=True)
 @mock.patch('py_zipkin.zipkin.ZipkinLoggingContext', autospec=True)
 def test_zipkin_span_passed_sampled_attrs(
     logging_context_cls_mock,
-    logger_handler_cls_mock,
     create_endpoint_mock,
     create_attrs_for_span_mock,
     mock_context_stack,
@@ -93,6 +84,7 @@ def test_zipkin_span_passed_sampled_attrs(
         parent_span_id=None,
         flags='0',
         is_sampled=True,
+        client_spans=[],
     )
     with zipkin.zipkin_span(
         service_name='some_service_name',
@@ -107,17 +99,16 @@ def test_zipkin_span_passed_sampled_attrs(
     assert not create_attrs_for_span_mock.called
     mock_context_stack.push.assert_called_once_with(zipkin_attrs)
     create_endpoint_mock.assert_called_once_with(5, 'some_service_name', None)
-    logger_handler_cls_mock.assert_called_once_with(zipkin_attrs)
     # Logging context should not report timestamp/duration for the server span,
     # since it's assumed that the client part of this span will do that.
     logging_context_cls_mock.assert_called_once_with(
         zipkin_attrs,
         create_endpoint_mock.return_value,
-        logger_handler_cls_mock.return_value,
         'span_name',
         transport_handler,
         report_root_timestamp=False,
         binary_annotations={},
+        annotations={},
         add_logging_annotation=False,
         client_context=False,
         max_span_batch_size=None,
@@ -129,11 +120,9 @@ def test_zipkin_span_passed_sampled_attrs(
 @pytest.mark.parametrize('firehose_enabled', [True, False])
 @mock.patch('py_zipkin.zipkin.create_attrs_for_span', autospec=True)
 @mock.patch('py_zipkin.zipkin.create_endpoint')
-@mock.patch('py_zipkin.zipkin.ZipkinLoggerHandler', autospec=True)
 @mock.patch('py_zipkin.zipkin.ZipkinLoggingContext', autospec=True)
 def test_zipkin_span_trace_with_0_sample_rate(
     logging_context_cls_mock,
-    logger_handler_cls_mock,
     create_endpoint_mock,
     create_attrs_for_span_mock,
     mock_context_stack,
@@ -145,6 +134,7 @@ def test_zipkin_span_trace_with_0_sample_rate(
         parent_span_id=None,
         flags='0',
         is_sampled=False,
+        client_spans=[],
     )
     transport_handler = mock.Mock()
     with zipkin.zipkin_span(
@@ -166,7 +156,6 @@ def test_zipkin_span_trace_with_0_sample_rate(
 
     # When firehose mode is on, we log regardless of sample rate
     assert create_endpoint_mock.call_count == (1 if firehose_enabled else 0)
-    assert logger_handler_cls_mock.call_count == (1 if firehose_enabled else 0)
     assert logging_context_cls_mock.call_count == (1 if firehose_enabled else 0)
     mock_context_stack.pop.assert_called_once_with()
 
@@ -234,11 +223,9 @@ def test_zipkin_extraneous_include_raises(mock_zipkin_span, span_func):
 
 @mock.patch('py_zipkin.zipkin.create_attrs_for_span', autospec=True)
 @mock.patch('py_zipkin.zipkin.create_endpoint')
-@mock.patch('py_zipkin.zipkin.ZipkinLoggerHandler', autospec=True)
 @mock.patch('py_zipkin.zipkin.ZipkinLoggingContext', autospec=True)
 def test_zipkin_span_trace_with_no_sampling(
     logging_context_cls_mock,
-    logger_handler_cls_mock,
     create_endpoint_mock,
     create_attrs_for_span_mock,
     mock_context_stack,
@@ -249,6 +236,7 @@ def test_zipkin_span_trace_with_no_sampling(
         parent_span_id=None,
         flags='0',
         is_sampled=False,
+        client_spans=[],
     )
     with zipkin.zipkin_span(
         service_name='my_service',
@@ -264,7 +252,6 @@ def test_zipkin_span_trace_with_no_sampling(
         zipkin_attrs,
     )
     assert create_endpoint_mock.call_count == 0
-    assert logger_handler_cls_mock.call_count == 0
     assert logging_context_cls_mock.call_count == 0
     mock_context_stack.pop.assert_called_once_with()
 
@@ -283,11 +270,9 @@ def test_zipkin_span_with_zipkin_attrs_required_params():
 
 @mock.patch('py_zipkin.zipkin.create_attrs_for_span', autospec=True)
 @mock.patch('py_zipkin.zipkin.create_endpoint')
-@mock.patch('py_zipkin.zipkin.ZipkinLoggerHandler', autospec=True)
 @mock.patch('py_zipkin.zipkin.ZipkinLoggingContext', autospec=True)
 def test_zipkin_trace_context_attrs_is_always_popped(
     logging_context_cls_mock,
-    logger_handler_cls_mock,
     create_endpoint_mock,
     create_attrs_for_span_mock,
     mock_context_stack,
@@ -343,43 +328,6 @@ def test_span_context_no_zipkin_attrs(mock_context_stack):
     assert not mock_context_stack.push.called
 
 
-@pytest.mark.parametrize('handlers', [[], [null_handler]])
-@mock.patch('py_zipkin.thread_local._thread_local', autospec=True)
-@mock.patch('py_zipkin.zipkin.generate_random_64bit_string', autospec=True)
-@mock.patch('py_zipkin.zipkin.zipkin_logger', autospec=True)
-def test_span_context_sampled_no_handlers(
-    zipkin_logger_mock,
-    generate_string_mock,
-    thread_local_mock,
-    handlers,
-):
-    zipkin_attrs = ZipkinAttrs(
-        trace_id='1111111111111111',
-        span_id='2222222222222222',
-        parent_span_id='3333333333333333',
-        flags='flags',
-        is_sampled=True,
-    )
-    thread_local_mock.zipkin_attrs = [zipkin_attrs]
-
-    zipkin_logger_mock.handlers = handlers
-    generate_string_mock.return_value = '1'
-
-    context = zipkin.zipkin_span(
-        service_name='my_service',
-        port=5,
-        transport_handler=mock.Mock(),
-        sample_rate=None,
-    )
-    with context:
-        # Assert that the new ZipkinAttrs were saved
-        new_zipkin_attrs = ThreadLocalStack().get()
-        assert new_zipkin_attrs.span_id == '1'
-
-    # Outside of the context, things should be returned to normal
-    assert ThreadLocalStack().get() == zipkin_attrs
-
-
 @pytest.mark.parametrize('span_func, expected_annotations', [
     (zipkin.zipkin_span, ('cs', 'cr', 'ss', 'sr')),
     (zipkin.zipkin_client_span, ('cs', 'cr')),
@@ -388,9 +336,7 @@ def test_span_context_sampled_no_handlers(
 @mock.patch('py_zipkin.thread_local._thread_local', autospec=True)
 @mock.patch('py_zipkin.zipkin.generate_random_64bit_string', autospec=True)
 @mock.patch('py_zipkin.zipkin.generate_random_128bit_string', autospec=True)
-@mock.patch('py_zipkin.zipkin.zipkin_logger', autospec=True)
 def test_span_context(
-    zipkin_logger_mock,
     generate_string_128bit_mock,
     generate_string_mock,
     thread_local_mock,
@@ -403,13 +349,9 @@ def test_span_context(
         parent_span_id='3333333333333333',
         flags='flags',
         is_sampled=True,
+        client_spans=[],
     )
     thread_local_mock.zipkin_attrs = [zipkin_attrs]
-    logging_handler = ZipkinLoggerHandler(zipkin_attrs)
-    assert logging_handler.parent_span_id is None
-    assert logging_handler.client_spans == []
-
-    zipkin_logger_mock.handlers = [logging_handler]
     generate_string_mock.return_value = '1'
 
     context = span_func(
@@ -421,23 +363,27 @@ def test_span_context(
     with context:
         # Assert that the new ZipkinAttrs were saved
         new_zipkin_attrs = get_zipkin_attrs()
-        assert new_zipkin_attrs.span_id == '1'
-        # And that the logging handler has a parent_span_id
-        assert logging_handler.parent_span_id == '1'
+        assert new_zipkin_attrs == ZipkinAttrs(
+            trace_id='1111111111111111',
+            span_id='1',
+            parent_span_id='2222222222222222',
+            flags='flags',
+            is_sampled=True,
+            client_spans=[],
+        )
 
     # Outside of the context, things should be returned to normal,
     # except a new client span is saved in the handler
-    assert logging_handler.parent_span_id is None
     assert get_zipkin_attrs() == zipkin_attrs
 
-    client_span = logging_handler.client_spans.pop()
-    assert logging_handler.client_spans == []
+    client_span = zipkin_attrs.client_spans.pop()
+    assert zipkin_attrs.client_spans == []
     # These reserved annotations are based on timestamps so pop em.
     # This also acts as a check that they exist.
     for annotation in expected_annotations:
         client_span['annotations'].pop(annotation)
 
-    expected_client_span = {
+    assert client_span == {
         'span_name': 'span',
         'service_name': 'svc',
         'parent_span_id': None,
@@ -446,18 +392,14 @@ def test_span_context(
         'binary_annotations': {'foo': 'bar'},
         'sa_binary_annotations': [],
     }
-    assert client_span == expected_client_span
-
     assert generate_string_128bit_mock.call_count == 0
 
 
 @mock.patch('py_zipkin.zipkin.create_attrs_for_span', autospec=True)
 @mock.patch('py_zipkin.zipkin.create_endpoint')
-@mock.patch('py_zipkin.zipkin.ZipkinLoggerHandler', autospec=True)
 @mock.patch('py_zipkin.zipkin.ZipkinLoggingContext', autospec=True)
 def test_zipkin_server_span_decorator(
     logging_context_cls_mock,
-    logger_handler_cls_mock,
     create_endpoint_mock,
     create_attrs_for_span_mock,
     mock_context_stack,
@@ -486,19 +428,16 @@ def test_zipkin_server_span_decorator(
         create_attrs_for_span_mock.return_value,
     )
     create_endpoint_mock.assert_called_once_with(5, 'some_service_name', '1.5.1.2')
-    logger_handler_cls_mock.assert_called_once_with(
-        create_attrs_for_span_mock.return_value,
-    )
     # The decorator was passed a sample rate and no Zipkin attrs, so it's
     # assumed to be the root of a trace and it should report timestamp/duration
     logging_context_cls_mock.assert_called_once_with(
         create_attrs_for_span_mock.return_value,
         create_endpoint_mock.return_value,
-        logger_handler_cls_mock.return_value,
         'span_name',
         transport_handler,
         report_root_timestamp=True,
         binary_annotations={},
+        annotations={},
         add_logging_annotation=False,
         client_context=False,
         max_span_batch_size=None,
@@ -509,11 +448,9 @@ def test_zipkin_server_span_decorator(
 
 @mock.patch('py_zipkin.zipkin.create_attrs_for_span', autospec=True)
 @mock.patch('py_zipkin.zipkin.create_endpoint')
-@mock.patch('py_zipkin.zipkin.ZipkinLoggerHandler', autospec=True)
 @mock.patch('py_zipkin.zipkin.ZipkinLoggingContext', autospec=True)
 def test_zipkin_client_span_decorator(
     logging_context_cls_mock,
-    logger_handler_cls_mock,
     create_endpoint_mock,
     create_attrs_for_span_mock,
     mock_context_stack,
@@ -543,18 +480,16 @@ def test_zipkin_client_span_decorator(
         create_attrs_for_span_mock.return_value,
     )
     create_endpoint_mock.assert_called_once_with(5, 'some_service_name', '1.5.1.2')
-    logger_handler_cls_mock.assert_called_once_with(
-        create_attrs_for_span_mock.return_value)
     # The decorator was passed a sample rate and no Zipkin attrs, so it's
     # assumed to be the root of a trace and it should report timestamp/duration
     logging_context_cls_mock.assert_called_once_with(
         create_attrs_for_span_mock.return_value,
         create_endpoint_mock.return_value,
-        logger_handler_cls_mock.return_value,
         'span_name',
         transport_handler,
         report_root_timestamp=True,
         binary_annotations={},
+        annotations={},
         add_logging_annotation=False,
         client_context=True,
         max_span_batch_size=None,
@@ -602,6 +537,7 @@ def test_update_binary_annotations():
         parent_span_id=None,
         flags='0',
         is_sampled=True,
+        client_spans=[],
     )
     context = zipkin.zipkin_span(
         service_name='my_service',
@@ -612,9 +548,9 @@ def test_update_binary_annotations():
     )
 
     with context:
-        assert 'test' not in context.logging_context.binary_annotations_dict
+        assert 'test' not in context.logging_context.binary_annotations
         context.update_binary_annotations({'test': 'hi'})
-        assert context.logging_context.binary_annotations_dict['test'] == 'hi'
+        assert context.logging_context.binary_annotations['test'] == 'hi'
 
         nested_context = zipkin.zipkin_span(
             service_name='my_service',
@@ -622,10 +558,10 @@ def test_update_binary_annotations():
             binary_annotations={'one': 'one'},
         )
         with nested_context:
-            assert 'one' not in context.logging_context.binary_annotations_dict
+            assert 'one' not in context.logging_context.binary_annotations
             nested_context.update_binary_annotations({'two': 'two'})
             assert 'two' in nested_context.binary_annotations
-            assert 'two' not in context.logging_context.binary_annotations_dict
+            assert 'two' not in context.logging_context.binary_annotations
 
 
 def test_update_binary_annotations_should_not_error_if_not_tracing():
@@ -635,6 +571,7 @@ def test_update_binary_annotations_should_not_error_if_not_tracing():
         parent_span_id=None,
         flags='0',
         is_sampled=False,
+        client_spans=[],
     )
     context = zipkin.zipkin_span(
         service_name='my_service',
@@ -667,6 +604,7 @@ def test_add_sa_binary_annotation():
         parent_span_id=None,
         flags='0',
         is_sampled=True,
+        client_spans=[],
     )
     context = zipkin.zipkin_span(
         service_name='my_service',
@@ -762,6 +700,7 @@ def test_adding_error_annotation_on_exception(mock_update_binary_annotations):
         parent_span_id=None,
         flags='0',
         is_sampled=True,
+        client_spans=[],
     )
     context = zipkin.zipkin_span(
         service_name='my_service',
@@ -789,6 +728,7 @@ def test_create_attrs_for_span(random_64bit_mock, random_128bit_mock):
         parent_span_id=None,
         flags='0',
         is_sampled=True,
+        client_spans=[],
     )
     assert expected_attrs == zipkin.create_attrs_for_span()
 
@@ -799,6 +739,7 @@ def test_create_attrs_for_span(random_64bit_mock, random_128bit_mock):
         parent_span_id=None,
         flags='0',
         is_sampled=False,
+        client_spans=[],
     )
     assert expected_attrs == zipkin.create_attrs_for_span(
         sample_rate=0.0,
@@ -813,6 +754,7 @@ def test_create_attrs_for_span(random_64bit_mock, random_128bit_mock):
         parent_span_id=None,
         flags='0',
         is_sampled=True,
+        client_spans=[],
     )
     assert expected_attrs == zipkin.create_attrs_for_span(
         use_128bit_trace_id=True,


### PR DESCRIPTION
This is the first installment for a minor py_zipkin refactor. This branch removes the logging interface and uses zipkin_attributes to store client spans in nested contexts.

**Testing Done**
- All tests pass (excluding logging-related tests that were removed)
- Still at 100% test coverage

Also resolves #61 