### PR TITLE
Fix error tracing when the exception message contains unicode

### DIFF
--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -371,7 +371,7 @@ class zipkin_span(object):
 
         # Add the error annotation if an exception occurred
         if any((_exc_type, _exc_value, _exc_traceback)):
-            error_msg = '{0}: {1}'.format(_exc_type.__name__, _exc_value)
+            error_msg = u'{0}: {1}'.format(_exc_type.__name__, _exc_value)
             self.update_binary_annotations({
                 zipkin_core.ERROR: error_msg,
             })

--- a/tests/thrift/thrift_test.py
+++ b/tests/thrift/thrift_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import mock
 import pytest
 import socket
@@ -146,10 +147,14 @@ def test_annotation_list_builder(ann_mock):
     assert ann_mock.call_count == 2
 
 
-def test_create_binary_annotation():
+@pytest.mark.parametrize(
+    'value',
+    [(b'binary', u'unicøde')],
+)
+def test_create_binary_annotation(value):
     bann = thrift.create_binary_annotation(
-        'foo', 'bar', 'baz', 'bla')
-    assert ('foo', 'bar', 'baz', 'bla') == (
+        'foo', value, 'baz', 'bla')
+    assert ('foo', value, 'baz', 'bla') == (
         bann.key, bann.value, bann.annotation_type, bann.host)
 
 

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -763,7 +763,11 @@ def test_adding_sa_binary_annotation_for_non_client_spans():
 )
 @mock.patch(
     'py_zipkin.zipkin.zipkin_span.update_binary_annotations', autospec=True)
-def test_adding_error_annotation_on_exception(mock_update_binary_annotations, exception_message, expected_error_string):
+def test_adding_error_annotation_on_exception(
+    mock_update_binary_annotations,
+    exception_message,
+    expected_error_string,
+):
     zipkin_attrs = ZipkinAttrs(
         trace_id='0',
         span_id='1',


### PR DESCRIPTION
I've noticed py_zipkin crashing with an UnicodeEncodeError' in the `stop` method in py_zipkin/zipkin.py if the exception message contains Unicode. This change fixes it, but causes `update_binary_annotations` to be called with an unicode object instead of a str object on Python 2 (it's a noop on Python 3). I'm not sure if that could be a problem - thoughts?