### PR TITLE
Fix pre-commit install failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 matrix:
   include:
+  - python: 3.6
+    env: TOXENV=pre-commit
   - python: 2.7
     env: TOXENV=py27
   - python: 3.4
@@ -9,7 +11,7 @@ matrix:
     env: TOXENV=py35
   - python: 3.6
     env: TOXENV=py36
-  - python: 2.7
+  - python: 3.6
     env: TOXENV=flake8
 before_install: pip install -U pip==18.0
 install: pip install tox coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -9,12 +9,13 @@ commands =
     coverage report -m --show-missing --fail-under 100
 
 [testenv:pre-commit]
-basepython = /usr/bin/python2.7
-deps = pre-commit>=0.2.10
+basepython = python3.6
+# Remove version contraint once https://gitlab.com/python-devs/importlib_resources/issues/67 is solved
+deps = pre-commit<1.12.0
 commands = pre-commit {posargs}
 
 [testenv:flake8]
-basepython = /usr/bin/python2.7
+basepython = python3.6
 deps = flake8
 commands =
     flake8 py_zipkin tests


### PR DESCRIPTION
The latest pre-commit doesn't install cleanly since it depends on
importlib-resources/ which is missing wheels in the public pypi.

I also changed pre-commit and flake8 to run under python 3.6. There's no
particular need to do that, but I'd rather not use py27 where we don't
need to.