### PR TITLE
Remove deprecated logging handler

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+0.13.0 (2018-06-25)
+-------------------
+- Removed deprecated `zipkin_logger.debug()` interface.
+- `py_zipkin.stack` was renamed as `py_zipkin.storage`. If you were
+  importing this module, you'll need to update your code.
+
 0.12.0 (2018-05-29)
 -------------------
 - Support max payload size for transport handlers.

--- a/README.md
+++ b/README.md
@@ -199,10 +199,37 @@ Using in multithreading evironments
 -----------------------------------
 
 If you want to use py_zipkin in a cooperative multithreading environment,
-e.g. asyncio, you need to explicitly pass an instance of `py_zipkin.stack.Stack`
+e.g. asyncio, you need to explicitly pass an instance of `py_zipkin.storage.Stack`
 as parameter `context_stack` for `zipkin_span` and `create_http_headers_for_new_span`.
 By default, py_zipkin uses a thread local storage for the attributes, which is
-defined in `py_zipkin.stack.ThreadLocalStack`.
+defined in `py_zipkin.storage.ThreadLocalStack`.
+
+Additionally, you'll also need to explicitly pass an instance of
+`py_zipkin.storage.SpanStorage` as parameter `span_storage` to `zipkin_span`.
+
+```python
+from py_zipkin.zipkin import zipkin_span
+from py_zipkin.storage import Stack
+from py_zipkin.storage import SpanStorage
+
+
+def my_function():
+    context_stack = Stack()
+    span_storage = SpanStorage()
+    await my_function(context_stack, span_storage)
+
+async def my_function(context_stack, span_storage):
+    with zipkin_span(
+        service_name='my_service',
+        span_name='some_function',
+        transport_handler=some_handler,
+        port=42,
+        sample_rate=0.05,
+        context_stack=context_stack,
+        span_storage=span_storage,
+    ):
+        result = do_stuff(a, b)
+```
 
 
 Firehose mode [EXPERIMENTAL]

--- a/py_zipkin/logging_helper.py
+++ b/py_zipkin/logging_helper.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-import logging
 import time
-from collections import defaultdict
 from logging import NullHandler
 
 from py_zipkin import _encoding_helpers
@@ -10,11 +8,6 @@ from py_zipkin.exception import ZipkinError
 from py_zipkin.transport import BaseTransportHandler
 from py_zipkin.util import generate_random_64bit_string
 
-
-null_handler = NullHandler()
-zipkin_logger = logging.getLogger('py_zipkin.logger')
-zipkin_logger.addHandler(null_handler)
-zipkin_logger.setLevel(logging.DEBUG)
 
 LOGGING_END_KEY = 'py_zipkin.logging_end'
 
@@ -32,10 +25,10 @@ class ZipkinLoggingContext(object):
         self,
         zipkin_attrs,
         endpoint,
-        log_handler,
         span_name,
         transport_handler,
         report_root_timestamp,
+        span_store,
         binary_annotations=None,
         add_logging_annotation=False,
         client_context=False,
@@ -44,10 +37,10 @@ class ZipkinLoggingContext(object):
     ):
         self.zipkin_attrs = zipkin_attrs
         self.endpoint = endpoint
-        self.log_handler = log_handler
         self.span_name = span_name
         self.transport_handler = transport_handler
         self.response_status_code = 0
+        self.span_store = span_store
         self.report_root_timestamp = report_root_timestamp
         self.binary_annotations_dict = binary_annotations or {}
         self.add_logging_annotation = add_logging_annotation
@@ -58,23 +51,18 @@ class ZipkinLoggingContext(object):
         self.sa_endpoint = None
 
     def start(self):
-        """Actions to be taken before request is handled.
-        1) Attach `zipkin_logger` to :class:`ZipkinLoggerHandler` object.
-        2) Record the start timestamp.
-        """
-        zipkin_logger.removeHandler(null_handler)
-        zipkin_logger.addHandler(self.log_handler)
+        """Actions to be taken before request is handled."""
+
+        # Record the start timestamp.
         self.start_timestamp = time.time()
         return self
 
     def stop(self):
         """Actions to be taken post request handling.
-        1) Log the service annotations to scribe.
-        2) Detach `zipkin_logger` handler.
         """
+
+        # Log the service annotations to scribe.
         self.log_spans()
-        zipkin_logger.removeHandler(self.log_handler)
-        zipkin_logger.addHandler(null_handler)
 
     def log_spans(self):
         """Main function to log all the annotations stored during the entire
@@ -92,6 +80,7 @@ class ZipkinLoggingContext(object):
             )
 
         if not self.zipkin_attrs.is_sampled:
+            self.span_store.clear()
             return
 
         span_sender = ZipkinBatchSender(self.transport_handler,
@@ -99,74 +88,43 @@ class ZipkinLoggingContext(object):
 
         self._log_spans_with_span_sender(span_sender)
 
+        self.span_store.clear()
+
     def _log_spans_with_span_sender(self, span_sender):
         with span_sender:
             end_timestamp = time.time()
-            # Collect additional annotations from the logging handler
-            annotations_by_span_id = defaultdict(dict)
-            binary_annotations_by_span_id = defaultdict(dict)
-            for msg in self.log_handler.extra_annotations:
-                span_id = msg['parent_span_id'] or self.zipkin_attrs.span_id
-                # This should check if these are non-None
-                annotations_by_span_id[span_id].update(msg['annotations'])
-                binary_annotations_by_span_id[span_id].update(
-                    msg['binary_annotations']
-                )
 
             # Collect, annotate, and log client spans from the logging handler
-            for span in self.log_handler.client_spans:
-                # The parent_span_id is either the parent ID set in the
-                # logging handler or the current Zipkin context's span ID.
-                parent_span_id = (
-                    span['parent_span_id'] or
-                    self.zipkin_attrs.span_id
-                )
-                # A new client span's span ID can be overridden
-                span_id = span['span_id'] or generate_random_64bit_string()
+            for span in self.span_store:
+
                 endpoint = _encoding_helpers.copy_endpoint_with_new_service_name(
                     self.endpoint, span['service_name']
                 )
-                # Collect annotations both logged with the new spans and
-                # logged in separate log messages.
-                annotations = span['annotations']
-                annotations.update(annotations_by_span_id[span_id])
-                binary_annotations = span['binary_annotations']
-                binary_annotations.update(
-                    binary_annotations_by_span_id[span_id])
 
                 timestamp, duration = get_local_span_timestamp_and_duration(
-                    annotations
+                    span['annotations']
                 )
 
                 span_sender.add_span(
-                    span_id=span_id,
-                    parent_span_id=parent_span_id,
-                    trace_id=self.zipkin_attrs.trace_id,
+                    span_id=span['span_id'],
+                    parent_span_id=span['parent_span_id'],
+                    trace_id=span['trace_id'],
                     span_name=span['span_name'],
-                    annotations=annotations,
-                    binary_annotations=binary_annotations,
+                    annotations=span['annotations'],
+                    binary_annotations=span['binary_annotations'],
                     timestamp_s=timestamp,
                     duration_s=duration,
                     endpoint=endpoint,
-                    sa_endpoint=span.get('sa_endpoint'),
+                    sa_endpoint=span['sa_endpoint'],
                 )
-
-            extra_annotations = annotations_by_span_id[
-                self.zipkin_attrs.span_id]
-            extra_binary_annotations = binary_annotations_by_span_id[
-                self.zipkin_attrs.span_id
-            ]
 
             k1, k2 = ('sr', 'ss')
             if self.client_context:
                 k1, k2 = ('cs', 'cr')
             annotations = {k1: self.start_timestamp, k2: end_timestamp}
-            annotations.update(extra_annotations)
 
             if self.add_logging_annotation:
                 annotations[LOGGING_END_KEY] = time.time()
-
-            self.binary_annotations_dict.update(extra_binary_annotations)
 
             if self.report_root_timestamp:
                 timestamp = self.start_timestamp
@@ -194,110 +152,6 @@ def get_local_span_timestamp_and_duration(annotations):
     elif 'sr' in annotations and 'ss' in annotations:
         return annotations['sr'], annotations['ss'] - annotations['sr']
     return None, None
-
-
-class ZipkinLoggerHandler(logging.StreamHandler, object):
-    """Logger Handler to log span annotations or additional client spans to
-    scribe. To connect to the handler, logger name must be
-    'py_zipkin.logger'.
-
-    :param zipkin_attrs: ZipkinAttrs namedtuple object
-    """
-
-    def __init__(self, zipkin_attrs):
-        super(ZipkinLoggerHandler, self).__init__()
-        # If parent_span_id is set, the application is in a logging context
-        # where each additional client span logged has this span as its parent.
-        # This is to allow logging of hierarchies of spans instead of just
-        # single client spans. See the SpanContext class.
-        self.parent_span_id = None
-        self.zipkin_attrs = zipkin_attrs
-        self.client_spans = []
-        self.extra_annotations = []
-
-    def store_local_span(
-        self,
-        span_name,
-        service_name,
-        annotations,
-        binary_annotations,
-        sa_endpoint,
-        span_id=None,
-    ):
-        """Convenience method for storing a local child span (a zipkin_span
-        inside other zipkin_spans) to be logged when the outermost zipkin_span
-        exits.
-        """
-        self.client_spans.append({
-            'span_name': span_name,
-            'service_name': service_name,
-            'parent_span_id': self.parent_span_id,
-            'span_id': span_id,
-            'annotations': annotations,
-            'binary_annotations': binary_annotations,
-            'sa_endpoint': sa_endpoint,
-        })
-
-    def emit(self, record):
-        """Handle each record message. This function is called whenever
-        zipkin_logger.debug() is called.
-
-        :param record: object containing the `msg` object.
-            Structure of record.msg should be the following:
-            ::
-
-            {
-                "annotations": {
-                    "cs": ts1,
-                    "cr": ts2,
-                },
-                "binary_annotations": {
-                    "http.uri": "/foo/bar",
-                },
-                "name": "foo_span",
-                "service_name": "myService",
-            }
-
-            Keys:
-            - annotations: str -> timestamp annotations
-            - binary_annotations: str -> str binary annotations
-              (One of either annotations or binary_annotations is required)
-            - name: str of new span name; only used if service-name is also
-              specified.
-            - service_name: str of new client span's service name.
-
-            If service_name is specified, this log msg is considered to
-            represent a new client span. If service_name is omitted, this is
-            considered additional annotation for the currently active
-            "parent span" (either the server span or the parent client span
-            inside a SpanContext).
-        """
-        if not self.zipkin_attrs.is_sampled:
-            return
-        span_name = record.msg.get('name', 'span')
-        annotations = record.msg.get('annotations', {})
-        binary_annotations = record.msg.get('binary_annotations', {})
-        if not annotations and not binary_annotations:
-            raise ZipkinError(
-                "At least one of annotation/binary annotation has"
-                " to be provided for {0} span".format(span_name)
-            )
-        service_name = record.msg.get('service_name', None)
-        # Presence of service_name means this is to be a new local span.
-        if service_name is not None:
-            self.store_local_span(
-                span_name=span_name,
-                service_name=service_name,
-                annotations=annotations,
-                binary_annotations=binary_annotations,
-                sa_endpoint=None,
-            )
-        else:
-            self.extra_annotations.append({
-                'annotations': annotations,
-                'binary_annotations': binary_annotations,
-                'parent_span_id': self.parent_span_id,
-            })
 
 
 class ZipkinBatchSender(object):

--- a/py_zipkin/logging_helper.py
+++ b/py_zipkin/logging_helper.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 import time
-from logging import NullHandler
 
 from py_zipkin import _encoding_helpers
 from py_zipkin import thrift
 from py_zipkin.exception import ZipkinError
 from py_zipkin.transport import BaseTransportHandler
-from py_zipkin.util import generate_random_64bit_string
 
 
 LOGGING_END_KEY = 'py_zipkin.logging_end'

--- a/py_zipkin/stack.py
+++ b/py_zipkin/stack.py
@@ -27,7 +27,10 @@ class Stack(object):
         self.index = 0
         return self
 
-    def __next__(self):
+    def __next__(self):  # pragma: no cover
+        return self.next()
+
+    def next(self):
         if len(self._storage) <= self.index:
             raise StopIteration
         self.index += 1

--- a/py_zipkin/stack.py
+++ b/py_zipkin/stack.py
@@ -23,6 +23,20 @@ class Stack(object):
         if self._storage:
             return self._storage[-1]
 
+    def __iter__(self):
+        self.index = 0
+        return self
+
+    def __next__(self):
+        if len(self._storage) <= self.index:
+            raise StopIteration
+        self.index += 1
+        return self._storage[self.index - 1]
+
+    def clear(self):
+        while len(self._storage) > 0:
+            self._storage.pop()
+
 
 class ThreadLocalStack(Stack):
     """
@@ -34,9 +48,9 @@ class ThreadLocalStack(Stack):
     Every instance shares the same thread local data.
     """
 
-    def __init__(self):
-        pass
+    def __init__(self, storage_fn=None):
+        self._storage_fn = storage_fn or thread_local.get_thread_local_zipkin_attrs
 
     @property
     def _storage(self):
-        return thread_local.get_thread_local_zipkin_attrs()
+        return self._storage_fn()

--- a/py_zipkin/storage.py
+++ b/py_zipkin/storage.py
@@ -1,3 +1,5 @@
+from collections import deque
+
 from py_zipkin import thread_local
 
 
@@ -23,23 +25,6 @@ class Stack(object):
         if self._storage:
             return self._storage[-1]
 
-    def __iter__(self):
-        self.index = 0
-        return self
-
-    def __next__(self):  # pragma: no cover
-        return self.next()
-
-    def next(self):
-        if len(self._storage) <= self.index:
-            raise StopIteration
-        self.index += 1
-        return self._storage[self.index - 1]
-
-    def clear(self):
-        while len(self._storage) > 0:
-            self._storage.pop()
-
 
 class ThreadLocalStack(Stack):
     """
@@ -51,9 +36,17 @@ class ThreadLocalStack(Stack):
     Every instance shares the same thread local data.
     """
 
-    def __init__(self, storage_fn=None):
-        self._storage_fn = storage_fn or thread_local.get_thread_local_zipkin_attrs
+    def __init__(self):
+        pass
 
     @property
     def _storage(self):
-        return self._storage_fn()
+        return thread_local.get_thread_local_zipkin_attrs()
+
+
+class SpanStorage(deque):
+    pass
+
+
+def default_span_storage():
+    return thread_local.get_thread_local_span_storage()

--- a/py_zipkin/thread_local.py
+++ b/py_zipkin/thread_local.py
@@ -6,7 +6,7 @@ _thread_local = threading.local()
 
 
 def get_thread_local_zipkin_attrs():
-    """A wrapper to return _thread_local.requests
+    """A wrapper to return _thread_local.zipkin_attrs
 
     :returns: list that may contain zipkin attribute tuples
     :rtype: list
@@ -14,6 +14,17 @@ def get_thread_local_zipkin_attrs():
     if not hasattr(_thread_local, 'zipkin_attrs'):
         _thread_local.zipkin_attrs = []
     return _thread_local.zipkin_attrs
+
+
+def get_thread_local_span_store():
+    """A wrapper to return _thread_local.span_store
+
+    :returns: list that may contain zipkin spans
+    :rtype: list
+    """
+    if not hasattr(_thread_local, 'span_store'):
+        _thread_local.span_store = []
+    return _thread_local.span_store
 
 
 def get_zipkin_attrs():

--- a/py_zipkin/thread_local.py
+++ b/py_zipkin/thread_local.py
@@ -8,6 +8,9 @@ _thread_local = threading.local()
 def get_thread_local_zipkin_attrs():
     """A wrapper to return _thread_local.zipkin_attrs
 
+    Returns a list of ZipkinAttrs objects, used for intra-process context
+    propagation.
+
     :returns: list that may contain zipkin attribute tuples
     :rtype: list
     """
@@ -16,15 +19,20 @@ def get_thread_local_zipkin_attrs():
     return _thread_local.zipkin_attrs
 
 
-def get_thread_local_span_store():
-    """A wrapper to return _thread_local.span_store
+def get_thread_local_span_storage():
+    """A wrapper to return _thread_local.span_storage
 
-    :returns: list that may contain zipkin spans
-    :rtype: list
+    Returns a SpanStorage object used to temporarily store all spans created in
+    the current process. The transport handlers will pull from this storage when
+    they emit the spans.
+
+    :returns: SpanStore object containing all non-root spans.
+    :rtype: py_zipkin.storage.SpanStore
     """
-    if not hasattr(_thread_local, 'span_store'):
-        _thread_local.span_store = []
-    return _thread_local.span_store
+    if not hasattr(_thread_local, 'span_storage'):
+        from py_zipkin.storage import SpanStorage
+        _thread_local.span_storage = SpanStorage()
+    return _thread_local.span_storage
 
 
 def get_zipkin_attrs():
@@ -33,7 +41,7 @@ def get_zipkin_attrs():
     :returns: tuple containing zipkin attrs
     :rtype: :class:`zipkin.ZipkinAttrs`
     """
-    from py_zipkin.stack import ThreadLocalStack
+    from py_zipkin.storage import ThreadLocalStack
     warnings.warn(
         'Use py_zipkin.stack.ThreadLocalStack().get',
         DeprecationWarning,
@@ -47,7 +55,7 @@ def pop_zipkin_attrs():
     :returns: tuple containing zipkin attrs
     :rtype: :class:`zipkin.ZipkinAttrs`
     """
-    from py_zipkin.stack import ThreadLocalStack
+    from py_zipkin.storage import ThreadLocalStack
     warnings.warn(
         'Use py_zipkin.stack.ThreadLocalStack().pop',
         DeprecationWarning,
@@ -61,7 +69,7 @@ def push_zipkin_attrs(zipkin_attr):
     :param zipkin_attr: tuple containing zipkin related attrs
     :type zipkin_attr: :class:`zipkin.ZipkinAttrs`
     """
-    from py_zipkin.stack import ThreadLocalStack
+    from py_zipkin.storage import ThreadLocalStack
     warnings.warn(
         'Use py_zipkin.stack.ThreadLocalStack().push',
         DeprecationWarning,

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -4,10 +4,9 @@ import random
 import time
 from collections import namedtuple
 
+from py_zipkin import thread_local
 from py_zipkin._encoding_helpers import create_endpoint
 from py_zipkin.exception import ZipkinError
-from py_zipkin.logging_helper import zipkin_logger
-from py_zipkin.logging_helper import ZipkinLoggerHandler
 from py_zipkin.logging_helper import ZipkinLoggingContext
 from py_zipkin.stack import ThreadLocalStack
 from py_zipkin.util import generate_random_128bit_string
@@ -112,6 +111,7 @@ class zipkin_span(object):
         use_128bit_trace_id=False,
         host=None,
         context_stack=None,
+        span_store_stack=None,
         firehose_handler=None
     ):
         """Logs a zipkin span. If this is the root span, then a zipkin
@@ -185,6 +185,9 @@ class zipkin_span(object):
         self.use_128bit_trace_id = use_128bit_trace_id
         self.host = host
         self._context_stack = context_stack or ThreadLocalStack()
+        self._span_store = span_store_stack or ThreadLocalStack(
+            storage_fn=thread_local.get_thread_local_span_store,
+        )
         self.firehose_handler = firehose_handler
 
         self.logging_context = None
@@ -193,6 +196,7 @@ class zipkin_span(object):
         # Spans that log a 'cs' timestamp can additionally record a
         # 'sa' binary annotation that shows where the request is going.
         self.sa_endpoint = None
+        self.existing_zipkin_attrs = None
 
         # Validation checks
         if self.zipkin_attrs or self.sample_rate is not None:
@@ -229,6 +233,7 @@ class zipkin_span(object):
                 include=self.include,
                 host=self.host,
                 context_stack=self._context_stack,
+                span_store_stack=self._span_store,
                 firehose_handler=self.firehose_handler,
             ):
                 return f(*args, **kwargs)
@@ -271,7 +276,7 @@ class zipkin_span(object):
                 )
 
         if not self.zipkin_attrs:
-            # This span is inside the context of an existing trace
+            # Check if this span is inside the context of an existing trace
             existing_zipkin_attrs = self._context_stack.get()
             if existing_zipkin_attrs:
                 self.zipkin_attrs = ZipkinAttrs(
@@ -309,14 +314,13 @@ class zipkin_span(object):
                 return self
             endpoint = create_endpoint(self.port, self.service_name, self.host)
             client_context = set(self.include) == {'client'}
-            self.log_handler = ZipkinLoggerHandler(self.zipkin_attrs)
             self.logging_context = ZipkinLoggingContext(
                 self.zipkin_attrs,
                 endpoint,
-                self.log_handler,
                 self.span_name,
                 self.transport_handler,
                 report_root_timestamp or self.report_root_timestamp_override,
+                self._span_store,
                 binary_annotations=self.binary_annotations,
                 add_logging_annotation=self.add_logging_annotation,
                 client_context=client_context,
@@ -324,31 +328,9 @@ class zipkin_span(object):
                 firehose_handler=self.firehose_handler,
             )
             self.logging_context.start()
-            self.logging_configured = True
-            return self
-        else:
-            # Patch the ZipkinLoggerHandler.
-            # Be defensive about logging setup. Since ZipkinAttrs are local to
-            # the thread, multithreaded frameworks can get in strange states.
-            # The logging is not going to be correct in these cases, so we set
-            # a flag that turns off logging on __exit__.
-            try:
-                # Assume there's only a single handler, since all logging
-                # should be set up in this package.
-                log_handler = zipkin_logger.handlers[0]
-            except IndexError:
-                return self
-            # Make sure it's not a NullHandler or something
-            if not isinstance(log_handler, ZipkinLoggerHandler):
-                return self
-            # Put span ID on logging handler.
-            self.log_handler = log_handler
-            # Store the old parent_span_id, probably None, in case we have
-            # nested zipkin_spans
-            self.old_parent_span_id = self.log_handler.parent_span_id
-            self.log_handler.parent_span_id = self.zipkin_attrs.span_id
-            self.logging_configured = True
-            return self
+
+        self.logging_configured = True
+        return self
 
     def __exit__(self, _exc_type, _exc_value, _exc_traceback):
         self.stop(_exc_type, _exc_value, _exc_traceback)
@@ -386,8 +368,6 @@ class zipkin_span(object):
         # zipkin_span).
         end_timestamp = time.time()
 
-        self.log_handler.parent_span_id = self.old_parent_span_id
-
         # We are simulating a full two-part span locally, so set cs=sr and ss=cr
         full_annotations = {
             'cs': self.start_timestamp,
@@ -402,14 +382,16 @@ class zipkin_span(object):
             if annotation in self.annotation_filter:
                 self.annotations.setdefault(annotation, timestamp)
 
-        self.log_handler.store_local_span(
-            span_name=self.span_name,
-            service_name=self.service_name,
-            annotations=self.annotations,
-            binary_annotations=self.binary_annotations,
-            sa_endpoint=self.sa_endpoint,
-            span_id=self.zipkin_attrs.span_id,
-        )
+        self._span_store.push({
+            'trace_id': self.zipkin_attrs.trace_id,
+            'span_name': self.span_name,
+            'service_name': self.service_name,
+            'parent_span_id': self.zipkin_attrs.parent_span_id,
+            'span_id': self.zipkin_attrs.span_id,
+            'annotations': self.annotations,
+            'binary_annotations': self.binary_annotations,
+            'sa_endpoint': self.sa_endpoint,
+        })
 
     def update_binary_annotations(self, extra_annotations):
         """Updates the binary annotations for the current span.

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -167,7 +167,7 @@ class zipkin_span(object):
         :type context_stack: object
         :param span_storage: explicit Span storage for storing zipkin spans
             before they're emitted.
-        : type span_storage: py_zipkin.storage.SpanStorage
+        :type span_storage: py_zipkin.storage.SpanStorage
         :param firehose_handler: [EXPERIMENTAL] Similar to transport_handler,
             except that it will receive 100% of the spans regardless of trace
             sampling rate

--- a/tests/logging_helper_test.py
+++ b/tests/logging_helper_test.py
@@ -4,36 +4,26 @@ import pytest
 from tests.conftest import MockTransportHandler
 from py_zipkin import logging_helper
 from py_zipkin import _encoding_helpers
+from py_zipkin.stack import Stack
 from py_zipkin.exception import ZipkinError
 from py_zipkin.zipkin import ZipkinAttrs
 
 
-# This test _must_ be the first test in this file
-def test_zipkin_doesnt_spew_on_first_log(capfd):
-    zipkin_logger = logging_helper.zipkin_logger
-
-    zipkin_logger.debug({
-        'annotations': {'foo': 2},
-        'name': 'bar',
-    })
-
-    out, err = capfd.readouterr()
-
-    assert not err
-    assert not out
+class SimpleStack(Stack):
+    def __init__(self):
+        super(SimpleStack, self).__init__([])
 
 
 @pytest.fixture
 def context():
     attr = ZipkinAttrs(None, None, None, None, False)
-    log_handler = logging_helper.ZipkinLoggerHandler(attr)
     return logging_helper.ZipkinLoggingContext(
         zipkin_attrs=attr,
         endpoint=_encoding_helpers.create_endpoint(80, 'test_server', '127.0.0.1'),
-        log_handler=log_handler,
         span_name='span_name',
         transport_handler=MockTransportHandler(),
         report_root_timestamp=False,
+        span_store=SimpleStack()
     )
 
 
@@ -57,20 +47,16 @@ def fake_endpoint():
     )
 
 
-@mock.patch('py_zipkin.logging_helper.zipkin_logger', autospec=True)
 @mock.patch('py_zipkin.logging_helper.time.time', autospec=True)
-def test_zipkin_logging_context(time_mock, mock_logger, context):
+def test_zipkin_logging_context(time_mock, context):
     # Tests the context manager aspects of the ZipkinLoggingContext
     time_mock.return_value = 42
     # Ignore the actual logging part
     with mock.patch.object(context, 'log_spans'):
         context.start()
-        mock_logger.addHandler.assert_called_once_with(context.log_handler)
         assert context.start_timestamp == 42
         context.stop()
         # Make sure the handler and the zipkin attrs are gone
-        mock_logger.removeHandler.assert_called_with(context.log_handler)
-        assert mock_logger.removeHandler.call_count == 2
         assert context.log_spans.call_count == 1
 
 
@@ -83,8 +69,7 @@ def test_zipkin_logging_server_context_log_spans(
     add_span_mock, flush_mock, time_mock, fake_endpoint
 ):
     # This lengthy function tests that the logging context properly
-    # logs both client and server spans, while attaching extra annotations
-    # logged throughout the context of the trace.
+    # logs both client and server spans.
     trace_id = '000000000000000f'
     parent_span_id = '0000000000000001'
     server_span_id = '0000000000000002'
@@ -98,39 +83,28 @@ def test_zipkin_logging_server_context_log_spans(
         flags=None,
         is_sampled=True,
     )
-    handler = logging_helper.ZipkinLoggerHandler(attr)
-    extra_server_annotations = {
-        'parent_span_id': None,
-        'annotations': {'foo': 1},
-        'binary_annotations': {'what': 'whoa'},
-    }
-    extra_client_annotations = {
-        'parent_span_id': client_span_id,
-        'annotations': {'ann1': 1},
-        'binary_annotations': {'bann1': 'aww'},
-    }
-    handler.extra_annotations = [
-        extra_server_annotations,
-        extra_client_annotations,
-    ]
-    handler.client_spans = [{
+    span_store = SimpleStack()
+
+    span_store.push({
+        'trace_id': trace_id,
         'span_id': client_span_id,
-        'parent_span_id': None,
+        'parent_span_id': server_span_id,
         'span_name': client_span_name,
         'service_name': client_svc_name,
         'annotations': {'ann2': 2, 'cs': 26, 'cr': 30},
         'binary_annotations': {'bann2': 'yiss'},
-    }]
+        'sa_endpoint': None,
+    })
 
     transport_handler = mock.Mock()
 
     context = logging_helper.ZipkinLoggingContext(
         zipkin_attrs=attr,
         endpoint=fake_endpoint,
-        log_handler=handler,
         span_name='GET /foo',
         transport_handler=transport_handler,
         report_root_timestamp=True,
+        span_store=span_store,
     )
 
     context.start_timestamp = 24
@@ -139,11 +113,11 @@ def test_zipkin_logging_server_context_log_spans(
     context.binary_annotations_dict = {'k': 'v'}
     time_mock.return_value = 42
 
-    expected_server_annotations = {'foo': 1, 'sr': 24, 'ss': 42}
-    expected_server_bin_annotations = {'k': 'v', 'what': 'whoa'}
+    expected_server_annotations = {'sr': 24, 'ss': 42}
+    expected_server_bin_annotations = {'k': 'v'}
 
-    expected_client_annotations = {'ann1': 1, 'ann2': 2, 'cs': 26, 'cr': 30}
-    expected_client_bin_annotations = {'bann1': 'aww', 'bann2': 'yiss'}
+    expected_client_annotations = {'ann2': 2, 'cs': 26, 'cr': 30}
+    expected_client_bin_annotations = {'bann2': 'yiss'}
 
     context.log_spans()
     client_log_call, server_log_call = add_span_mock.call_args_list
@@ -183,8 +157,7 @@ def test_zipkin_logging_server_context_log_spans_with_firehose(
     add_span_mock, flush_mock, time_mock, fake_endpoint
 ):
     # This lengthy function tests that the logging context properly
-    # logs both client and server spans, while attaching extra annotations
-    # logged throughout the context of the trace.
+    # logs both client and server spans.
     trace_id = '000000000000000f'
     parent_span_id = '0000000000000001'
     server_span_id = '0000000000000002'
@@ -198,29 +171,19 @@ def test_zipkin_logging_server_context_log_spans_with_firehose(
         flags=None,
         is_sampled=True,
     )
-    handler = logging_helper.ZipkinLoggerHandler(attr)
-    extra_server_annotations = {
-        'parent_span_id': None,
-        'annotations': {'foo': 1},
-        'binary_annotations': {'what': 'whoa'},
-    }
-    extra_client_annotations = {
-        'parent_span_id': client_span_id,
-        'annotations': {'ann1': 1},
-        'binary_annotations': {'bann1': 'aww'},
-    }
-    handler.extra_annotations = [
-        extra_server_annotations,
-        extra_client_annotations,
-    ]
-    handler.client_spans = [{
+
+    span_store = SimpleStack()
+
+    span_store.push({
+        'trace_id': trace_id,
         'span_id': client_span_id,
-        'parent_span_id': None,
+        'parent_span_id': server_span_id,
         'span_name': client_span_name,
         'service_name': client_svc_name,
         'annotations': {'ann2': 2, 'cs': 26, 'cr': 30},
         'binary_annotations': {'bann2': 'yiss'},
-    }]
+        'sa_endpoint': None,
+    })
 
     transport_handler = mock.Mock()
     firehose_handler = mock.Mock()
@@ -228,11 +191,11 @@ def test_zipkin_logging_server_context_log_spans_with_firehose(
     context = logging_helper.ZipkinLoggingContext(
         zipkin_attrs=attr,
         endpoint=fake_endpoint,
-        log_handler=handler,
         span_name='GET /foo',
         transport_handler=transport_handler,
         report_root_timestamp=True,
-        firehose_handler=firehose_handler
+        span_store=span_store,
+        firehose_handler=firehose_handler,
     )
 
     context.start_timestamp = 24
@@ -241,11 +204,11 @@ def test_zipkin_logging_server_context_log_spans_with_firehose(
     context.binary_annotations_dict = {'k': 'v'}
     time_mock.return_value = 42
 
-    expected_server_annotations = {'foo': 1, 'sr': 24, 'ss': 42}
-    expected_server_bin_annotations = {'k': 'v', 'what': 'whoa'}
+    expected_server_annotations = {'sr': 24, 'ss': 42}
+    expected_server_bin_annotations = {'k': 'v'}
 
-    expected_client_annotations = {'ann1': 1, 'ann2': 2, 'cs': 26, 'cr': 30}
-    expected_client_bin_annotations = {'bann1': 'aww', 'bann2': 'yiss'}
+    expected_client_annotations = {'ann2': 2, 'cs': 26, 'cr': 30}
+    expected_client_bin_annotations = {'bann2': 'yiss'}
 
     context.log_spans()
     call_args = add_span_mock.call_args_list
@@ -297,19 +260,18 @@ def test_zipkin_logging_client_context_log_spans(
         flags=None,
         is_sampled=True,
     )
-    handler = logging_helper.ZipkinLoggerHandler(attr)
-    handler.client_spans = []
 
+    span_store = SimpleStack()
     transport_handler = mock.Mock()
 
     context = logging_helper.ZipkinLoggingContext(
         zipkin_attrs=attr,
         endpoint=fake_endpoint,
-        log_handler=handler,
         span_name='GET /foo',
         transport_handler=transport_handler,
         report_root_timestamp=True,
-        client_context=True
+        span_store=span_store,
+        client_context=True,
     )
 
     context.start_timestamp = 24
@@ -351,15 +313,16 @@ def test_batch_sender_add_span_not_called_if_not_sampled(add_span_mock,
         flags=None,
         is_sampled=False,
     )
-    log_handler = logging_helper.ZipkinLoggerHandler(attr)
+    span_store = SimpleStack()
     transport_handler = mock.Mock()
+
     context = logging_helper.ZipkinLoggingContext(
         zipkin_attrs=attr,
         endpoint=_encoding_helpers.create_endpoint(80, 'test_server', '127.0.0.1'),
-        log_handler=log_handler,
         span_name='span_name',
         transport_handler=transport_handler,
         report_root_timestamp=False,
+        span_store=span_store,
     )
     context.log_spans()
     assert add_span_mock.call_count == 0
@@ -381,16 +344,17 @@ def test_batch_sender_add_span_not_sampled_with_firehose(add_span_mock,
         flags=None,
         is_sampled=False,
     )
-    log_handler = logging_helper.ZipkinLoggerHandler(attr)
+    span_store = SimpleStack()
     transport_handler = mock.Mock()
     firehose_handler = mock.Mock()
+
     context = logging_helper.ZipkinLoggingContext(
         zipkin_attrs=attr,
         endpoint=_encoding_helpers.create_endpoint(80, 'test_server', '127.0.0.1'),
-        log_handler=log_handler,
         span_name='span_name',
         transport_handler=transport_handler,
         report_root_timestamp=False,
+        span_store=span_store,
         firehose_handler=firehose_handler,
     )
     context.start_timestamp = 24
@@ -402,59 +366,6 @@ def test_batch_sender_add_span_not_sampled_with_firehose(add_span_mock,
     context.log_spans()
     assert add_span_mock.call_count == 1
     assert flush_mock.call_count == 1
-
-
-def test_zipkin_handler_init():
-    handler = logging_helper.ZipkinLoggerHandler('foo')
-    assert handler.zipkin_attrs == 'foo'
-
-
-def test_zipkin_handler_does_not_emit_unsampled_record(unsampled_zipkin_attr):
-    handler = logging_helper.ZipkinLoggerHandler(unsampled_zipkin_attr)
-    assert not handler.emit('bla')
-
-
-def test_handler_stores_client_span_on_emit(sampled_zipkin_attr):
-    record = mock.Mock()
-    record.msg = {
-        'annotations': 'ann1', 'binary_annotations': 'bann1',
-        'name': 'foo', 'service_name': 'blargh',
-    }
-    handler = logging_helper.ZipkinLoggerHandler(sampled_zipkin_attr)
-    assert handler.client_spans == []
-    handler.emit(record)
-    assert handler.client_spans == [{
-        'span_name': 'foo',
-        'service_name': 'blargh',
-        'parent_span_id': None,
-        'span_id': None,
-        'annotations': 'ann1',
-        'binary_annotations': 'bann1',
-        'sa_endpoint': None,
-    }]
-
-
-def test_handler_stores_extra_annotations_on_emit(sampled_zipkin_attr):
-    record = mock.Mock()
-    record.msg = {'annotations': 'ann1', 'binary_annotations': 'bann1'}
-    handler = logging_helper.ZipkinLoggerHandler(sampled_zipkin_attr)
-    assert handler.extra_annotations == []
-    handler.emit(record)
-    assert handler.extra_annotations == [{
-        'annotations': 'ann1',
-        'binary_annotations': 'bann1',
-        'parent_span_id': None,
-    }]
-
-
-def test_zipkin_handler_raises_exception_if_ann_and_bann_not_provided(
-        sampled_zipkin_attr):
-    record = mock.Mock(msg={'name': 'foo'})
-    handler = logging_helper.ZipkinLoggerHandler(sampled_zipkin_attr)
-    with pytest.raises(ZipkinError) as excinfo:
-        handler.emit(record)
-    assert ("At least one of annotation/binary annotation has to be provided"
-            " for foo span" == str(excinfo.value))
 
 
 @mock.patch('py_zipkin.logging_helper.thrift.encode_bytes_list', autospec=True)

--- a/tests/stack_test.py
+++ b/tests/stack_test.py
@@ -1,59 +1,67 @@
 import mock
+import pytest
 
-import py_zipkin.stack
+import py_zipkin.storage
+
+
+@pytest.fixture(autouse=True, scope='module')
+def create_zipkin_attrs():
+    # The following tests all expect _thread_local.zipkin_attrs to exist: if it
+    # doesn't, mock.patch will fail.
+    py_zipkin.storage.ThreadLocalStack().get()
 
 
 @mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', [])
 def test_get_zipkin_attrs_returns_none_if_no_zipkin_attrs():
-    assert not py_zipkin.stack.ThreadLocalStack().get()
-    assert not py_zipkin.stack.ThreadLocalStack().get()
+    assert not py_zipkin.storage.ThreadLocalStack().get()
+    assert not py_zipkin.storage.ThreadLocalStack().get()
 
 
 def test_get_zipkin_attrs_with_context_returns_none_if_no_zipkin_attrs():
-    assert not py_zipkin.stack.Stack([]).get()
+    assert not py_zipkin.storage.Stack([]).get()
 
 
-@mock.patch('py_zipkin.stack.thread_local._thread_local.zipkin_attrs', ['foo'])
+@mock.patch('py_zipkin.storage.thread_local._thread_local.zipkin_attrs', ['foo'])
 def test_get_zipkin_attrs_returns_the_last_of_the_list():
-    assert 'foo' == py_zipkin.stack.ThreadLocalStack().get()
+    assert 'foo' == py_zipkin.storage.ThreadLocalStack().get()
 
 
 def test_get_zipkin_attrs_with_context_returns_the_last_of_the_list():
-    assert 'foo' == py_zipkin.stack.Stack(['bar', 'foo']).get()
+    assert 'foo' == py_zipkin.storage.Stack(['bar', 'foo']).get()
 
 
 @mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', [])
 def test_pop_zipkin_attrs_does_nothing_if_no_requests():
-    assert not py_zipkin.stack.ThreadLocalStack().pop()
+    assert not py_zipkin.storage.ThreadLocalStack().pop()
 
 
 def test_pop_zipkin_attrs_with_context_does_nothing_if_no_requests():
-    assert not py_zipkin.stack.Stack([]).pop()
+    assert not py_zipkin.storage.Stack([]).pop()
 
 
 @mock.patch(
     'py_zipkin.thread_local._thread_local.zipkin_attrs', ['foo', 'bar']
 )
 def test_pop_zipkin_attrs_removes_the_last_zipkin_attrs():
-    assert 'bar' == py_zipkin.stack.ThreadLocalStack().pop()
-    assert 'foo' == py_zipkin.stack.ThreadLocalStack().get()
+    assert 'bar' == py_zipkin.storage.ThreadLocalStack().pop()
+    assert 'foo' == py_zipkin.storage.ThreadLocalStack().get()
 
 
 def test_pop_zipkin_attrs_with_context_removes_the_last_zipkin_attrs():
-    context_stack = py_zipkin.stack.Stack(['foo', 'bar'])
+    context_stack = py_zipkin.storage.Stack(['foo', 'bar'])
     assert 'bar' == context_stack.pop()
     assert 'foo' == context_stack.get()
 
 
 @mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', ['foo'])
 def test_push_zipkin_attrs_adds_new_zipkin_attrs_to_list():
-    assert 'foo' == py_zipkin.stack.ThreadLocalStack().get()
-    py_zipkin.stack.ThreadLocalStack().push('bar')
-    assert 'bar' == py_zipkin.stack.ThreadLocalStack().get()
+    assert 'foo' == py_zipkin.storage.ThreadLocalStack().get()
+    py_zipkin.storage.ThreadLocalStack().push('bar')
+    assert 'bar' == py_zipkin.storage.ThreadLocalStack().get()
 
 
 def test_push_zipkin_attrs_with_context_adds_new_zipkin_attrs_to_list():
-    stack = py_zipkin.stack.Stack(['foo'])
+    stack = py_zipkin.storage.Stack(['foo'])
     assert 'foo' == stack.get()
     stack.push('bar')
     assert 'bar' == stack.get()

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -5,13 +5,17 @@ import pytest
 import py_zipkin.zipkin as zipkin
 from py_zipkin import _encoding_helpers
 from py_zipkin.exception import ZipkinError
-from py_zipkin.logging_helper import null_handler
-from py_zipkin.logging_helper import ZipkinLoggerHandler
 from py_zipkin.stack import ThreadLocalStack
+from py_zipkin.stack import Stack
 from py_zipkin.thread_local import get_zipkin_attrs
 from py_zipkin.util import generate_random_64bit_string
 from py_zipkin.zipkin import ZipkinAttrs
 from tests.conftest import MockTransportHandler
+
+
+class SimpleStack(Stack):
+    def __init__(self):
+        super(SimpleStack, self).__init__([])
 
 
 @pytest.fixture
@@ -24,17 +28,17 @@ def mock_context_stack():
 
 @mock.patch('py_zipkin.zipkin.create_attrs_for_span', autospec=True)
 @mock.patch('py_zipkin.zipkin.create_endpoint')
-@mock.patch('py_zipkin.zipkin.ZipkinLoggerHandler', autospec=True)
 @mock.patch('py_zipkin.zipkin.ZipkinLoggingContext', autospec=True)
 def test_zipkin_span_for_new_trace(
     logging_context_cls_mock,
-    logger_handler_cls_mock,
     create_endpoint_mock,
     create_attrs_for_span_mock,
     mock_context_stack,
 ):
     transport_handler = MockTransportHandler()
     firehose_handler = mock.Mock()
+    span_store = SimpleStack()
+
     with zipkin.zipkin_span(
         service_name='some_service_name',
         span_name='span_name',
@@ -42,10 +46,12 @@ def test_zipkin_span_for_new_trace(
         port=5,
         sample_rate=100.0,
         context_stack=mock_context_stack,
+        span_store_stack=span_store,
         firehose_handler=firehose_handler,
     ) as zipkin_context:
         assert zipkin_context.port == 5
         pass
+
     create_attrs_for_span_mock.assert_called_once_with(
         sample_rate=100.0,
         use_128bit_trace_id=False,
@@ -54,15 +60,13 @@ def test_zipkin_span_for_new_trace(
         create_attrs_for_span_mock.return_value,
     )
     create_endpoint_mock.assert_called_once_with(5, 'some_service_name', None)
-    logger_handler_cls_mock.assert_called_once_with(
-        create_attrs_for_span_mock.return_value)
-    logging_context_cls_mock.assert_called_once_with(
+    assert logging_context_cls_mock.call_args == mock.call(
         create_attrs_for_span_mock.return_value,
         create_endpoint_mock.return_value,
-        logger_handler_cls_mock.return_value,
         'span_name',
         transport_handler,
-        report_root_timestamp=True,
+        True,
+        span_store,
         binary_annotations={},
         add_logging_annotation=False,
         client_context=False,
@@ -74,11 +78,9 @@ def test_zipkin_span_for_new_trace(
 
 @mock.patch('py_zipkin.zipkin.create_attrs_for_span', autospec=True)
 @mock.patch('py_zipkin.zipkin.create_endpoint')
-@mock.patch('py_zipkin.zipkin.ZipkinLoggerHandler', autospec=True)
 @mock.patch('py_zipkin.zipkin.ZipkinLoggingContext', autospec=True)
 def test_zipkin_span_passed_sampled_attrs(
     logging_context_cls_mock,
-    logger_handler_cls_mock,
     create_endpoint_mock,
     create_attrs_for_span_mock,
     mock_context_stack,
@@ -93,6 +95,8 @@ def test_zipkin_span_passed_sampled_attrs(
         flags='0',
         is_sampled=True,
     )
+    span_store = SimpleStack()
+
     with zipkin.zipkin_span(
         service_name='some_service_name',
         span_name='span_name',
@@ -101,21 +105,22 @@ def test_zipkin_span_passed_sampled_attrs(
         sample_rate=100.0,
         zipkin_attrs=zipkin_attrs,
         context_stack=mock_context_stack,
+        span_store_stack=span_store,
     ) as zipkin_context:
         assert zipkin_context.port == 5
+
     assert not create_attrs_for_span_mock.called
     mock_context_stack.push.assert_called_once_with(zipkin_attrs)
     create_endpoint_mock.assert_called_once_with(5, 'some_service_name', None)
-    logger_handler_cls_mock.assert_called_once_with(zipkin_attrs)
     # Logging context should not report timestamp/duration for the server span,
     # since it's assumed that the client part of this span will do that.
     logging_context_cls_mock.assert_called_once_with(
         zipkin_attrs,
         create_endpoint_mock.return_value,
-        logger_handler_cls_mock.return_value,
         'span_name',
         transport_handler,
-        report_root_timestamp=False,
+        False,
+        span_store,
         binary_annotations={},
         add_logging_annotation=False,
         client_context=False,
@@ -128,11 +133,9 @@ def test_zipkin_span_passed_sampled_attrs(
 @pytest.mark.parametrize('firehose_enabled', [True, False])
 @mock.patch('py_zipkin.zipkin.create_attrs_for_span', autospec=True)
 @mock.patch('py_zipkin.zipkin.create_endpoint')
-@mock.patch('py_zipkin.zipkin.ZipkinLoggerHandler', autospec=True)
 @mock.patch('py_zipkin.zipkin.ZipkinLoggingContext', autospec=True)
 def test_zipkin_span_trace_with_0_sample_rate(
     logging_context_cls_mock,
-    logger_handler_cls_mock,
     create_endpoint_mock,
     create_attrs_for_span_mock,
     mock_context_stack,
@@ -146,16 +149,19 @@ def test_zipkin_span_trace_with_0_sample_rate(
         is_sampled=False,
     )
     transport_handler = MockTransportHandler()
+    span_store = SimpleStack()
+
     with zipkin.zipkin_span(
         service_name='some_service_name',
         span_name='span_name',
         transport_handler=transport_handler,
         sample_rate=0.0,
         context_stack=mock_context_stack,
+        span_store_stack=span_store,
         firehose_handler=mock.Mock() if firehose_enabled else None
     ) as zipkin_context:
         assert zipkin_context.port == 0
-        pass
+
     create_attrs_for_span_mock.assert_called_once_with(
         sample_rate=0.0,
         use_128bit_trace_id=False,
@@ -165,7 +171,6 @@ def test_zipkin_span_trace_with_0_sample_rate(
 
     # When firehose mode is on, we log regardless of sample rate
     assert create_endpoint_mock.call_count == (1 if firehose_enabled else 0)
-    assert logger_handler_cls_mock.call_count == (1 if firehose_enabled else 0)
     assert logging_context_cls_mock.call_count == (1 if firehose_enabled else 0)
     mock_context_stack.pop.assert_called_once_with()
 
@@ -233,11 +238,9 @@ def test_zipkin_extraneous_include_raises(mock_zipkin_span, span_func):
 
 @mock.patch('py_zipkin.zipkin.create_attrs_for_span', autospec=True)
 @mock.patch('py_zipkin.zipkin.create_endpoint')
-@mock.patch('py_zipkin.zipkin.ZipkinLoggerHandler', autospec=True)
 @mock.patch('py_zipkin.zipkin.ZipkinLoggingContext', autospec=True)
 def test_zipkin_span_trace_with_no_sampling(
     logging_context_cls_mock,
-    logger_handler_cls_mock,
     create_endpoint_mock,
     create_attrs_for_span_mock,
     mock_context_stack,
@@ -249,6 +252,7 @@ def test_zipkin_span_trace_with_no_sampling(
         flags='0',
         is_sampled=False,
     )
+
     with zipkin.zipkin_span(
         service_name='my_service',
         span_name='span_name',
@@ -256,14 +260,15 @@ def test_zipkin_span_trace_with_no_sampling(
         transport_handler=MockTransportHandler(),
         port=5,
         context_stack=mock_context_stack,
+        span_store_stack=SimpleStack(),
     ):
         pass
+
     assert create_attrs_for_span_mock.call_count == 0
     mock_context_stack.push.assert_called_once_with(
         zipkin_attrs,
     )
     assert create_endpoint_mock.call_count == 0
-    assert logger_handler_cls_mock.call_count == 0
     assert logging_context_cls_mock.call_count == 0
     mock_context_stack.pop.assert_called_once_with()
 
@@ -282,11 +287,9 @@ def test_zipkin_span_with_zipkin_attrs_required_params():
 
 @mock.patch('py_zipkin.zipkin.create_attrs_for_span', autospec=True)
 @mock.patch('py_zipkin.zipkin.create_endpoint')
-@mock.patch('py_zipkin.zipkin.ZipkinLoggerHandler', autospec=True)
 @mock.patch('py_zipkin.zipkin.ZipkinLoggingContext', autospec=True)
 def test_zipkin_trace_context_attrs_is_always_popped(
     logging_context_cls_mock,
-    logger_handler_cls_mock,
     create_endpoint_mock,
     create_attrs_for_span_mock,
     mock_context_stack,
@@ -299,6 +302,7 @@ def test_zipkin_trace_context_attrs_is_always_popped(
             port=22,
             sample_rate=100.0,
             context_stack=mock_context_stack,
+            span_store_stack=SimpleStack()
         ):
             raise Exception
     mock_context_stack.pop.assert_called_once_with()
@@ -342,15 +346,11 @@ def test_span_context_no_zipkin_attrs(mock_context_stack):
     assert not mock_context_stack.push.called
 
 
-@pytest.mark.parametrize('handlers', [[], [null_handler]])
 @mock.patch('py_zipkin.thread_local._thread_local', autospec=True)
 @mock.patch('py_zipkin.zipkin.generate_random_64bit_string', autospec=True)
-@mock.patch('py_zipkin.zipkin.zipkin_logger', autospec=True)
 def test_span_context_sampled_no_handlers(
-    zipkin_logger_mock,
     generate_string_mock,
     thread_local_mock,
-    handlers,
 ):
     zipkin_attrs = ZipkinAttrs(
         trace_id='1111111111111111',
@@ -361,7 +361,6 @@ def test_span_context_sampled_no_handlers(
     )
     thread_local_mock.zipkin_attrs = [zipkin_attrs]
 
-    zipkin_logger_mock.handlers = handlers
     generate_string_mock.return_value = '1'
 
     context = zipkin.zipkin_span(
@@ -387,9 +386,7 @@ def test_span_context_sampled_no_handlers(
 @mock.patch('py_zipkin.thread_local._thread_local', autospec=True)
 @mock.patch('py_zipkin.zipkin.generate_random_64bit_string', autospec=True)
 @mock.patch('py_zipkin.zipkin.generate_random_128bit_string', autospec=True)
-@mock.patch('py_zipkin.zipkin.zipkin_logger', autospec=True)
 def test_span_context(
-    zipkin_logger_mock,
     generate_string_128bit_mock,
     generate_string_mock,
     thread_local_mock,
@@ -404,11 +401,8 @@ def test_span_context(
         is_sampled=True,
     )
     thread_local_mock.zipkin_attrs = [zipkin_attrs]
-    logging_handler = ZipkinLoggerHandler(zipkin_attrs)
-    assert logging_handler.parent_span_id is None
-    assert logging_handler.client_spans == []
+    span_store = SimpleStack()
 
-    zipkin_logger_mock.handlers = [logging_handler]
     generate_string_mock.return_value = '1'
 
     context = span_func(
@@ -416,30 +410,27 @@ def test_span_context(
         span_name='span',
         annotations={'something': 1},
         binary_annotations={'foo': 'bar'},
+        span_store_stack=span_store,
     )
     with context:
         # Assert that the new ZipkinAttrs were saved
         new_zipkin_attrs = get_zipkin_attrs()
         assert new_zipkin_attrs.span_id == '1'
-        # And that the logging handler has a parent_span_id
-        assert logging_handler.parent_span_id == '1'
 
-    # Outside of the context, things should be returned to normal,
-    # except a new client span is saved in the handler
-    assert logging_handler.parent_span_id is None
+    # Outside of the context, things should be returned to normal
     assert get_zipkin_attrs() == zipkin_attrs
 
-    client_span = logging_handler.client_spans.pop()
-    assert logging_handler.client_spans == []
+    client_span = span_store.pop()
     # These reserved annotations are based on timestamps so pop em.
     # This also acts as a check that they exist.
     for annotation in expected_annotations:
         client_span['annotations'].pop(annotation)
 
     expected_client_span = {
+        'trace_id': '1111111111111111',
         'span_name': 'span',
         'service_name': 'svc',
-        'parent_span_id': None,
+        'parent_span_id': '2222222222222222',
         'span_id': '1',
         'annotations': {'something': 1},
         'binary_annotations': {'foo': 'bar'},
@@ -452,16 +443,15 @@ def test_span_context(
 
 @mock.patch('py_zipkin.zipkin.create_attrs_for_span', autospec=True)
 @mock.patch('py_zipkin.zipkin.create_endpoint')
-@mock.patch('py_zipkin.zipkin.ZipkinLoggerHandler', autospec=True)
 @mock.patch('py_zipkin.zipkin.ZipkinLoggingContext', autospec=True)
 def test_zipkin_server_span_decorator(
     logging_context_cls_mock,
-    logger_handler_cls_mock,
     create_endpoint_mock,
     create_attrs_for_span_mock,
     mock_context_stack,
 ):
     transport_handler = MockTransportHandler()
+    span_store = SimpleStack()
 
     @zipkin.zipkin_span(
         service_name='some_service_name',
@@ -471,6 +461,7 @@ def test_zipkin_server_span_decorator(
         sample_rate=100.0,
         host='1.5.1.2',
         context_stack=mock_context_stack,
+        span_store_stack=span_store,
     )
     def test_func(a, b):
         return a + b
@@ -485,18 +476,15 @@ def test_zipkin_server_span_decorator(
         create_attrs_for_span_mock.return_value,
     )
     create_endpoint_mock.assert_called_once_with(5, 'some_service_name', '1.5.1.2')
-    logger_handler_cls_mock.assert_called_once_with(
-        create_attrs_for_span_mock.return_value,
-    )
     # The decorator was passed a sample rate and no Zipkin attrs, so it's
     # assumed to be the root of a trace and it should report timestamp/duration
-    logging_context_cls_mock.assert_called_once_with(
+    assert logging_context_cls_mock.call_args == mock.call(
         create_attrs_for_span_mock.return_value,
         create_endpoint_mock.return_value,
-        logger_handler_cls_mock.return_value,
         'span_name',
         transport_handler,
-        report_root_timestamp=True,
+        True,
+        span_store,
         binary_annotations={},
         add_logging_annotation=False,
         client_context=False,
@@ -508,16 +496,15 @@ def test_zipkin_server_span_decorator(
 
 @mock.patch('py_zipkin.zipkin.create_attrs_for_span', autospec=True)
 @mock.patch('py_zipkin.zipkin.create_endpoint')
-@mock.patch('py_zipkin.zipkin.ZipkinLoggerHandler', autospec=True)
 @mock.patch('py_zipkin.zipkin.ZipkinLoggingContext', autospec=True)
 def test_zipkin_client_span_decorator(
     logging_context_cls_mock,
-    logger_handler_cls_mock,
     create_endpoint_mock,
     create_attrs_for_span_mock,
     mock_context_stack,
 ):
     transport_handler = MockTransportHandler()
+    span_store = SimpleStack()
 
     @zipkin.zipkin_span(
         service_name='some_service_name',
@@ -528,6 +515,7 @@ def test_zipkin_client_span_decorator(
         include=('client',),
         host='1.5.1.2',
         context_stack=mock_context_stack,
+        span_store_stack=span_store,
     )
     def test_func(a, b):
         return a + b
@@ -542,17 +530,15 @@ def test_zipkin_client_span_decorator(
         create_attrs_for_span_mock.return_value,
     )
     create_endpoint_mock.assert_called_once_with(5, 'some_service_name', '1.5.1.2')
-    logger_handler_cls_mock.assert_called_once_with(
-        create_attrs_for_span_mock.return_value)
     # The decorator was passed a sample rate and no Zipkin attrs, so it's
     # assumed to be the root of a trace and it should report timestamp/duration
-    logging_context_cls_mock.assert_called_once_with(
+    assert logging_context_cls_mock.call_args == mock.call(
         create_attrs_for_span_mock.return_value,
         create_endpoint_mock.return_value,
-        logger_handler_cls_mock.return_value,
         'span_name',
         transport_handler,
-        report_root_timestamp=True,
+        True,
+        span_store,
         binary_annotations={},
         add_logging_annotation=False,
         client_context=True,


### PR DESCRIPTION
The logging handler interface is deprecated and no one is using it anyway. It also complicates the code quite a lot, so let's get rid of it.

`py_zipkin/logging_helper.py` is now way shorter and much more understandable.

## Main changes
### span_store
The main issue that came up is that until now we stored "client" spans in the logging_handler, which won't be possible anymore. We still need a global singleton storage, so I added a second thread local list.

Also since the new store doesn't go out of scope with the root span, we need to wipe it at the end of `stop`.

### [binary_]annotations_by_span_id
The old code allowed you to set extra annotations via the logging_handler. That would only ever happen if we used the `debug` function (which no one uses), so removing it should be fine.

## Other changes
### span_id, trace_id and parent_span_id
The code was doing something weird with parent_span_id. It was saving it in logger_handler and setting them afterwards with some complicated logic. I can't think of a (still existing) use case for that so I just put the parent_span_id and the trace_id directly into the span dict we're creating.

### Stack is now iterable
We don't want to pop elements out of span_store, since both the firehose handler and the transport handler need to iterate through it. So I made Stack iterable, with the drawback that we have to clear it once we're done.

cc @sjaensch. You guys will probably need to pass a custom `span_store_stack` as well if you upgrade your py_zipkin version.