### PR TITLE
Allow overriding the span name

### DIFF
--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -509,6 +509,21 @@ class zipkin_span(object):
                 raise ValueError('SA annotation already set.')
             self.logging_context.sa_endpoint = sa_endpoint
 
+    def override_span_name(self, name):
+        """Overrides the current span name.
+
+        This is useful if you don't know the span name yet when you create the
+        zipkin_span object. i.e. pyramid_zipkin doesn't know which route the
+        request matched until the function wrapped by the context manager
+        completes.
+
+        :param name: New span name
+        :type name: str
+        """
+        self.span_name = name
+        if self.logging_context:
+            self.logging_context.span_name = name
+
 
 def _validate_args(kwargs):
     if 'kind' in kwargs:

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,16 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+import os
+
 from setuptools import find_packages
 from setuptools import setup
-import os
 
 __version__ = '0.13.0'
 
+
 def read(f):
     return open(os.path.join(os.path.dirname(__file__), f)).read().strip()
+
 
 setup(
     name='py_zipkin',
@@ -23,10 +26,10 @@ setup(
     packages=find_packages(exclude=('tests*', 'testing*', 'tools*')),
     package_data={'': ['*.thrift']},
     install_requires=[
-        'enum34;python_version<"3.4"',
         'six',
         'thriftpy',
     ],
+    extras_require={':python_version=="2.7"': ['enum34']},
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 import mock
 import pytest
 
-from py_zipkin.zipkin import ZipkinAttrs
-from py_zipkin.transport import BaseTransportHandler
 from py_zipkin._encoding_helpers import IEncoder
+from py_zipkin.transport import BaseTransportHandler
+from py_zipkin.zipkin import ZipkinAttrs
 
 
 @pytest.fixture
@@ -30,12 +30,17 @@ class MockTransportHandler(BaseTransportHandler):
 
     def __init__(self, max_payload_bytes=None):
         self.max_payload_bytes = max_payload_bytes
+        self.payloads = []
 
     def send(self, payload):
+        self.payloads.append(payload)
         return payload
 
     def get_max_payload_bytes(self):
         return self.max_payload_bytes
+
+    def get_payloads(self):
+        return self.payloads
 
 
 class MockEncoder(IEncoder):


### PR DESCRIPTION
Allow overriding the span name after the span is initialized.

This will be useful in pyramid_zipkin since pyramid doesn't know which route the request matched until the function wrapped by the context manager completes.

I've made this function very specific. I'm unsure whether I should make it more generic and allow overriding any span property: `service_name`, `port`, `timestamp` and `duration`.