### PR TITLE
Internal span refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     env: TOXENV=py36
   - python: 2.7
     env: TOXENV=flake8
+before_install: pip install -U pip==18.0
 install: pip install tox coveralls
 script: tox
 after_success: coveralls

--- a/py_zipkin/__init__.py
+++ b/py_zipkin/__init__.py
@@ -1,0 +1,8 @@
+# DeprecationWarnings are silent since Python 2.7.
+# The `default` filter only prints the first occurrence of matching warnings for
+# each location where the warning is issued, so that we don't spam our users logs.
+import warnings
+warnings.simplefilter('default', DeprecationWarning)
+
+# Export useful functions and types from private modules.
+from py_zipkin._encoding_helpers import Kind  # noqa

--- a/py_zipkin/_encoding_helpers.py
+++ b/py_zipkin/_encoding_helpers.py
@@ -1,10 +1,141 @@
 import socket
 from collections import namedtuple
 
+from enum import Enum
+
+from py_zipkin.exception import ZipkinError
+
+
 Endpoint = namedtuple(
     'Endpoint',
     ['service_name', 'ipv4', 'ipv6', 'port'],
 )
+
+
+_V1Span = namedtuple(
+    'V1Span',
+    ['trace_id', 'name', 'parent_id', 'id', 'timestamp', 'duration', 'endpoint',
+     'debug', 'annotations', 'binary_annotations', 'sa_endpoint'],
+)
+
+
+class Kind(Enum):
+    CLIENT = 'CLIENT'
+    SERVER = 'SERVER'
+    LOCAL = None
+
+
+_DROP_ANNOTATIONS_BY_KIND = {
+    Kind.CLIENT: {'ss', 'sr'},
+    Kind.SERVER: {'cs', 'cr'},
+}
+
+
+class SpanBuilder(object):
+    def __init__(
+        self,
+        trace_id,
+        name,
+        parent_id,
+        span_id,
+        timestamp,
+        duration,
+        annotations,
+        tags,
+        kind,
+        local_endpoint=None,
+        service_name=None,
+        sa_endpoint=None,
+        report_timestamp=True,
+    ):
+        """Internal Span representation. It can generate both v1 and v2 spans.
+
+        It doesn't exactly map to either V1 or V2, since an intermediate format
+        makes it easier to convert to either format.
+
+        :param trace_id: Trace id.
+        :type trace_id: str
+        :param name: Name of the span.
+        :type name: str
+        :param parent_id: Parent span id.
+        :type parent_id: str
+        :param span_id: Span id.
+        :type span_id: str
+        :param timestamp: start timestamp in seconds.
+        :type timestamp: float
+        :param duration: span duration in seconds.
+        :type duration: float
+        :param annotations: Optional dict of str -> timestamp annotations.
+        :type annotations: dict
+        :param tags: Optional dict of str -> str span tags.
+        :type tags: dict
+        :param kind: Span type (client, server, local, etc...)
+        :type kind: Kind
+        :param local_endpoint: The host that recorded this span.
+        :type local_endpoint: Endpoint
+        :param service_name: The name of the called service
+        :type service_name: str
+        :param sa_endpoint: Remote server in client spans.
+        :type sa_endpoint: Endpoint
+        :param report_timestamp: Whether the span should report
+            timestamp and duration.
+        :type report_timestamp: bool
+        """
+        self.trace_id = trace_id
+        self.name = name
+        self.parent_id = parent_id
+        self.span_id = span_id
+        self.kind = kind
+        self.timestamp = timestamp
+        self.duration = duration
+        self.annotations = annotations
+        self.tags = tags
+        self.local_endpoint = local_endpoint
+        self.service_name = service_name
+        self.sa_endpoint = sa_endpoint
+        self.report_timestamp = report_timestamp
+
+        if kind is not None and not isinstance(kind, Kind):
+            raise ZipkinError(
+                'Invalid kind value {}. Must be of type Kind.'.format(kind))
+
+    def build_v1_span(self):
+        """Converts the current span to a V1 Span.
+
+        :returns: newly generated _V1Span
+        """
+        # We are simulating a full two-part span locally, so set cs=sr and ss=cr
+        full_annotations = {
+            'cs': self.timestamp,
+            'sr': self.timestamp,
+            'ss': self.timestamp + self.duration,
+            'cr': self.timestamp + self.duration,
+        }
+
+        if self.kind != Kind.LOCAL:
+            # If kind is not LOCAL, then we only want client or
+            # server side annotations.
+            for ann in _DROP_ANNOTATIONS_BY_KIND[self.kind]:
+                del full_annotations[ann]
+
+        # Add user-defined annotations. We write them in full_annotations
+        # instead of the opposite so that user annotations will override
+        # any automatically generated annotation.
+        full_annotations.update(self.annotations)
+
+        return _V1Span(
+            trace_id=self.trace_id,
+            name=self.name,
+            parent_id=self.parent_id,
+            id=self.span_id,
+            timestamp=self.timestamp if self.report_timestamp else None,
+            duration=self.duration if self.report_timestamp else None,
+            endpoint=self.local_endpoint,
+            debug=False,
+            annotations=full_annotations,
+            binary_annotations=self.tags,
+            sa_endpoint=self.sa_endpoint,
+        )
 
 
 def create_endpoint(port=0, service_name='unknown', host=None):

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     packages=find_packages(exclude=('tests*', 'testing*', 'tools*')),
     package_data={'': ['*.thrift']},
     install_requires=[
+        'enum34;python_version<"3.4"',
         'six',
         'thriftpy',
     ],

--- a/tests/integration/zipkin_integration_test.py
+++ b/tests/integration/zipkin_integration_test.py
@@ -3,6 +3,7 @@ from thriftpy.protocol.binary import read_list_begin
 from thriftpy.protocol.binary import TBinaryProtocol
 from thriftpy.transport import TMemoryBuffer
 
+from py_zipkin import Kind
 from py_zipkin import zipkin
 from py_zipkin.logging_helper import LOGGING_END_KEY
 from py_zipkin.thrift import zipkin_core
@@ -187,6 +188,57 @@ def test_annotation_override():
                 assert ann.timestamp == 100 * USECS
             elif ann.value == 'cr':
                 assert ann.timestamp == 300 * USECS
+
+    check_spans(_decode_binary_thrift_objs(mock_logs[0]))
+    check_spans(_decode_binary_thrift_objs(mock_firehose_logs[0]))
+
+
+def test_sr_ss_annotation_override():
+    """This is the same as above, but we override an annotation
+    in the inner span
+    """
+    mock_transport_handler, mock_logs = mock_logger()
+    mock_firehose_handler, mock_firehose_logs = mock_logger()
+    with zipkin.zipkin_span(
+        service_name='test_service_name',
+        span_name='test_span_name',
+        transport_handler=mock_transport_handler,
+        sample_rate=100.0,
+        binary_annotations={'some_key': 'some_value'},
+        firehose_handler=mock_firehose_handler,
+    ):
+        with zipkin.zipkin_span(
+            service_name='nested_service',
+            span_name='nested_span',
+            annotations={'nested_annotation': 43, 'sr': 100, 'ss': 300},
+            binary_annotations={'nested_key': 'nested_value'},
+            kind=Kind.SERVER,
+        ):
+            pass
+
+    def check_spans(spans):
+        nested_span = spans[0]
+        root_span = spans[1]
+        assert nested_span.name == 'nested_span'
+        assert nested_span.annotations[0].host.service_name == 'nested_service'
+        assert nested_span.parent_id == root_span.id
+        assert nested_span.binary_annotations[0].key == 'nested_key'
+        assert nested_span.binary_annotations[0].value == 'nested_value'
+        # Local nested spans report timestamp and duration
+        assert nested_span.timestamp == 100 * USECS
+        assert nested_span.duration == 200 * USECS
+        assert len(nested_span.annotations) == 3
+        assert set([ann.value for ann in nested_span.annotations]) == set([
+            'ss', 'sr', 'nested_annotation'])
+        for ann in nested_span.annotations:
+            if ann.value == 'nested_annotation':
+                assert ann.timestamp == 43 * USECS
+            elif ann.value == 'sr':
+                assert ann.timestamp == 100 * USECS
+            elif ann.value == 'ss':
+                assert ann.timestamp == 300 * USECS
+            else:
+                raise ValueError('unexpected annotation {}'.format(ann))
 
     check_spans(_decode_binary_thrift_objs(mock_logs[0]))
     check_spans(_decode_binary_thrift_objs(mock_firehose_logs[0]))
@@ -396,3 +448,134 @@ def test_no_sampling_with_inner_span():
 
     assert len(mock_logs) == 0
     check_spans(_decode_binary_thrift_objs(mock_firehose_logs[0]))
+
+
+def test_client_span():
+    mock_transport_handler, mock_logs = mock_logger()
+    with zipkin.zipkin_client_span(
+        service_name='test_service_name',
+        span_name='test_span_name',
+        transport_handler=mock_transport_handler,
+        sample_rate=100.0,
+        binary_annotations={'some_key': 'some_value'},
+        add_logging_annotation=True,
+    ):
+        pass
+
+    def check_spans(spans):
+        client_span = spans[0]
+        assert client_span.name == 'test_span_name'
+        assert client_span.annotations[0].host.service_name == 'test_service_name'
+        assert client_span.binary_annotations[0].key == 'some_key'
+        assert client_span.binary_annotations[0].value == 'some_value'
+        assert client_span.timestamp is not None
+        assert client_span.duration is not None
+        assert len(client_span.annotations) == 3
+        assert set([ann.value for ann in client_span.annotations]) == {
+            'cs', 'cr', 'py_zipkin.logging_end'}
+
+    assert len(mock_logs) == 1
+    check_spans(_decode_binary_thrift_objs(mock_logs[0]))
+
+
+def test_server_span():
+    mock_transport_handler, mock_logs = mock_logger()
+    with zipkin.zipkin_server_span(
+        service_name='test_service_name',
+        span_name='test_span_name',
+        transport_handler=mock_transport_handler,
+        sample_rate=100.0,
+        binary_annotations={'some_key': 'some_value'},
+        add_logging_annotation=True,
+    ):
+        with zipkin.zipkin_client_span(
+            service_name='nested_service',
+            span_name='nested_span',
+            annotations={'nested_annotation': 43},
+            binary_annotations={'nested_key': 'nested_value'},
+        ):
+            pass
+
+        pass
+
+    def check_spans(spans):
+        client_span = spans[0]
+        server_span = spans[1]
+        assert server_span.name == 'test_span_name'
+        assert server_span.annotations[0].host.service_name == 'test_service_name'
+        assert server_span.binary_annotations[0].key == 'some_key'
+        assert server_span.binary_annotations[0].value == 'some_value'
+        # Local nested spans report timestamp and duration
+        assert server_span.timestamp is not None
+        assert server_span.duration is not None
+        assert len(server_span.annotations) == 3
+        assert set([ann.value for ann in server_span.annotations]) == {
+            'ss', 'sr', 'py_zipkin.logging_end'}
+
+        assert client_span.name == 'nested_span'
+        assert client_span.annotations[0].host.service_name == 'nested_service'
+        assert client_span.binary_annotations[0].key == 'nested_key'
+        assert client_span.binary_annotations[0].value == 'nested_value'
+        # Local nested spans report timestamp and duration
+        assert client_span.timestamp is not None
+        assert client_span.duration is not None
+        assert len(client_span.annotations) == 3
+        assert set([ann.value for ann in client_span.annotations]) == {
+            'cs', 'cr', 'nested_annotation'}
+
+    assert len(mock_logs) == 1
+    check_spans(_decode_binary_thrift_objs(mock_logs[0]))
+
+
+def test_include_still_works():
+    mock_transport_handler, mock_logs = mock_logger()
+    with zipkin.zipkin_span(
+        service_name='test_service_name',
+        span_name='test_span_name',
+        transport_handler=mock_transport_handler,
+        sample_rate=100.0,
+        binary_annotations={'some_key': 'some_value'},
+        add_logging_annotation=True,
+    ):
+        with zipkin.zipkin_span(
+            service_name='nested_service',
+            span_name='nested_span',
+            annotations={'nested_annotation': 43},
+            binary_annotations={'nested_key': 'nested_value'},
+            include={'client'},
+        ):
+            pass
+        with zipkin.zipkin_span(
+            service_name='nested_service',
+            span_name='nested_span',
+            annotations={'nested_annotation': 43},
+            binary_annotations={'nested_key': 'nested_value'},
+            include={'server'},
+        ):
+            pass
+        with zipkin.zipkin_span(
+            service_name='nested_service',
+            span_name='nested_span',
+            annotations={'nested_annotation': 43},
+            binary_annotations={'nested_key': 'nested_value'},
+            include={'client', 'server'},
+        ):
+            pass
+        pass
+
+    def check_spans(spans):
+        client_span = spans[0]
+        server_span = spans[1]
+        local_span = spans[2]
+        assert len(client_span.annotations) == 3
+        assert set([ann.value for ann in client_span.annotations]) == {
+            'cs', 'cr', 'nested_annotation'}
+        assert len(server_span.annotations) == 3
+        assert set([ann.value for ann in server_span.annotations]) == {
+            'ss', 'sr', 'nested_annotation'}
+        assert len(local_span.annotations) == 5
+        assert set([ann.value for ann in local_span.annotations]) == {
+            'cs', 'cr', 'ss', 'sr', 'nested_annotation'}
+
+    assert len(mock_logs) == 1
+    check_spans(_decode_binary_thrift_objs(mock_logs[0]))

--- a/tests/logging_helper_test.py
+++ b/tests/logging_helper_test.py
@@ -3,6 +3,8 @@ import pytest
 
 from py_zipkin import _encoding_helpers
 from py_zipkin import logging_helper
+from py_zipkin import Kind
+from py_zipkin._encoding_helpers import SpanBuilder
 from py_zipkin.exception import ZipkinError
 from py_zipkin.storage import SpanStorage
 from py_zipkin.zipkin import ZipkinAttrs
@@ -18,7 +20,8 @@ def context():
         span_name='span_name',
         transport_handler=MockTransportHandler(),
         report_root_timestamp=False,
-        span_storage=SpanStorage()
+        span_storage=SpanStorage(),
+        service_name='test_server',
     )
 
 
@@ -80,16 +83,19 @@ def test_zipkin_logging_server_context_emit_spans(
     )
     span_storage = SpanStorage()
 
-    span_storage.append({
-        'trace_id': trace_id,
-        'span_id': client_span_id,
-        'parent_span_id': server_span_id,
-        'span_name': client_span_name,
-        'service_name': client_svc_name,
-        'annotations': {'ann2': 2, 'cs': 26, 'cr': 30},
-        'binary_annotations': {'bann2': 'yiss'},
-        'sa_endpoint': None,
-    })
+    client_span = SpanBuilder(
+        trace_id=trace_id,
+        name=client_span_name,
+        parent_id=server_span_id,
+        span_id=client_span_id,
+        timestamp=26.0,
+        duration=4.0,
+        annotations={'ann2': 2, 'cs': 26, 'cr': 30},
+        tags={'bann2': 'yiss'},
+        kind=Kind.CLIENT,
+        service_name=client_svc_name,
+    )
+    span_storage.append(client_span)
 
     transport_handler = mock.Mock()
 
@@ -100,6 +106,7 @@ def test_zipkin_logging_server_context_emit_spans(
         transport_handler=transport_handler,
         report_root_timestamp=True,
         span_storage=span_storage,
+        service_name='test_server',
     )
 
     context.start_timestamp = 24
@@ -108,38 +115,22 @@ def test_zipkin_logging_server_context_emit_spans(
     context.binary_annotations_dict = {'k': 'v'}
     time_mock.return_value = 42
 
-    expected_server_annotations = {'sr': 24, 'ss': 42}
-    expected_server_bin_annotations = {'k': 'v'}
-
-    expected_client_annotations = {'ann2': 2, 'cs': 26, 'cr': 30}
-    expected_client_bin_annotations = {'bann2': 'yiss'}
-
     context.emit_spans()
     client_log_call, server_log_call = add_span_mock.call_args_list
-    assert server_log_call[1] == {
-        'span_id': server_span_id,
-        'parent_span_id': parent_span_id,
-        'trace_id': trace_id,
-        'span_name': 'GET /foo',
-        'annotations': expected_server_annotations,
-        'binary_annotations': expected_server_bin_annotations,
-        'duration_s': 18,
-        'timestamp_s': 24,
-        'endpoint': fake_endpoint,
-        'sa_endpoint': None,
-    }
-    assert client_log_call[1] == {
-        'span_id': client_span_id,
-        'parent_span_id': server_span_id,
-        'trace_id': trace_id,
-        'span_name': client_span_name,
-        'annotations': expected_client_annotations,
-        'binary_annotations': expected_client_bin_annotations,
-        'duration_s': 4,
-        'timestamp_s': 26,
-        'endpoint': _encoding_helpers.create_endpoint(80, 'svc', '127.0.0.1'),
-        'sa_endpoint': None,
-    }
+    assert server_log_call[0][1].build_v1_span() == SpanBuilder(
+        trace_id=trace_id,
+        name='GET /foo',
+        parent_id=parent_span_id,
+        span_id=server_span_id,
+        timestamp=24.0,
+        duration=18.0,
+        annotations={'sr': 24, 'ss': 42},
+        tags={'k': 'v'},
+        kind=Kind.SERVER,
+        service_name=client_svc_name,
+        local_endpoint=fake_endpoint,
+    ).build_v1_span()
+    assert client_log_call[0][1] == client_span
     assert flush_mock.call_count == 1
 
 
@@ -169,16 +160,19 @@ def test_zipkin_logging_server_context_emit_spans_with_firehose(
 
     span_storage = SpanStorage()
 
-    span_storage.append({
-        'trace_id': trace_id,
-        'span_id': client_span_id,
-        'parent_span_id': server_span_id,
-        'span_name': client_span_name,
-        'service_name': client_svc_name,
-        'annotations': {'ann2': 2, 'cs': 26, 'cr': 30},
-        'binary_annotations': {'bann2': 'yiss'},
-        'sa_endpoint': None,
-    })
+    client_span = SpanBuilder(
+        trace_id=trace_id,
+        name=client_span_name,
+        parent_id=server_span_id,
+        span_id=client_span_id,
+        timestamp=26.0,
+        duration=4.0,
+        annotations={'ann2': 2, 'cs': 26, 'cr': 30},
+        tags={'bann2': 'yiss'},
+        kind=Kind.CLIENT,
+        service_name=client_svc_name,
+    )
+    span_storage.append(client_span)
 
     transport_handler = mock.Mock()
     firehose_handler = mock.Mock()
@@ -191,6 +185,7 @@ def test_zipkin_logging_server_context_emit_spans_with_firehose(
         report_root_timestamp=True,
         span_storage=span_storage,
         firehose_handler=firehose_handler,
+        service_name='test_server',
     )
 
     context.start_timestamp = 24
@@ -199,40 +194,26 @@ def test_zipkin_logging_server_context_emit_spans_with_firehose(
     context.binary_annotations_dict = {'k': 'v'}
     time_mock.return_value = 42
 
-    expected_server_annotations = {'sr': 24, 'ss': 42}
-    expected_server_bin_annotations = {'k': 'v'}
-
-    expected_client_annotations = {'ann2': 2, 'cs': 26, 'cr': 30}
-    expected_client_bin_annotations = {'bann2': 'yiss'}
-
     context.emit_spans()
     call_args = add_span_mock.call_args_list
     firehose_client_log_call, client_log_call = call_args[0], call_args[2]
     firehose_server_log_call, server_log_call = call_args[1], call_args[3]
-    assert server_log_call[1] == firehose_server_log_call[1] == {
-        'span_id': server_span_id,
-        'parent_span_id': parent_span_id,
-        'trace_id': trace_id,
-        'span_name': 'GET /foo',
-        'annotations': expected_server_annotations,
-        'binary_annotations': expected_server_bin_annotations,
-        'duration_s': 18,
-        'timestamp_s': 24,
-        'endpoint': fake_endpoint,
-        'sa_endpoint': None,
-    }
-    assert client_log_call[1] == firehose_client_log_call[1] == {
-        'span_id': client_span_id,
-        'parent_span_id': server_span_id,
-        'trace_id': trace_id,
-        'span_name': client_span_name,
-        'annotations': expected_client_annotations,
-        'binary_annotations': expected_client_bin_annotations,
-        'duration_s': 4,
-        'timestamp_s': 26,
-        'endpoint': _encoding_helpers.create_endpoint(80, 'svc', '127.0.0.1'),
-        'sa_endpoint': None,
-    }
+    assert server_log_call[0][1].build_v1_span() == \
+        firehose_server_log_call[0][1].build_v1_span()
+    assert server_log_call[0][1].build_v1_span() == SpanBuilder(
+        trace_id=trace_id,
+        name='GET /foo',
+        parent_id=parent_span_id,
+        span_id=server_span_id,
+        timestamp=24.0,
+        duration=18.0,
+        annotations={'sr': 24, 'ss': 42},
+        tags={'k': 'v'},
+        kind=Kind.SERVER,
+        service_name=client_svc_name,
+        local_endpoint=fake_endpoint,
+    ).build_v1_span()
+    assert client_log_call[0][1] == firehose_client_log_call[0][1] == client_span
     assert flush_mock.call_count == 2
 
 
@@ -267,6 +248,7 @@ def test_zipkin_logging_client_context_emit_spans(
         report_root_timestamp=True,
         span_storage=span_storage,
         client_context=True,
+        service_name='test_server',
     )
 
     context.start_timestamp = 24
@@ -275,23 +257,21 @@ def test_zipkin_logging_client_context_emit_spans(
     context.binary_annotations_dict = {'k': 'v'}
     time_mock.return_value = 42
 
-    expected_server_annotations = {'cs': 24, 'cr': 42}
-    expected_server_bin_annotations = {'k': 'v'}
-
     context.emit_spans()
     log_call = add_span_mock.call_args_list[0]
-    assert log_call[1] == {
-        'span_id': client_span_id,
-        'parent_span_id': None,
-        'trace_id': trace_id,
-        'span_name': 'GET /foo',
-        'annotations': expected_server_annotations,
-        'binary_annotations': expected_server_bin_annotations,
-        'duration_s': 18,
-        'timestamp_s': 24,
-        'endpoint': fake_endpoint,
-        'sa_endpoint': None,
-    }
+    assert log_call[0][1].build_v1_span() == SpanBuilder(
+        trace_id=trace_id,
+        name='GET /foo',
+        parent_id=None,
+        span_id=client_span_id,
+        timestamp=24.0,
+        duration=18.0,
+        annotations={'cs': 24, 'cr': 42},
+        tags={'k': 'v'},
+        kind=Kind.CLIENT,
+        service_name='test_server',
+        local_endpoint=fake_endpoint,
+    ).build_v1_span()
     assert flush_mock.call_count == 1
 
 
@@ -318,6 +298,7 @@ def test_batch_sender_add_span_not_called_if_not_sampled(add_span_mock,
         transport_handler=transport_handler,
         report_root_timestamp=False,
         span_storage=span_storage,
+        service_name='test_server',
     )
     context.emit_spans()
     assert add_span_mock.call_count == 0
@@ -351,6 +332,7 @@ def test_batch_sender_add_span_not_sampled_with_firehose(add_span_mock,
         report_root_timestamp=False,
         span_storage=span_storage,
         firehose_handler=firehose_handler,
+        service_name='test_server',
     )
     context.start_timestamp = 24
     context.response_status_code = 200
@@ -375,18 +357,19 @@ def test_batch_sender_add_span(
     # triggers a flush of all the already added spans.
     sender = logging_helper.ZipkinBatchSender(MockTransportHandler())
     with sender:
-        sender.add_span(
-            span_id='0000000000000002',
-            parent_span_id='0000000000000001',
+        sender.add_span(SpanBuilder(
             trace_id='000000000000000f',
-            span_name='span',
+            name='span',
+            parent_id='0000000000000001',
+            span_id='0000000000000002',
+            timestamp=26.0,
+            duration=4.0,
             annotations=empty_annotations_dict,
-            binary_annotations=empty_binary_annotations_dict,
-            timestamp_s=None,
-            duration_s=None,
-            endpoint=fake_endpoint,
-            sa_endpoint=None,
-        )
+            tags=empty_binary_annotations_dict,
+            kind=Kind.CLIENT,
+            local_endpoint=fake_endpoint,
+            service_name='test_service',
+        ))
     assert mock_encode_bytes_list.call_count == 1
 
 
@@ -410,18 +393,21 @@ def test_batch_sender_add_span_many_times(
     max_portion_size = logging_helper.ZipkinBatchSender.MAX_PORTION_SIZE
     with sender:
         for _ in range(max_portion_size * 2 + 1):
-            sender.add_span(
-                span_id='0000000000000002',
-                parent_span_id='0000000000000001',
+            sender.add_span(SpanBuilder(
                 trace_id='000000000000000f',
-                span_name='span',
+                name='span',
+                parent_id='0000000000000001',
+                span_id='0000000000000002',
+                timestamp=26.0,
+                duration=4.0,
                 annotations=empty_annotations_dict,
-                binary_annotations=empty_binary_annotations_dict,
-                timestamp_s=None,
-                duration_s=None,
-                endpoint=fake_endpoint,
-                sa_endpoint=None,
-            )
+                tags=empty_binary_annotations_dict,
+                kind=Kind.CLIENT,
+                local_endpoint=fake_endpoint,
+                service_name='test_service',
+                report_timestamp=False,
+            ))
+
     assert mock_encode_bytes_list.call_count == 3
     assert len(mock_encode_bytes_list.call_args_list[0][0][0]) == max_portion_size
     assert len(mock_encode_bytes_list.call_args_list[1][0][0]) == max_portion_size
@@ -434,33 +420,36 @@ def test_batch_sender_add_span_too_big(
     fake_endpoint,
 ):
     # This time we set max_payload_bytes to 1000, so we have to send more batches.
-    # Each encoded span is 65 bytes, so we can fit 15 of those in 1000 bytes.
+    # Each encoded span is 175 bytes, so we can fit 5 of those in 1000 bytes.
     mock_transport_handler = mock.Mock(spec=MockTransportHandler)
     mock_transport_handler.get_max_payload_bytes = lambda: 1000
     sender = logging_helper.ZipkinBatchSender(mock_transport_handler, 100)
     with sender:
         for _ in range(201):
-            sender.add_span(
-                span_id='0000000000000002',
-                parent_span_id='0000000000000001',
+            sender.add_span(SpanBuilder(
                 trace_id='000000000000000f',
-                span_name='span',
+                name='span',
+                parent_id='0000000000000001',
+                span_id='0000000000000002',
+                timestamp=26.0,
+                duration=4.0,
                 annotations=empty_annotations_dict,
-                binary_annotations=empty_binary_annotations_dict,
-                timestamp_s=None,
-                duration_s=None,
-                endpoint=fake_endpoint,
-                sa_endpoint=None,
-            )
-    # 15 spans per batch, means we need 201 / 15 = 14 batches to send them all.
-    assert mock_transport_handler.call_count == 14
-    for i in range(13):
-        # The first 13 batches have 15 spans of 65 bytes + 5 bytes of
-        # list headers = 980 bytes
-        assert len(mock_transport_handler.call_args_list[i][0][0]) == 980
-    # The last batch has the 6 remaining spans of 65 bytes + 5 bytes of
-    # list headers = 395 bytes
-    assert len(mock_transport_handler.call_args_list[13][0][0]) == 395
+                tags=empty_binary_annotations_dict,
+                kind=Kind.CLIENT,
+                local_endpoint=fake_endpoint,
+                service_name='test_service',
+                report_timestamp=False,
+            ))
+
+    # 5 spans per batch, means we need 201 / 4 = 41 batches to send them all.
+    assert mock_transport_handler.call_count == 41
+    for i in range(40):
+        # The first 40 batches have 5 spans of 175 bytes + 5 bytes of
+        # list headers = 880 bytes
+        assert len(mock_transport_handler.call_args_list[i][0][0]) == 880
+    # The last batch has a single remaining span of 175 bytes + 5 bytes of
+    # list headers = 180 bytes
+    assert len(mock_transport_handler.call_args_list[40][0][0]) == 180
 
 
 @mock.patch('py_zipkin.logging_helper.thrift.encode_bytes_list', autospec=True)
@@ -476,18 +465,20 @@ def test_batch_sender_flush_calls_transport_handler_with_correct_params(
     transport_handler.get_max_payload_bytes = lambda: None
     sender = logging_helper.ZipkinBatchSender(transport_handler)
     with sender:
-        sender.add_span(
-            span_id='0000000000000002',
-            parent_span_id='0000000000000001',
+        sender.add_span(SpanBuilder(
             trace_id='000000000000000f',
-            span_name='span',
+            name='span',
+            parent_id='0000000000000001',
+            span_id='0000000000000002',
+            timestamp=26.0,
+            duration=4.0,
             annotations=empty_annotations_dict,
-            binary_annotations=empty_binary_annotations_dict,
-            timestamp_s=None,
-            duration_s=None,
-            endpoint=fake_endpoint,
-            sa_endpoint=None,
-        )
+            tags=empty_binary_annotations_dict,
+            kind=Kind.CLIENT,
+            local_endpoint=fake_endpoint,
+            service_name='test_service',
+            report_timestamp=False,
+        ))
     transport_handler.assert_called_once_with(mock_encode_bytes_list.return_value)
 
 
@@ -504,41 +495,19 @@ def test_batch_sender_defensive_about_transport_handler(
     None."""
     sender = logging_helper.ZipkinBatchSender(transport_handler=None)
     with sender:
-        sender.add_span(
+        sender.add_span(SpanBuilder(
+            trace_id='000000000000000f',
+            name='span',
+            parent_id='0000000000000001',
             span_id='0000000000000002',
-            parent_span_id='0000000000000001',
-            trace_id='00000000000000015',
-            span_name='span',
+            timestamp=26.0,
+            duration=4.0,
             annotations=empty_annotations_dict,
-            binary_annotations=empty_binary_annotations_dict,
-            timestamp_s=None,
-            duration_s=None,
-            endpoint=fake_endpoint,
-            sa_endpoint=None,
-        )
+            tags=empty_binary_annotations_dict,
+            kind=Kind.CLIENT,
+            local_endpoint=fake_endpoint,
+            service_name='test_service',
+            report_timestamp=False,
+        ))
     assert create_sp.call_count == 1
     assert mock_encode_bytes_list.call_count == 0
-
-
-def test_get_local_span_timestamp_and_duration_client():
-    timestamp, duration = logging_helper.get_local_span_timestamp_and_duration(
-        {'cs': 16, 'cr': 30},
-    )
-    assert timestamp == 16
-    assert duration == 14
-
-
-def test_get_local_span_timestamp_and_duration_server():
-    timestamp, duration = logging_helper.get_local_span_timestamp_and_duration(
-        {'sr': 12, 'ss': 30},
-    )
-    assert timestamp == 12
-    assert duration == 18
-
-
-def test_get_local_span_timestamp_and_duration_none():
-    timestamp, duration = logging_helper.get_local_span_timestamp_and_duration(
-        {'cs': 16, 'other': 5}
-    )
-    assert timestamp is None
-    assert duration is None


### PR DESCRIPTION
Another refactoring split off https://github.com/Yelp/py_zipkin/pull/82 since that PR is too big for me to understand if I'm breaking something.

This change is backward compatible and only refactors py_zipkin internals so that we now send around a `Span` object rather than `dicts`.

It also introduces `kind`, borrowed from the v2 format, that supersededs the old `include` argument. `include` is still supported to maintain backward compatibility and is transparently converted to the right `kind`.

----

Most integration tests pass without changes which is good. The only thing that is different is that if you set the `ss`, `sr`, `cs` or `cr` annotations that won't affect a span timestamp or duration. The annotations themselves are preserved though.

Passing in annotations to force a specific timestamp and duration is weird and not portable (what do you do if you're using v2? Pass the old annotations?). If that's something that people need and use, I can just add 2 extra arguments to `zipkin_span` and allow people to set timestamp and duration there.