### PR TITLE
Support JSON encoding for V1 Spans

### DIFF
--- a/py_zipkin/__init__.py
+++ b/py_zipkin/__init__.py
@@ -1,0 +1,3 @@
+from py_zipkin._encoding_helpers import Encoding
+
+_ = Encoding

--- a/py_zipkin/_encoding_helpers.py
+++ b/py_zipkin/_encoding_helpers.py
@@ -1,10 +1,19 @@
+import json
 import socket
 from collections import namedtuple
+from enum import Enum
+
+from py_zipkin import thrift
 
 Endpoint = namedtuple(
     'Endpoint',
     ['service_name', 'ipv4', 'ipv6', 'port'],
 )
+
+
+class Encoding(Enum):
+    THRIFT = 1
+    JSON = 2
 
 
 def create_endpoint(port=0, service_name='unknown', host=None):
@@ -64,3 +73,203 @@ def copy_endpoint_with_new_service_name(endpoint, new_service_name):
         ipv6=endpoint.ipv6,
         port=endpoint.port,
     )
+
+
+def get_encoder(encoding):
+    """Creates encoder object for the given encoding.
+
+    :param encoding: desired output encoding protocol.
+    :type encoding: Encoding
+    """
+    if encoding == Encoding.THRIFT:
+        return _V1ThriftEncoder()
+    elif encoding == Encoding.JSON:
+        return _V1JSONEncoder()
+    else:
+        raise ValueError('Unknown encoding')
+
+
+class IEncoder(object):
+    """Encoder interface."""
+
+    def fits(self, queue, current_size, max_size, new_span):
+        """Returns the overhead in bytes of a list.
+
+        The overhead is measured as the difference between
+        the sum of the size in bytes of all objects and the
+        size of their list concatenation.
+
+        i.e. In JSON is 2 since
+
+        :param queue: queue
+        :type queue: list
+        :returns: (int) overhead in bytes of a list object.
+        """
+        raise NotImplementedError()
+
+    def encode_span(self, *argv):
+        raise NotImplementedError()
+
+    def encode_queue(self, queue):
+        raise NotImplementedError()
+
+
+class _V1ThriftEncoder(IEncoder):
+    """Thrift encoder for V1 spans."""
+
+    def fits(self, queue, current_size, max_size, new_span):
+        return thrift.LIST_HEADER_SIZE + current_size + len(new_span) <= max_size
+
+    def encode_span(
+        self,
+        span_id,
+        parent_span_id,
+        trace_id,
+        span_name,
+        annotations,
+        binary_annotations,
+        timestamp_s,
+        duration_s,
+        endpoint,
+        sa_endpoint,
+    ):
+        thrift_endpoint = thrift.create_endpoint(
+            endpoint.port,
+            endpoint.service_name,
+            endpoint.ipv4,
+            endpoint.ipv6,
+        )
+
+        thrift_annotations = thrift.annotation_list_builder(
+            annotations,
+            thrift_endpoint,
+        )
+
+        # Binary annotations can be set through debug messages or the
+        # set_extra_binary_annotations registry setting.
+        thrift_binary_annotations = thrift.binary_annotation_list_builder(
+            binary_annotations,
+            thrift_endpoint,
+        )
+
+        # Add sa binary annotation
+        if sa_endpoint is not None:
+            thrift_sa_endpoint = thrift.create_endpoint(
+                sa_endpoint.port,
+                sa_endpoint.service_name,
+                sa_endpoint.ipv4,
+                sa_endpoint.ipv6,
+            )
+            thrift_binary_annotations.append(thrift.create_binary_annotation(
+                key=thrift.zipkin_core.SERVER_ADDR,
+                value=thrift.SERVER_ADDR_VAL,
+                annotation_type=thrift.zipkin_core.AnnotationType.BOOL,
+                host=thrift_sa_endpoint,
+            ))
+
+        thrift_span = thrift.create_span(
+            span_id,
+            parent_span_id,
+            trace_id,
+            span_name,
+            thrift_annotations,
+            thrift_binary_annotations,
+            timestamp_s,
+            duration_s,
+        )
+
+        encoded_span = thrift.span_to_bytes(thrift_span)
+
+        return encoded_span, len(encoded_span)
+
+    def encode_queue(self, queue):
+        return thrift.encode_bytes_list(queue)
+
+
+class _V1JSONEncoder(IEncoder):
+    """JSON encoder for V1 spans."""
+
+    def fits(self, queue, current_size, max_size, new_span):
+        # Json lists only have a 2 bytes overhead from '[]' plus 2 bytes from
+        # ', ' between elements
+        return 2 + (len(queue) - 1) * 2 + current_size + len(new_span) <= max_size
+
+    def _create_v1_endpoint(self, endpoint):
+        """Converts an Endpoint to a v1 endpoint dict.
+
+        :param endpoint: endpoint object to convert.
+        :type endpoint: Endpoint
+        :returns: dict representing a V1 endpoint.
+        """
+        v1_endpoint = {
+            'serviceName': endpoint.service_name,
+            'port': endpoint.port,
+        }
+        if endpoint.ipv4 is not None:
+            v1_endpoint['ipv4'] = endpoint.ipv4
+        if endpoint.ipv6 is not None:
+            v1_endpoint['ipv6'] = endpoint.ipv6
+
+        return v1_endpoint
+
+    def encode_span(
+        self,
+        span_id,
+        parent_span_id,
+        trace_id,
+        span_name,
+        annotations,
+        binary_annotations,
+        timestamp_s,
+        duration_s,
+        endpoint,
+        sa_endpoint,
+    ):
+
+        span = {
+            'traceId': trace_id,
+            'name': span_name,
+            'id': span_id,
+            'debug': False,
+            'annotations': [],
+            'binaryAnnotations': [],
+        }
+
+        if parent_span_id:
+            span['parentId'] = parent_span_id
+        if timestamp_s:
+            span['timestamp'] = int(timestamp_s * 1000000)
+        if duration_s:
+            span['duration'] = int(duration_s * 1000000)
+
+        v1_endpoint = self._create_v1_endpoint(endpoint)
+
+        for key, timestamp in annotations.items():
+            span['annotations'].append({
+                'endpoint': v1_endpoint,
+                'timestamp': int(timestamp * 1000000),
+                'value': key,
+            })
+
+        for key, value in binary_annotations.items():
+            span['binaryAnnotations'].append({
+                'key': key,
+                'value': value,
+                'endpoint': v1_endpoint,
+            })
+
+        # Add sa binary annotations
+        if sa_endpoint is not None:
+            json_sa_endpoint = self._create_v1_endpoint(sa_endpoint)
+            span['binaryAnnotations'].append({
+                'key': 'sa',
+                'value': '1',
+                'endpoint': json_sa_endpoint,
+            })
+
+        encoded_span = json.dumps(span)
+
+        return encoded_span, len(encoded_span)
+
+    def encode_queue(self, queue):
+        return '[' + ', '.join(queue) + ']'

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -5,6 +5,7 @@ import time
 from collections import namedtuple
 
 from py_zipkin._encoding_helpers import create_endpoint
+from py_zipkin._encoding_helpers import Encoding
 from py_zipkin.exception import ZipkinError
 from py_zipkin.logging_helper import zipkin_logger
 from py_zipkin.logging_helper import ZipkinLoggerHandler
@@ -112,7 +113,8 @@ class zipkin_span(object):
         use_128bit_trace_id=False,
         host=None,
         context_stack=None,
-        firehose_handler=None
+        firehose_handler=None,
+        encoding=Encoding.THRIFT,
     ):
         """Logs a zipkin span. If this is the root span, then a zipkin
         trace is started as well.
@@ -186,6 +188,7 @@ class zipkin_span(object):
         self.host = host
         self._context_stack = context_stack or ThreadLocalStack()
         self.firehose_handler = firehose_handler
+        self.encoding = encoding
 
         self.logging_context = None
         self.logging_configured = False
@@ -230,6 +233,7 @@ class zipkin_span(object):
                 host=self.host,
                 context_stack=self._context_stack,
                 firehose_handler=self.firehose_handler,
+                encoding=self.encoding,
             ):
                 return f(*args, **kwargs)
         return decorated
@@ -322,6 +326,7 @@ class zipkin_span(object):
                 client_context=client_context,
                 max_span_batch_size=self.max_span_batch_size,
                 firehose_handler=self.firehose_handler,
+                encoding=self.encoding,
             )
             self.logging_context.start()
             self.logging_configured = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
+import mock
 import pytest
 
 from py_zipkin.zipkin import ZipkinAttrs
 from py_zipkin.transport import BaseTransportHandler
+from py_zipkin._encoding_helpers import IEncoder
 
 
 @pytest.fixture
@@ -34,3 +36,13 @@ class MockTransportHandler(BaseTransportHandler):
 
     def get_max_payload_bytes(self):
         return self.max_payload_bytes
+
+
+class MockEncoder(IEncoder):
+
+    def __init__(self, fits=True, encoded_span='', encoded_queue=''):
+        self.fits = mock.Mock(return_value=fits)
+        self.encode_span = mock.Mock(
+            return_value=(encoded_span, len(encoded_span)),
+        )
+        self.encode_queue = mock.Mock(return_value=encoded_queue)

--- a/tests/integration/zipkin_integration_test.py
+++ b/tests/integration/zipkin_integration_test.py
@@ -1,9 +1,14 @@
+import json
+from collections import namedtuple
+
 import pytest
 from thriftpy.protocol.binary import read_list_begin
 from thriftpy.protocol.binary import TBinaryProtocol
 from thriftpy.transport import TMemoryBuffer
 
+import py_zipkin
 from py_zipkin import zipkin
+from py_zipkin._encoding_helpers import Endpoint
 from py_zipkin.logging_helper import LOGGING_END_KEY
 from py_zipkin.logging_helper import zipkin_logger
 from py_zipkin.thrift import zipkin_core
@@ -11,6 +16,28 @@ from py_zipkin.zipkin import ZipkinAttrs
 
 
 USECS = 1000000
+
+
+Annotation = namedtuple('Annotation', ['host', 'timestamp', 'value'])
+BinaryAnnotation = namedtuple('BinaryAnnotation', ['key', 'value', 'host'])
+V1Span = namedtuple('V1Span', [
+    'trace_id',
+    'name',
+    'parent_id',
+    'id',
+    'timestamp',
+    'duration',
+    'debug',
+    'annotations',
+    'binary_annotations',
+    'trace_id_high',
+])
+
+
+SUPPORTED_ENCODINGS = [
+    py_zipkin.Encoding.THRIFT,
+    py_zipkin.Encoding.JSON,
+]
 
 
 @pytest.fixture
@@ -29,9 +56,13 @@ def mock_logger():
     return mock_transport_handler, mock_logs
 
 
-def _decode_binary_thrift_obj(obj):
-    spans = _decode_binary_thrift_objs(obj)
-    return spans[0]
+def decode(obj, encoding):
+    if encoding == py_zipkin.Encoding.THRIFT:
+        return _decode_binary_thrift_objs(obj)
+    elif encoding == py_zipkin.Encoding.JSON:
+        return _decode_json_v1_span(obj)
+    else:
+        raise ValueError("unknown encoding")
 
 
 def _decode_binary_thrift_objs(obj):
@@ -45,7 +76,58 @@ def _decode_binary_thrift_objs(obj):
     return spans
 
 
+def _decode_json_v1_span(obj):
+    json_spans = json.loads(obj)
+    spans = []
+
+    for json_span in json_spans:
+        ann = json_span['annotations']
+        new_ann = []
+        for a in ann:
+            new_ann.append(Annotation(
+                Endpoint(
+                    a['endpoint'].get('serviceName'),
+                    a['endpoint'].get('ipv4'),
+                    a['endpoint'].get('ipv6'),
+                    a['endpoint'].get('port'),
+                ),
+                a['timestamp'],
+                a['value'],
+            ))
+
+        old_bin = json_span['binaryAnnotations']
+        new_bin = []
+        for b in old_bin:
+            new_bin.append(BinaryAnnotation(
+                b['key'],
+                b['value'],
+                Endpoint(
+                    b['endpoint'].get('serviceName'),
+                    b['endpoint'].get('ipv4'),
+                    b['endpoint'].get('ipv6'),
+                    b['endpoint'].get('port'),
+                ),
+            ))
+
+        spans.append(V1Span(
+            json_span.get('traceId'),
+            json_span.get('name'),
+            json_span.get('parentId'),
+            json_span.get('id'),
+            json_span.get('timestamp'),
+            json_span.get('duration'),
+            json_span.get('debug'),
+            new_ann,
+            new_bin,
+            None,
+        ))
+
+    return spans
+
+
+@pytest.mark.parametrize('encoding', SUPPORTED_ENCODINGS)
 def test_starting_zipkin_trace_with_sampling_rate(
+    encoding,
     default_annotations,
 ):
     mock_transport_handler, mock_logs = mock_logger()
@@ -58,6 +140,7 @@ def test_starting_zipkin_trace_with_sampling_rate(
         binary_annotations={'some_key': 'some_value'},
         add_logging_annotation=True,
         firehose_handler=mock_firehose_handler,
+        encoding=encoding,
     ):
         pass
 
@@ -73,13 +156,12 @@ def test_starting_zipkin_trace_with_sampling_rate(
         assert span.binary_annotations[0].value == 'some_value'
         assert set([ann.value for ann in span.annotations]) == default_annotations
 
-    check_span(_decode_binary_thrift_obj(mock_logs[0]))
-    check_span(_decode_binary_thrift_obj(mock_firehose_logs[0]))
+    check_span(decode(mock_logs[0], encoding)[0])
+    check_span(decode(mock_firehose_logs[0], encoding)[0])
 
 
-def test_starting_zipkin_trace_with_128bit_trace_id(
-    default_annotations,
-):
+@pytest.mark.parametrize('encoding', SUPPORTED_ENCODINGS)
+def test_starting_zipkin_trace_with_128bit_trace_id(encoding):
     mock_transport_handler, mock_logs = mock_logger()
     mock_firehose_handler, mock_firehose_logs = mock_logger()
     with zipkin.zipkin_span(
@@ -90,19 +172,24 @@ def test_starting_zipkin_trace_with_128bit_trace_id(
         binary_annotations={'some_key': 'some_value'},
         add_logging_annotation=True,
         use_128bit_trace_id=True,
-        firehose_handler=mock_firehose_handler
+        firehose_handler=mock_firehose_handler,
+        encoding=encoding,
     ):
         pass
 
     def check_span(span):
         assert span.trace_id is not None
-        assert span.trace_id_high is not None
+        if encoding == py_zipkin.Encoding.THRIFT:
+            assert span.trace_id_high is not None
+        elif encoding == py_zipkin.Encoding.JSON:
+            assert len(span.trace_id) == 32
 
-    check_span(_decode_binary_thrift_obj(mock_logs[0]))
-    check_span(_decode_binary_thrift_obj(mock_firehose_logs[0]))
+    check_span(decode(mock_logs[0], encoding)[0])
+    check_span(decode(mock_firehose_logs[0], encoding)[0])
 
 
-def test_span_inside_trace():
+@pytest.mark.parametrize('encoding', SUPPORTED_ENCODINGS)
+def test_span_inside_trace(encoding):
     mock_transport_handler, mock_logs = mock_logger()
     mock_firehose_handler, mock_firehose_logs = mock_logger()
     with zipkin.zipkin_span(
@@ -112,6 +199,7 @@ def test_span_inside_trace():
         sample_rate=100.0,
         binary_annotations={'some_key': 'some_value'},
         firehose_handler=mock_firehose_handler,
+        encoding=encoding,
     ):
         with zipkin.zipkin_span(
             service_name='nested_service',
@@ -139,11 +227,12 @@ def test_span_inside_trace():
             if ann.value == 'nested_annotation':
                 assert ann.timestamp == 43 * USECS
 
-    check_spans(_decode_binary_thrift_objs(mock_logs[0]))
-    check_spans(_decode_binary_thrift_objs(mock_firehose_logs[0]))
+    check_spans(decode(mock_logs[0], encoding))
+    check_spans(decode(mock_firehose_logs[0], encoding))
 
 
-def test_annotation_override():
+@pytest.mark.parametrize('encoding', SUPPORTED_ENCODINGS)
+def test_annotation_override(encoding):
     """This is the same as above, but we override an annotation
     in the inner span
     """
@@ -156,6 +245,7 @@ def test_annotation_override():
         sample_rate=100.0,
         binary_annotations={'some_key': 'some_value'},
         firehose_handler=mock_firehose_handler,
+        encoding=encoding,
     ):
         with zipkin.zipkin_span(
             service_name='nested_service',
@@ -187,23 +277,24 @@ def test_annotation_override():
             elif ann.value == 'cr':
                 assert ann.timestamp == 300 * USECS
 
-    check_spans(_decode_binary_thrift_objs(mock_logs[0]))
-    check_spans(_decode_binary_thrift_objs(mock_firehose_logs[0]))
+    check_spans(decode(mock_logs[0], encoding))
+    check_spans(decode(mock_firehose_logs[0], encoding))
 
 
 def _verify_service_span(span, annotations):
     assert span.name == 'service_span'
-    assert span.trace_id == 0
-    assert span.id == 1
+    assert int(span.trace_id) == 0
+    assert int(span.id) == 1
     assert span.annotations[0].host.service_name == 'test_service_name'
     assert span.annotations[0].host.port == 0
-    assert span.parent_id == 2
+    assert int(span.parent_id) == 2
     assert span.binary_annotations[0].key == 'some_key'
     assert span.binary_annotations[0].value == 'some_value'
     assert set([ann.value for ann in span.annotations]) == annotations
 
 
-def test_service_span(default_annotations):
+@pytest.mark.parametrize('encoding', SUPPORTED_ENCODINGS)
+def test_service_span(encoding, default_annotations):
     mock_transport_handler, mock_logs = mock_logger()
     mock_firehose_handler, mock_firehose_logs = mock_logger()
     zipkin_attrs = ZipkinAttrs(
@@ -221,11 +312,12 @@ def test_service_span(default_annotations):
         binary_annotations={'some_key': 'some_value'},
         add_logging_annotation=True,
         firehose_handler=mock_firehose_handler,
+        encoding=encoding,
     ):
         pass
 
-    span = _decode_binary_thrift_obj(mock_logs[0])
-    firehose_span = _decode_binary_thrift_obj(mock_firehose_logs[0])
+    span = decode(mock_logs[0], encoding)[0]
+    firehose_span = decode(mock_firehose_logs[0], encoding)[0]
     _verify_service_span(span, default_annotations)
     _verify_service_span(firehose_span, default_annotations)
 
@@ -235,7 +327,9 @@ def test_service_span(default_annotations):
     assert span.duration is None
 
 
+@pytest.mark.parametrize('encoding', SUPPORTED_ENCODINGS)
 def test_service_span_report_timestamp_override(
+    encoding,
     default_annotations,
 ):
     mock_transport_handler, mock_logs = mock_logger()
@@ -254,16 +348,19 @@ def test_service_span_report_timestamp_override(
         binary_annotations={'some_key': 'some_value'},
         add_logging_annotation=True,
         report_root_timestamp=True,
+        encoding=encoding,
     ):
         pass
 
-    span = _decode_binary_thrift_obj(mock_logs[0])
+    span = decode(mock_logs[0], encoding)[0]
     _verify_service_span(span, default_annotations)
     assert span.timestamp is not None
     assert span.duration is not None
 
 
+@pytest.mark.parametrize('encoding', SUPPORTED_ENCODINGS)
 def test_service_span_that_is_independently_sampled(
+    encoding,
     default_annotations,
 ):
     mock_transport_handler, mock_logs = mock_logger()
@@ -285,6 +382,7 @@ def test_service_span_that_is_independently_sampled(
         binary_annotations={'some_key': 'some_value'},
         add_logging_annotation=True,
         firehose_handler=mock_firehose_handler,
+        encoding=encoding,
     ):
         pass
 
@@ -300,11 +398,12 @@ def test_service_span_that_is_independently_sampled(
         assert span.duration is not None
         assert set([ann.value for ann in span.annotations]) == default_annotations
 
-    check_span(_decode_binary_thrift_obj(mock_logs[0]))
-    check_span(_decode_binary_thrift_obj(mock_firehose_logs[0]))
+    check_span(decode(mock_logs[0], encoding)[0])
+    check_span(decode(mock_firehose_logs[0], encoding)[0])
 
 
-def test_log_debug_for_new_span():
+@pytest.mark.parametrize('encoding', SUPPORTED_ENCODINGS)
+def test_log_debug_for_new_span(encoding):
     mock_transport_handler, mock_logs = mock_logger()
     mock_firehose_handler, mock_firehose_logs = mock_logger()
     with zipkin.zipkin_span(
@@ -315,6 +414,7 @@ def test_log_debug_for_new_span():
         binary_annotations={'some_key': 'some_value'},
         add_logging_annotation=True,
         firehose_handler=mock_firehose_handler,
+        encoding=encoding,
     ):
         zipkin_logger.debug({
             'annotations': {
@@ -342,11 +442,12 @@ def test_log_debug_for_new_span():
             [ann.value for ann in logged_span.annotations]
         ) == set(['cs', 'cr'])
 
-    check_spans(_decode_binary_thrift_objs(mock_logs[0]))
-    check_spans(_decode_binary_thrift_objs(mock_firehose_logs[0]))
+    check_spans(decode(mock_logs[0], encoding))
+    check_spans(decode(mock_firehose_logs[0], encoding))
 
 
-def test_log_debug_for_existing_span(default_annotations):
+@pytest.mark.parametrize('encoding', SUPPORTED_ENCODINGS)
+def test_log_debug_for_existing_span(encoding, default_annotations):
     mock_transport_handler, mock_logs = mock_logger()
     mock_firehose_handler, mock_firehose_logs = mock_logger()
     with zipkin.zipkin_span(
@@ -357,6 +458,7 @@ def test_log_debug_for_existing_span(default_annotations):
         binary_annotations={'some_key': 'some_value'},
         add_logging_annotation=True,
         firehose_handler=mock_firehose_handler,
+        encoding=encoding,
     ):
         zipkin_logger.debug({
             'annotations': {
@@ -387,13 +489,12 @@ def test_log_debug_for_existing_span(default_annotations):
         assert binary_annotations[1].value == 'some_value'
 
     assert len(mock_logs) == 1
-    check_span(_decode_binary_thrift_obj(mock_logs[0]))
-    check_span(_decode_binary_thrift_obj(mock_firehose_logs[0]))
+    check_span(decode(mock_logs[0], encoding)[0])
+    check_span(decode(mock_firehose_logs[0], encoding)[0])
 
 
-def test_zipkin_trace_with_no_sampling_no_firehose(
-    default_annotations
-):
+@pytest.mark.parametrize('encoding', SUPPORTED_ENCODINGS)
+def test_zipkin_trace_with_no_sampling_no_firehose(encoding):
     mock_transport_handler, mock_logs = mock_logger()
     with zipkin.zipkin_span(
         service_name='test_service_name',
@@ -402,13 +503,16 @@ def test_zipkin_trace_with_no_sampling_no_firehose(
         sample_rate=None,
         binary_annotations={'some_key': 'some_value'},
         add_logging_annotation=True,
+        encoding=encoding,
     ):
         pass
 
     assert len(mock_logs) == 0
 
 
+@pytest.mark.parametrize('encoding', SUPPORTED_ENCODINGS)
 def test_zipkin_trace_with_no_sampling_with_firehose(
+    encoding,
     default_annotations
 ):
     mock_transport_handler, mock_logs = mock_logger()
@@ -421,6 +525,7 @@ def test_zipkin_trace_with_no_sampling_with_firehose(
         binary_annotations={'some_key': 'some_value'},
         add_logging_annotation=True,
         firehose_handler=mock_firehose_handler,
+        encoding=encoding,
     ):
         pass
 
@@ -437,10 +542,11 @@ def test_zipkin_trace_with_no_sampling_with_firehose(
         assert set([ann.value for ann in span.annotations]) == default_annotations
 
     assert len(mock_logs) == 0
-    check_span(_decode_binary_thrift_obj(mock_firehose_logs[0]))
+    check_span(decode(mock_firehose_logs[0], encoding)[0])
 
 
-def test_no_sampling_with_inner_span():
+@pytest.mark.parametrize('encoding', SUPPORTED_ENCODINGS)
+def test_no_sampling_with_inner_span(encoding):
     mock_transport_handler, mock_logs = mock_logger()
     mock_firehose_handler, mock_firehose_logs = mock_logger()
     with zipkin.zipkin_span(
@@ -451,6 +557,7 @@ def test_no_sampling_with_inner_span():
         binary_annotations={'some_key': 'some_value'},
         add_logging_annotation=True,
         firehose_handler=mock_firehose_handler,
+        encoding=encoding,
     ):
         with zipkin.zipkin_span(
             service_name='nested_service',
@@ -481,4 +588,4 @@ def test_no_sampling_with_inner_span():
                 assert ann.timestamp == 43 * USECS
 
     assert len(mock_logs) == 0
-    check_spans(_decode_binary_thrift_objs(mock_firehose_logs[0]))
+    check_spans(decode(mock_firehose_logs[0], encoding))

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -68,6 +68,7 @@ def test_zipkin_span_for_new_trace(
         client_context=False,
         max_span_batch_size=None,
         firehose_handler=firehose_handler,
+        encoding=_encoding_helpers.Encoding.THRIFT,
     )
     mock_context_stack.pop.assert_called_once_with()
 
@@ -120,7 +121,8 @@ def test_zipkin_span_passed_sampled_attrs(
         add_logging_annotation=False,
         client_context=False,
         max_span_batch_size=None,
-        firehose_handler=None
+        firehose_handler=None,
+        encoding=_encoding_helpers.Encoding.THRIFT,
     )
     mock_context_stack.pop.assert_called_once_with()
 
@@ -502,6 +504,7 @@ def test_zipkin_server_span_decorator(
         client_context=False,
         max_span_batch_size=None,
         firehose_handler=None,
+        encoding=_encoding_helpers.Encoding.THRIFT,
     )
     mock_context_stack.pop.assert_called_once_with()
 
@@ -558,6 +561,7 @@ def test_zipkin_client_span_decorator(
         client_context=True,
         max_span_batch_size=None,
         firehose_handler=None,
+        encoding=_encoding_helpers.Encoding.THRIFT,
     )
     mock_context_stack.pop.assert_called_once_with()
 


### PR DESCRIPTION
As the title says, this PR adds JSON encoding for V1 spans. This branch is based on `decouple_thrift`, so that one will need to be merged first.

### API changes
`with zipkin_span` now accepts a new argument `encoding`. The valid encodings are listed in an enum imported in `py_zipkin/__init__.py` so users can just do `py_zipkin.Encoding.JSON`. `encoding` defaults to `THRIFT` so this change is backward compatible.

### ZipkinBatchSender
The `ZipkinBatchSender` now receives the encoder instance as argument and uses it to encode the single spans and create the final list. All references to `thrift` are now contained in `_encoding_helpers.py`.

### Encoders
We now have 2 new `_V1ThriftEncoder` and `_V1JSONEncoder`. Every encoder respects the simple `IEncoder` interface.

One issue I encountered is that JSON lists don't have a fixed overhead since single elements are also separated by `", "`. That meant having a `fits` function that receives a bunch of params and tells you whether the new span fits or not. I don't like it much since it receives a lot of arguments, but I didn't know how to better write this API.

cc @adriancole