### PR TITLE
Change DeprecationWarnings to logging.warning

### DIFF
--- a/py_zipkin/__init__.py
+++ b/py_zipkin/__init__.py
@@ -1,9 +1,3 @@
-# DeprecationWarnings are silent since Python 2.7.
-# The `default` filter only prints the first occurrence of matching warnings for
-# each location where the warning is issued, so that we don't spam our users logs.
-import warnings
-warnings.simplefilter('default', DeprecationWarning)
-
 # Export useful functions and types from private modules.
 from py_zipkin.encoding._types import Encoding  # noqa
 from py_zipkin.encoding._types import Kind  # noqa

--- a/py_zipkin/thread_local.py
+++ b/py_zipkin/thread_local.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
+import logging
 import threading
-import warnings
 
 _thread_local = threading.local()
+
+log = logging.getLogger('py_zipkin.thread_local')
 
 
 def get_thread_local_zipkin_attrs():
@@ -42,10 +44,7 @@ def get_zipkin_attrs():
     :rtype: :class:`zipkin.ZipkinAttrs`
     """
     from py_zipkin.storage import ThreadLocalStack
-    warnings.warn(
-        'Use py_zipkin.stack.ThreadLocalStack().get',
-        DeprecationWarning,
-    )
+    log.warning('Use py_zipkin.stack.ThreadLocalStack().get')
     return ThreadLocalStack().get()
 
 
@@ -56,10 +55,7 @@ def pop_zipkin_attrs():
     :rtype: :class:`zipkin.ZipkinAttrs`
     """
     from py_zipkin.storage import ThreadLocalStack
-    warnings.warn(
-        'Use py_zipkin.stack.ThreadLocalStack().pop',
-        DeprecationWarning,
-    )
+    log.warning('Use py_zipkin.stack.ThreadLocalStack().pop')
     return ThreadLocalStack().pop()
 
 
@@ -70,8 +66,5 @@ def push_zipkin_attrs(zipkin_attr):
     :type zipkin_attr: :class:`zipkin.ZipkinAttrs`
     """
     from py_zipkin.storage import ThreadLocalStack
-    warnings.warn(
-        'Use py_zipkin.stack.ThreadLocalStack().push',
-        DeprecationWarning,
-    )
+    log.warning('Use py_zipkin.stack.ThreadLocalStack().push')
     return ThreadLocalStack().push(zipkin_attr)

--- a/py_zipkin/thread_local.py
+++ b/py_zipkin/thread_local.py
@@ -44,7 +44,8 @@ def get_zipkin_attrs():
     :rtype: :class:`zipkin.ZipkinAttrs`
     """
     from py_zipkin.storage import ThreadLocalStack
-    log.warning('Use py_zipkin.stack.ThreadLocalStack().get')
+    log.warning('get_zipkin_attrs is deprecated. '
+                'Use py_zipkin.storage.ThreadLocalStack().get')
     return ThreadLocalStack().get()
 
 
@@ -55,7 +56,8 @@ def pop_zipkin_attrs():
     :rtype: :class:`zipkin.ZipkinAttrs`
     """
     from py_zipkin.storage import ThreadLocalStack
-    log.warning('Use py_zipkin.stack.ThreadLocalStack().pop')
+    log.warning('pop_zipkin_attrs is deprecated. '
+                'Use py_zipkin.storage.ThreadLocalStack().pop')
     return ThreadLocalStack().pop()
 
 
@@ -66,5 +68,6 @@ def push_zipkin_attrs(zipkin_attr):
     :type zipkin_attr: :class:`zipkin.ZipkinAttrs`
     """
     from py_zipkin.storage import ThreadLocalStack
-    log.warning('Use py_zipkin.stack.ThreadLocalStack().push')
+    log.warning('push_zipkin_attrs is deprecated. '
+                'Use py_zipkin.storage.ThreadLocalStack().push')
     return ThreadLocalStack().push(zipkin_attr)

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import functools
+import logging
 import random
 import time
-import warnings
 from collections import namedtuple
 
 from py_zipkin import Encoding
@@ -32,6 +32,8 @@ ZipkinAttrs = namedtuple(
 )
 
 ERROR_KEY = 'error'
+
+log = logging.getLogger('py_zipkin.zipkin')
 
 
 class zipkin_span(object):
@@ -225,18 +227,16 @@ class zipkin_span(object):
         if 'sr' in self.annotations and 'ss' in self.annotations:
             self.duration = self.annotations['ss'] - self.annotations['sr']
             self.timestamp = self.annotations['sr']
-            warnings.warn(
+            log.warning(
                 "Manually setting 'sr'/'ss' annotations is deprecated. Please "
-                "use the timestamp and duration parameters.",
-                DeprecationWarning,
+                "use the timestamp and duration parameters."
             )
         if 'cr' in self.annotations and 'cs' in self.annotations:
             self.duration = self.annotations['cr'] - self.annotations['cs']
             self.timestamp = self.annotations['cs']
-            warnings.warn(
+            log.warning(
                 "Manually setting 'cr'/'cs' annotations is deprecated. Please "
-                "use the timestamp and duration parameters.",
-                DeprecationWarning,
+                "use the timestamp and duration parameters."
             )
 
         # Root spans have transport_handler and at least one of zipkin_attrs
@@ -299,9 +299,8 @@ class zipkin_span(object):
                 # than it's a client or server span respectively.
                 # If neither or both are present, then it's a local span
                 # which is represented by kind = None.
-                warnings.warn(
-                    'The include argument is deprecated. Please use kind.',
-                    DeprecationWarning,
+                log.warning(
+                    'The include argument is deprecated. Please use kind.'
                 )
                 if 'client' in include and 'server' not in include:
                     return Kind.CLIENT


### PR DESCRIPTION
DeprecationWarnings are hidden by default in python >= 2.7, so for them
to be usef we need to enable them. Doing so though enabled
DeprecationWarnings for every library and module you import, which
causes a lot of unrelated DeprecationWarnings to be printed. And you
can't do anything for most of them since they're from some other
library you're using.

Let's change these to logging.warning then and revert
DeprecationWarnings to their hidden default.