### PR TITLE
Add support for JSON V2 spans

### DIFF
--- a/py_zipkin/_encoding_helpers.py
+++ b/py_zipkin/_encoding_helpers.py
@@ -176,10 +176,10 @@ class SpanBuilder(object):
             parent_id=self.parent_id,
             id=self.span_id,
             kind=self.kind,
-            timestamp=self.timestamp if self.report_timestamp else None,
-            duration=self.duration if self.report_timestamp else None,
+            timestamp=self.timestamp,
+            duration=self.duration,
             debug=False,
-            shared=False,
+            shared=self.report_timestamp is False,
             local_endpoint=self.local_endpoint,
             remote_endpoint=remote_endpoint,
             annotations=self.annotations,
@@ -485,6 +485,8 @@ class _V2JSONEncoder(_BaseJSONEncoder):
             json_span['timestamp'] = int(span.timestamp * 1000000)
         if span.duration:
             json_span['duration'] = int(span.duration * 1000000)
+        if span.shared is True:
+            json_span['shared'] = True
         if span.kind and span.kind.value is not None:
             json_span['kind'] = span.kind.value
         if span.local_endpoint:

--- a/py_zipkin/_encoding_helpers.py
+++ b/py_zipkin/_encoding_helpers.py
@@ -467,8 +467,6 @@ class _V2JSONEncoder(_BaseJSONEncoder):
             'traceId': span.trace_id,
             'name': span.name,
             'id': span.id,
-            'annotations': [],
-            'tags': {},
         }
 
         if span.parent_id:
@@ -487,14 +485,17 @@ class _V2JSONEncoder(_BaseJSONEncoder):
             json_span['remoteEndpoint'] = self._create_json_endpoint(
                 span.remote_endpoint,
             )
+        if span.tags and len(span.tags) > 0:
+            json_span['tags'] = span.tags
 
-        for key, timestamp in span.annotations.items():
-            json_span['annotations'].append({
-                'timestamp': int(timestamp * 1000000),
-                'value': key,
-            })
-
-        json_span['tags'].update(span.tags)
+        if span.annotations:
+            json_span['annotations'] = [
+                {
+                    'timestamp': int(timestamp * 1000000),
+                    'value': key,
+                }
+                for key, timestamp in span.annotations.items()
+            ]
 
         encoded_span = json.dumps(json_span)
 

--- a/tests/encoding_helpers_test.py
+++ b/tests/encoding_helpers_test.py
@@ -111,7 +111,7 @@ class TestBaseJSONEncoder(object):
             service_name='test_service',
             host='127.0.0.1',
         )
-        assert encoder._create_json_endpoint(ipv4_endpoint) == {
+        assert encoder._create_json_endpoint(ipv4_endpoint, False) == {
             'serviceName': 'test_service',
             'port': 8888,
             'ipv4': '127.0.0.1',
@@ -122,8 +122,29 @@ class TestBaseJSONEncoder(object):
             service_name='test_service',
             host='2001:0db8:85a3:0000:0000:8a2e:0370:7334',
         )
-        assert encoder._create_json_endpoint(ipv6_endpoint) == {
+        assert encoder._create_json_endpoint(ipv6_endpoint, False) == {
             'serviceName': 'test_service',
+            'port': 8888,
+            'ipv6': '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+        }
+
+        v1_endpoint = _encoding_helpers.create_endpoint(
+            port=8888,
+            service_name=None,
+            host='2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+        )
+        assert encoder._create_json_endpoint(v1_endpoint, True) == {
+            'serviceName': '',
+            'port': 8888,
+            'ipv6': '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+        }
+
+        v2_endpoint = _encoding_helpers.create_endpoint(
+            port=8888,
+            service_name=None,
+            host='2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+        )
+        assert encoder._create_json_endpoint(v2_endpoint, False) == {
             'port': 8888,
             'ipv6': '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
         }

--- a/tests/encoding_helpers_test.py
+++ b/tests/encoding_helpers_test.py
@@ -91,7 +91,7 @@ def test_iencoder_throws_not_implemented_errors():
         encoder.encode_queue([])
 
 
-class TestV1JSONEncoder(object):
+class TestBaseJSONEncoder(object):
     @pytest.fixture
     def encoder(self):
         """Test encoder"""
@@ -105,13 +105,13 @@ class TestV1JSONEncoder(object):
         # with max_size = 56 it fits perfectly since there's space for the 2 ', '
         assert encoder.fits(2, 30, 56, '{"trace_id": "1234"}') is True
 
-    def test_create_v1_endpoint(self, encoder):
+    def test_create_json_endpoint(self, encoder):
         ipv4_endpoint = _encoding_helpers.create_endpoint(
             port=8888,
             service_name='test_service',
             host='127.0.0.1',
         )
-        assert encoder._create_v1_endpoint(ipv4_endpoint) == {
+        assert encoder._create_json_endpoint(ipv4_endpoint) == {
             'serviceName': 'test_service',
             'port': 8888,
             'ipv4': '127.0.0.1',
@@ -122,7 +122,7 @@ class TestV1JSONEncoder(object):
             service_name='test_service',
             host='2001:0db8:85a3:0000:0000:8a2e:0370:7334',
         )
-        assert encoder._create_v1_endpoint(ipv6_endpoint) == {
+        assert encoder._create_json_endpoint(ipv6_endpoint) == {
             'serviceName': 'test_service',
             'port': 8888,
             'ipv6': '2001:0db8:85a3:0000:0000:8a2e:0370:7334',

--- a/tests/integration/encoding_test.py
+++ b/tests/integration/encoding_test.py
@@ -1,0 +1,282 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import json
+import time
+from collections import OrderedDict
+
+import mock
+import pytest
+from thriftpy.protocol.binary import read_list_begin
+from thriftpy.protocol.binary import TBinaryProtocol
+from thriftpy.transport import TMemoryBuffer
+
+from py_zipkin import Encoding
+from py_zipkin import Kind
+from py_zipkin import zipkin
+from py_zipkin.thrift import zipkin_core
+from py_zipkin import thrift
+from py_zipkin.util import generate_random_64bit_string
+from py_zipkin.zipkin import ZipkinAttrs
+
+
+def mock_logger():
+    mock_logs = []
+
+    def mock_transport_handler(message):
+        mock_logs.append(message)
+
+    return mock_transport_handler, mock_logs
+
+
+def _decode_binary_thrift_objs(obj):
+    spans = []
+    trans = TMemoryBuffer(obj)
+    _, size = read_list_begin(trans)
+    for _ in range(size):
+        span = zipkin_core.Span()
+        span.read(TBinaryProtocol(trans))
+        spans.append(span)
+    return spans
+
+
+def us(seconds):
+    return int(seconds * 1000 * 1000)
+
+
+def check_v1_json(obj, zipkin_attrs, inner_span_id, ts):
+    inner_span, root_span = json.loads(obj)
+
+    endpoint = {
+        'ipv4': '10.0.0.0',
+        'port': 8080,
+        'serviceName': 'test_service_name',
+    }
+    assert root_span == {
+        'traceId': zipkin_attrs.trace_id,
+        'parentId': zipkin_attrs.parent_span_id,
+        'name': 'test_span_name',
+        'id': zipkin_attrs.span_id,
+        'binaryAnnotations': [
+            {
+                'endpoint': endpoint,
+                'key': 'some_key',
+                'value': 'some_value',
+            },
+            {
+                'endpoint': {
+                    'ipv6': '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+                    'port': 8888,
+                    'serviceName': 'sa_service',
+                },
+                'key': 'sa',
+                'value': '1',
+            },
+        ],
+        'annotations': [
+            {
+                'endpoint': endpoint,
+                'timestamp': us(ts),
+                'value': 'cs',
+            },
+            {
+                'endpoint': endpoint,
+                'timestamp': us(ts + 10),
+                'value': 'cr',
+            },
+        ],
+    }
+
+    assert inner_span == {
+        'traceId': zipkin_attrs.trace_id,
+        'parentId': zipkin_attrs.span_id,
+        'name': 'inner_span',
+        'id': inner_span_id,
+        'timestamp': us(ts),
+        'duration': us(5),
+        'binaryAnnotations': [],
+        'annotations': [
+            {
+                'endpoint': endpoint,
+                'timestamp': us(ts),
+                'value': 'cs',
+            },
+            {
+                'endpoint': endpoint,
+                'timestamp': us(ts),
+                'value': 'sr',
+            },
+            {
+                'endpoint': endpoint,
+                'timestamp': us(ts + 5),
+                'value': 'ss',
+            },
+            {
+                'endpoint': endpoint,
+                'timestamp': us(ts + 5),
+                'value': 'cr',
+            },
+            {
+                'endpoint': endpoint,
+                'timestamp': us(ts),
+                'value': 'ws',
+            },
+        ],
+    }
+
+
+def check_v1_thrift(obj, zipkin_attrs, inner_span_id, ts):
+    inner_span, root_span = _decode_binary_thrift_objs(obj)
+
+    endpoint = thrift.create_endpoint(
+        port=8080,
+        service_name='test_service_name',
+        ipv4='10.0.0.0',
+    )
+    binary_annotations = thrift.binary_annotation_list_builder(
+        {'some_key': 'some_value'},
+        endpoint,
+    )
+    binary_annotations.append(thrift.create_binary_annotation(
+        'sa',
+        '\x01',
+        zipkin_core.AnnotationType.BOOL,
+        thrift.create_endpoint(
+            port=8888,
+            service_name='sa_service',
+            ipv6='2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+        ),
+    ))
+
+    expected_root = thrift.create_span(
+        span_id=zipkin_attrs.span_id,
+        parent_span_id=zipkin_attrs.parent_span_id,
+        trace_id=zipkin_attrs.trace_id,
+        span_name='test_span_name',
+        annotations=thrift.annotation_list_builder(
+            OrderedDict([('cs', ts), ('cr', ts + 10)]),
+            endpoint,
+        ),
+        binary_annotations=binary_annotations,
+        timestamp_s=None,
+        duration_s=None,
+    )
+    # py.test diffs of thrift Spans are pretty useless and hide many things
+    # These prints would only appear on stdout if the test fails and help comparing
+    # the 2 spans.
+    print(root_span)
+    print(expected_root)
+    assert root_span == expected_root
+
+    expected_inner = thrift.create_span(
+        span_id=inner_span_id,
+        parent_span_id=zipkin_attrs.span_id,
+        trace_id=zipkin_attrs.trace_id,
+        span_name='inner_span',
+        annotations=thrift.annotation_list_builder(
+            OrderedDict([('cs', ts), ('sr', ts), ('ss', ts + 5),
+                         ('cr', ts + 5), ('ws', ts)]),
+            endpoint,
+        ),
+        binary_annotations=[],
+        timestamp_s=ts,
+        duration_s=5,
+    )
+    # py.test diffs of thrift Spans are pretty useless and hide many things
+    # These prints would only appear on stdout if the test fails and help comparing
+    # the 2 spans.
+    print(inner_span)
+    print(expected_inner)
+    assert inner_span == expected_inner
+
+
+def check_v2_json(obj, zipkin_attrs, inner_span_id, ts):
+    inner_span, root_span = json.loads(obj)
+
+    assert root_span == {
+        'traceId': zipkin_attrs.trace_id,
+        'name': 'test_span_name',
+        'parentId': zipkin_attrs.parent_span_id,
+        'id': zipkin_attrs.span_id,
+        'kind': 'CLIENT',
+        'localEndpoint': {
+            'ipv4': '10.0.0.0',
+            'port': 8080,
+            'serviceName': 'test_service_name',
+        },
+        'remoteEndpoint': {
+            'ipv6': '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+            'port': 8888,
+            'serviceName': 'sa_service',
+        },
+        'annotations': [],
+        'tags': {'some_key': 'some_value'},
+    }
+
+    assert inner_span == {
+        'traceId': zipkin_attrs.trace_id,
+        'name': 'inner_span',
+        'parentId': zipkin_attrs.span_id,
+        'id': inner_span_id,
+        'timestamp': us(ts),
+        'duration': us(5),
+        'localEndpoint': {
+            'ipv4': '10.0.0.0',
+            'port': 8080,
+            'serviceName': 'test_service_name',
+        },
+        'tags': {},
+        'annotations': [{'timestamp': us(ts), 'value': 'ws'}],
+    }
+
+
+@pytest.mark.parametrize('encoding,validate_fn', [
+    (Encoding.V1_THRIFT, check_v1_thrift),
+    (Encoding.V1_JSON, check_v1_json),
+    (Encoding.V2_JSON, check_v2_json),
+])
+def test_encoding(encoding, validate_fn):
+    zipkin_attrs = ZipkinAttrs(
+        trace_id=generate_random_64bit_string(),
+        span_id=generate_random_64bit_string(),
+        parent_span_id=generate_random_64bit_string(),
+        is_sampled=True,
+        flags=None,
+    )
+    inner_span_id = generate_random_64bit_string()
+    mock_transport_handler, mock_logs = mock_logger()
+    ts = time.time()
+    with mock.patch('time.time', autospec=True) as mock_time:
+        # zipkin.py start, logging_helper.start, 3 x logging_helper.stop
+        # I don't understand why logging_helper.stop would run 3 times, but
+        # that's what I'm seeing in the test
+        mock_time.side_effect = iter([ts, ts, ts + 10, ts + 10, ts + 10])
+        with zipkin.zipkin_span(
+            service_name='test_service_name',
+            span_name='test_span_name',
+            transport_handler=mock_transport_handler,
+            binary_annotations={'some_key': 'some_value'},
+            encoding=encoding,
+            zipkin_attrs=zipkin_attrs,
+            host='10.0.0.0',
+            port=8080,
+            kind=Kind.CLIENT,
+        ) as span:
+            with mock.patch.object(
+                zipkin,
+                'generate_random_64bit_string',
+                return_value=inner_span_id,
+            ):
+                with zipkin.zipkin_span(
+                    service_name='test_service_name',
+                    span_name='inner_span',
+                    timestamp=ts,
+                    duration=5,
+                    annotations={'ws': ts},
+                ):
+                    span.add_sa_binary_annotation(
+                        8888,
+                        'sa_service',
+                        '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+                    )
+
+    validate_fn(mock_logs[0], zipkin_attrs, inner_span_id, ts)

--- a/tests/integration/encoding_test.py
+++ b/tests/integration/encoding_test.py
@@ -197,6 +197,9 @@ def check_v2_json(obj, zipkin_attrs, inner_span_id, ts):
         'parentId': zipkin_attrs.parent_span_id,
         'id': zipkin_attrs.span_id,
         'kind': 'CLIENT',
+        'timestamp': us(ts),
+        'duration': us(10),
+        'shared': True,
         'localEndpoint': {
             'ipv4': '10.0.0.0',
             'port': 8080,

--- a/tests/integration/encoding_test.py
+++ b/tests/integration/encoding_test.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import json
-import time
 from collections import OrderedDict
 
 import mock

--- a/tests/integration/encoding_test.py
+++ b/tests/integration/encoding_test.py
@@ -208,7 +208,6 @@ def check_v2_json(obj, zipkin_attrs, inner_span_id, ts):
             'port': 8888,
             'serviceName': 'sa_service',
         },
-        'annotations': [],
         'tags': {'some_key': 'some_value'},
     }
 
@@ -224,7 +223,6 @@ def check_v2_json(obj, zipkin_attrs, inner_span_id, ts):
             'port': 8080,
             'serviceName': 'test_service_name',
         },
-        'tags': {},
         'annotations': [{'timestamp': us(ts), 'value': 'ws'}],
     }
 
@@ -244,7 +242,12 @@ def test_encoding(encoding, validate_fn):
     )
     inner_span_id = generate_random_64bit_string()
     mock_transport_handler, mock_logs = mock_logger()
-    ts = time.time()
+    # Let's hardcode the timestamp rather than call time.time() every time.
+    # The issue with time.time() is that the convertion to int of the
+    # returned float value * 1000000 is not precise and in the same test
+    # sometimes returns N and sometimes N+1. This ts value doesn't have that
+    # issue afaict, probably since it ends in zeros.
+    ts = 1538544126.115900
     with mock.patch('time.time', autospec=True) as mock_time:
         # zipkin.py start, logging_helper.start, 3 x logging_helper.stop
         # I don't understand why logging_helper.stop would run 3 times, but

--- a/tests/integration/zipkin_integration_test.py
+++ b/tests/integration/zipkin_integration_test.py
@@ -345,8 +345,7 @@ def _verify_service_span(span, annotations):
     assert set([ann.value for ann in span.annotations]) == annotations
 
 
-@pytest.mark.parametrize('encoding', SUPPORTED_ENCODINGS)
-def test_service_span(encoding, default_annotations):
+def test_service_span(default_annotations):
     mock_transport_handler, mock_logs = mock_logger()
     mock_firehose_handler, mock_firehose_logs = mock_logger()
     zipkin_attrs = ZipkinAttrs(
@@ -364,12 +363,12 @@ def test_service_span(encoding, default_annotations):
         binary_annotations={'some_key': 'some_value'},
         add_logging_annotation=True,
         firehose_handler=mock_firehose_handler,
-        encoding=encoding,
+        encoding=Encoding.V1_THRIFT,
     ):
         pass
 
-    span = decode(mock_logs[0], encoding)[0]
-    firehose_span = decode(mock_firehose_logs[0], encoding)[0]
+    span = decode(mock_logs[0], Encoding.V1_THRIFT)[0]
+    firehose_span = decode(mock_firehose_logs[0], Encoding.V1_THRIFT)[0]
     _verify_service_span(span, default_annotations)
     _verify_service_span(firehose_span, default_annotations)
 
@@ -379,11 +378,7 @@ def test_service_span(encoding, default_annotations):
     assert span.duration is None
 
 
-@pytest.mark.parametrize('encoding', SUPPORTED_ENCODINGS)
-def test_service_span_report_timestamp_override(
-    encoding,
-    default_annotations,
-):
+def test_service_span_report_timestamp_override(default_annotations):
     mock_transport_handler, mock_logs = mock_logger()
     zipkin_attrs = ZipkinAttrs(
         trace_id='0',
@@ -400,11 +395,11 @@ def test_service_span_report_timestamp_override(
         binary_annotations={'some_key': 'some_value'},
         add_logging_annotation=True,
         report_root_timestamp=True,
-        encoding=encoding,
+        encoding=Encoding.V1_THRIFT,
     ):
         pass
 
-    span = decode(mock_logs[0], encoding)[0]
+    span = decode(mock_logs[0], Encoding.V1_THRIFT)[0]
     _verify_service_span(span, default_annotations)
     assert span.timestamp is not None
     assert span.duration is not None


### PR DESCRIPTION
This is useful to add before #100 so that we have `Kind.V2_JSON` as a supported encoding.

The main part of this change is in `_V2JSONEncoder`, which is able to encode a `Span` to the `JSON V2` format. Since several functions were the same as `_V1JSONEncoder` I refactored them away in a base class.

--------

I also added a new integration test file called `encoding_test.py`. Right now we were trying to run the existing integration tests against all the possible encodings we support, which isn't scalable and make the tests complicated.
Also, most of the py_zipkin code is the same for all encodings, so the only thing we need to test for the encodings are what changes between `_V2JSONEncoder` and `_V1JSONEncoder` and `_V1ThriftEncoder`.

This also gives a better idea of what's exactly coming out of the handlers (at least in the python case) since I can compare dicts rather than have many complicated helper functions that make it difficult to understand what's the real object that is being emitted.

cc @adriancole