### PR TITLE
Fix memory leak

### DIFF
--- a/py_zipkin/storage.py
+++ b/py_zipkin/storage.py
@@ -45,7 +45,29 @@ class ThreadLocalStack(Stack):
 
 
 class SpanStorage(deque):
-    pass
+    def __init__(self):
+        super(SpanStorage, self).__init__()
+        self._is_transport_configured = False
+
+    def is_transport_configured(self):
+        """Helper function to check whether a transport is configured.
+
+        We need to propagate this info to the child zipkin_spans since
+        if no transport is set-up they should not generate any Span to
+        avoid memory leaks.
+
+        :returns: whether transport is configured or not
+        :rtype: bool
+        """
+        return self._is_transport_configured
+
+    def set_transport_configured(self, configured):
+        """Set whether the transport is configured or not.
+
+        :param configured: whether transport is configured or not
+        :type configured: bool
+        """
+        self._is_transport_configured = configured
 
 
 def default_span_storage():

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -338,9 +338,11 @@ class zipkin_span(object):
                     use_128bit_trace_id=self.use_128bit_trace_id,
                 )
 
+        print('self.zipkin_attrs: {}'.format(self.zipkin_attrs))
         if not self.zipkin_attrs:
             # Check if this span is inside the context of an existing trace
             existing_zipkin_attrs = self._context_stack.get()
+            print('existing_zipkin_attrs: {}'.format(existing_zipkin_attrs))
             if existing_zipkin_attrs:
                 self.zipkin_attrs = ZipkinAttrs(
                     trace_id=existing_zipkin_attrs.trace_id,

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -209,8 +209,8 @@ class zipkin_span(object):
         self.duration = duration
         self.encoding = encoding
 
+        self._is_local_root_span = False
         self.logging_context = None
-        self.logging_configured = False
         self.do_pop_attrs = False
         # Spans that log a 'cs' timestamp can additionally record a
         # 'sa' binary annotation that shows where the request is going.
@@ -239,11 +239,19 @@ class zipkin_span(object):
                 DeprecationWarning,
             )
 
-        # Validation checks
+        # Root spans have transport_handler and at least one of zipkin_attrs
+        # or sample_rate.
         if self.zipkin_attrs or self.sample_rate is not None:
+            # transport_handler is mandatory for root spans
             if self.transport_handler is None:
                 raise ZipkinError(
                     'Root spans require a transport handler to be given')
+
+            self._is_local_root_span = True
+
+        # If firehose_handler than this is a local root span.
+        if self.firehose_handler:
+            self._is_local_root_span = True
 
         if self.sample_rate is not None and not (0.0 <= self.sample_rate <= 100.0):
             raise ZipkinError('Sample rate must be between 0.0 and 100.0')
@@ -316,42 +324,48 @@ class zipkin_span(object):
         never attached in the unsampled case, so the spans are never logged.
         """
         self.do_pop_attrs = False
-        # If zipkin_attrs are passed in or this span is doing its own sampling,
-        # it will need to actually log spans at __exit__.
-        perform_logging = bool(self.zipkin_attrs or
-                               self.sample_rate is not None or
-                               self.firehose_handler is not None)
         report_root_timestamp = False
 
-        if self.sample_rate is not None:
-            if self.zipkin_attrs and not self.zipkin_attrs.is_sampled:
-                report_root_timestamp = True
-                self.zipkin_attrs = create_attrs_for_span(
-                    sample_rate=self.sample_rate,
-                    trace_id=self.zipkin_attrs.trace_id,
-                    use_128bit_trace_id=self.use_128bit_trace_id,
-                )
-            elif not self.zipkin_attrs:
-                report_root_timestamp = True
-                self.zipkin_attrs = create_attrs_for_span(
-                    sample_rate=self.sample_rate,
-                    use_128bit_trace_id=self.use_128bit_trace_id,
-                )
+        # This check is technically not necessary since only root spans will have
+        # sample_rate, zipkin_attrs or a transport set. But it helps making the
+        # code clearer by separating the logic for a root span from the one for a
+        # child span.
+        if self._is_local_root_span:
 
-        print('self.zipkin_attrs: {}'.format(self.zipkin_attrs))
-        if not self.zipkin_attrs:
-            # Check if this span is inside the context of an existing trace
-            existing_zipkin_attrs = self._context_stack.get()
-            print('existing_zipkin_attrs: {}'.format(existing_zipkin_attrs))
-            if existing_zipkin_attrs:
-                self.zipkin_attrs = ZipkinAttrs(
-                    trace_id=existing_zipkin_attrs.trace_id,
-                    span_id=generate_random_64bit_string(),
-                    parent_span_id=existing_zipkin_attrs.span_id,
-                    flags=existing_zipkin_attrs.flags,
-                    is_sampled=existing_zipkin_attrs.is_sampled,
-                )
-            elif self.firehose_handler is not None:
+            # If sample_rate is set, we need to (re)generate a trace context.
+            # If zipkin_attrs (trace context) were passed in as argument there are
+            # 2 possibilities:
+            # is_sampled = False --> we keep the same trace_id but re-roll the dice
+            #                        for is_sampled.
+            # is_sampled = True  --> we don't want to stop sampling halfway through
+            #                        a sampled trace, so we do nothing.
+            # If no zipkin_attrs were passed in, we generate new ones and start a
+            # new trace.
+            if self.sample_rate is not None:
+
+                # If this trace is not sampled, we re-roll the dice.
+                if self.zipkin_attrs and not self.zipkin_attrs.is_sampled:
+                    # This will be the root span of the trace, so we should
+                    # set timestamp and duration.
+                    report_root_timestamp = True
+                    self.zipkin_attrs = create_attrs_for_span(
+                        sample_rate=self.sample_rate,
+                        trace_id=self.zipkin_attrs.trace_id,
+                        use_128bit_trace_id=self.use_128bit_trace_id,
+                    )
+
+                # If zipkin_attrs was not passed in, we simply generate new
+                # zipkin_attrs to start a new trace.
+                elif not self.zipkin_attrs:
+                    # This will be the root span of the trace, so we should
+                    # set timestamp and duration.
+                    report_root_timestamp = True
+                    self.zipkin_attrs = create_attrs_for_span(
+                        sample_rate=self.sample_rate,
+                        use_128bit_trace_id=self.use_128bit_trace_id,
+                    )
+
+            if self.firehose_handler and not self.zipkin_attrs:
                 # If it has gotten here, the only thing that is
                 # causing a trace is the firehose. So we force a trace
                 # with sample rate of 0
@@ -360,6 +374,21 @@ class zipkin_span(object):
                     sample_rate=0.0,
                     use_128bit_trace_id=self.use_128bit_trace_id,
                 )
+        else:
+            # If zipkin_attrs was not passed in, we check if there's already a
+            # trace context in _context_stack.
+            if not self.zipkin_attrs:
+                existing_zipkin_attrs = self._context_stack.get()
+                # If there's an existing context, let's create new zipkin_attrs
+                # with that context as parent.
+                if existing_zipkin_attrs:
+                    self.zipkin_attrs = ZipkinAttrs(
+                        trace_id=existing_zipkin_attrs.trace_id,
+                        span_id=generate_random_64bit_string(),
+                        parent_span_id=existing_zipkin_attrs.span_id,
+                        flags=existing_zipkin_attrs.flags,
+                        is_sampled=existing_zipkin_attrs.is_sampled,
+                    )
 
         # If zipkin_attrs are not set up by now, that means this span is not
         # configured to perform logging itself, and it's not in an existing
@@ -373,7 +402,7 @@ class zipkin_span(object):
 
         self.start_timestamp = time.time()
 
-        if perform_logging:
+        if self._is_local_root_span:
             # Don't set up any logging if we're not sampling
             if not self.zipkin_attrs.is_sampled and not self.firehose_handler:
                 return self
@@ -394,8 +423,8 @@ class zipkin_span(object):
                 encoding=self.encoding,
             )
             self.logging_context.start()
+            self._span_storage.set_transport_configured(configured=True)
 
-        self.logging_configured = True
         return self
 
     def __exit__(self, _exc_type, _exc_value, _exc_traceback):
@@ -411,7 +440,10 @@ class zipkin_span(object):
         if self.do_pop_attrs:
             self._context_stack.pop()
 
-        if not self.logging_configured:
+        # If no transport is configured, there's no reason to create a new Span.
+        # This also helps avoiding memory leaks since without a transport nothing
+        # would pull spans out of _span_storage.
+        if not self._span_storage.is_transport_configured():
             return
 
         # Add the error annotation if an exception occurred
@@ -427,6 +459,7 @@ class zipkin_span(object):
         if self.logging_context:
             self.logging_context.stop()
             self.logging_context = None
+            self._span_storage.set_transport_configured(configured=False)
             return
 
         # If we've gotten here, that means that this span is a child span of

--- a/tests/integration/zipkin_integration_test.py
+++ b/tests/integration/zipkin_integration_test.py
@@ -727,7 +727,10 @@ def test_can_set_sa_annotation(encoding):
 
 
 def test_memory_leak():
+    # In py_zipkin >= 0.13.0 and <= 0.14.0 this test fails since the
+    # span_storage contains 10 spans once you exit the for loop.
     mock_transport_handler, mock_logs = mock_logger()
+    assert len(storage.default_span_storage()) == 0
     for _ in range(10):
         with zipkin.zipkin_client_span(
             service_name='test_service_name',
@@ -737,7 +740,7 @@ def test_memory_leak():
             binary_annotations={'some_key': 'some_value'},
             add_logging_annotation=True,
             encoding=Encoding.V1_JSON,
-        ) as span:
+        ):
             with zipkin.zipkin_span(
                 service_name='inner_service_name',
                 span_name='inner_span_name',


### PR DESCRIPTION
Added a new `is_transport_configured` helper to `SpanStorage`. This returns `True` only if a transport handler is setup, which allows client context managers to not generate a span if there's no correctly configured root context.

In py_zipkin < 0.13 we used to use `zipkin_logger` to check for this, but now we don't have that global singleton anymore.

The `test_memory_leak` test failed before (span_storage had 10 items into it at the end of the loop) but passes now.

------

I also added a bunch of comments and rearranged a bit the if/else in `zipkin_span` `start()`. The logic is the same as before, but this is hopefully a bit more clear.
I had a very hard time understanding those multiple if/else since some of them only apply to the root context, others only to client spans.