### PR TITLE
Fix multithreading issues with SpanStorage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: check-yaml
     -   id: debug-statements
     -   id: name-tests-test
-        exclude: tests/acceptance/test_helper.py
+        exclude: tests/test_helpers.py
     -   id: flake8
         args:
         - --max-line-length=83

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ py_zipkin (for the moment) thrift-encodes spans. The actual transport layer is
 pluggable, though.
 
 The recommended way to implement a new transport handler is to subclass
-`py_zipkin.transport.BaseTransportHandler` and implement the `send` and 
+`py_zipkin.transport.BaseTransportHandler` and implement the `send` and
 `get_max_payload_bytes` methods.
 
 `send` receives an already encoded thrift list as argument.
@@ -151,7 +151,7 @@ your Zipkin collector is running at localhost:9411.
 
 > NOTE: older versions of py_zipkin suggested implementing the transport handler
 > as a function with a single argument. That's still supported and should work
-> with the current py_zipkin version, but it's deprecated. 
+> with the current py_zipkin version, but it's deprecated.
 
 ```python
 import requests

--- a/py_zipkin/logging_helper.py
+++ b/py_zipkin/logging_helper.py
@@ -6,6 +6,8 @@ from py_zipkin import Kind
 from py_zipkin.encoding._helpers import Span
 from py_zipkin.encoding._helpers import copy_endpoint_with_new_service_name
 from py_zipkin.encoding._encoders import get_encoder
+from py_zipkin.encoding._helpers import copy_endpoint_with_new_service_name
+from py_zipkin.encoding._helpers import SpanBuilder
 from py_zipkin.exception import ZipkinError
 from py_zipkin.transport import BaseTransportHandler
 

--- a/py_zipkin/storage/__init__.py
+++ b/py_zipkin/storage/__init__.py
@@ -1,10 +1,19 @@
 import logging
 from collections import deque
 
-from py_zipkin import thread_local
+from py_zipkin.thread_local import get_thread_local_span_storage
+from py_zipkin.thread_local import get_thread_local_zipkin_attrs
 
 
 log = logging.getLogger('py_zipkin.storage')
+
+
+class ZipkinStorage(object):
+
+    def __init__(self):
+        self._is_transport_configured = False
+        self.span_storage = SpanStorage()
+        self.context_stack = Stack()
 
 
 class Stack(object):
@@ -45,17 +54,23 @@ class ThreadLocalStack(Stack):
     """
 
     def __init__(self):
-        pass
+        log.warning('ThreadLocalStack is deprecated. Set local_storage instead.')
 
     @property
     def _storage(self):
-        return thread_local.get_thread_local_zipkin_attrs()
+        return get_thread_local_zipkin_attrs()
 
 
 class SpanStorage(deque):
-    def __init__(self):
-        super(SpanStorage, self).__init__()
-        self._is_transport_configured = False
+    pass
+
+
+def default_span_storage():
+    log.warning('default_span_storage is deprecated. Set local_storage instead.')
+    return get_thread_local_span_storage()
+
+
+class LocalStorage(object):
 
     def is_transport_configured(self):
         """Helper function to check whether a transport is configured.
@@ -67,7 +82,7 @@ class SpanStorage(deque):
         :returns: whether transport is configured or not
         :rtype: bool
         """
-        return self._is_transport_configured
+        return self.storage._is_transport_configured
 
     def set_transport_configured(self, configured):
         """Set whether the transport is configured or not.
@@ -75,45 +90,11 @@ class SpanStorage(deque):
         :param configured: whether transport is configured or not
         :type configured: bool
         """
-        self._is_transport_configured = configured
+        self.storage._is_transport_configured = configured
 
-
-class ThreadLocalSpanStorage(object):
-    """
-    ThreadLocalSpanStorage is wrapper around SpanStorage that stores the
-    SpanStorage object in thread local.
-
-    The thread local storage is accessed lazily in every method call,
-    so the thread that calls the method matters, not the thread that
-    instantiated the class. This is important since for example decorators
-    are created at import time and in a different thread than where the
-    rest of the code runs.
-    Every instance shares the same thread local data.
-
-    To make this work I infortunately need to override every method of
-    SpanStorage and call the real span_storage instance.
-    """
+    def get_zipkin_attrs(self):
+        return self.storage.context_stack.get()
 
     @property
-    def _storage(self):
-        return thread_local.get_thread_local_span_storage()
-
-    def __iter__(self):
-        # No need to override __next__ as __iter__ returns a pointer to
-        # itself. So python will call __next__ directly on the right object.
-        return self._storage.__iter__()
-
-    def __len__(self):
-        return len(self._storage)
-
-    def append(self, el):
-        return self._storage.append(el)
-
-    def clear(self):
-        return self._storage.clear()
-
-    def is_transport_configured(self):
-        return self._storage.is_transport_configured()
-
-    def set_transport_configured(self, configured):
-        self._storage.set_transport_configured(configured)
+    def storage(self):
+        raise NotImplementedError()

--- a/py_zipkin/storage/thread_local.py
+++ b/py_zipkin/storage/thread_local.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from py_zipkin import thread_local
+from py_zipkin.storage import LocalStorage
+from py_zipkin.storage import ZipkinStorage
+
+
+class ThreadLocalStorage(LocalStorage):
+    """
+    ThreadLocalSpanStorage is wrapper around SpanStorage that stores the
+    SpanStorage object in thread local.
+
+    The thread local storage is accessed lazily in every method call,
+    so the thread that calls the method matters, not the thread that
+    instantiated the class. This is important since for example decorators
+    are created at import time and in a different thread than where the
+    rest of the code runs.
+    Every instance shares the same thread local data.
+
+    To make this work I infortunately need to override every method of
+    SpanStorage and call the real span_storage instance.
+    """
+
+    @property
+    def storage(self):
+        if not hasattr(thread_local._thread_local, 'zipkin_storage'):
+            thread_local._thread_local.zipkin_storage = ZipkinStorage()
+        return thread_local._thread_local.zipkin_storage

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -204,7 +204,7 @@ class zipkin_span(object):
         if span_storage is not None:
             self._span_storage = span_storage
         else:
-            self._span_storage = storage.default_span_storage()
+            self._span_storage = storage.ThreadLocalSpanStorage()
         self.firehose_handler = firehose_handler
         self.kind = self._generate_kind(kind, include)
         self.timestamp = timestamp
@@ -256,7 +256,8 @@ class zipkin_span(object):
         if self.sample_rate is not None and not (0.0 <= self.sample_rate <= 100.0):
             raise ZipkinError('Sample rate must be between 0.0 and 100.0')
 
-        if not isinstance(self._span_storage, storage.SpanStorage):
+        if not (isinstance(self._span_storage, storage.SpanStorage) or
+                isinstance(self._span_storage, storage.ThreadLocalSpanStorage)):
             raise ZipkinError('span_storage should be an instance '
                               'of py_zipkin.storage.SpanStorage')
 

--- a/tests/encoding/_decoders_test.py
+++ b/tests/encoding/_decoders_test.py
@@ -5,9 +5,9 @@ import mock
 import pytest
 
 from py_zipkin import thrift
+from py_zipkin.encoding._decoders import _V1ThriftDecoder
 from py_zipkin.encoding._decoders import get_decoder
 from py_zipkin.encoding._decoders import IDecoder
-from py_zipkin.encoding._decoders import _V1ThriftDecoder
 from py_zipkin.encoding._helpers import Endpoint
 from py_zipkin.encoding._types import Encoding
 from py_zipkin.encoding._types import Kind

--- a/tests/integration/multithreading_test.py
+++ b/tests/integration/multithreading_test.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+import json
+from threading import Thread
+
+from py_zipkin import Encoding
+from py_zipkin.zipkin import zipkin_span
+from tests.conftest import MockTransportHandler
+
+
+@zipkin_span(service_name='service1', span_name='service1_do_stuff')
+def do_stuff():
+    return 'OK'
+
+
+def run_inside_another_thread(transport):
+    """Run this function inside a different thread.
+
+    :param transport: transport handler. We need to pass it in since any
+        assertion we do inside this thread gets silently swallowed, so we
+        need a way to return the results to the main thread.
+    :type transport: MockTransportHandler
+    """
+    with zipkin_span(
+        service_name='webapp',
+        span_name='index',
+        transport_handler=transport,
+        sample_rate=100.0,
+        encoding=Encoding.V2_JSON,
+    ):
+        do_stuff()
+
+
+def test_decorator_works_in_a_new_thread():
+    """The zipkin_span decorator is instanciated in a thread and then run in
+    another. Let's verify that it works and that it stores the span in the
+    right thread's thread-storage.
+    """
+    transport = MockTransportHandler()
+    thread = Thread(target=run_inside_another_thread, args=(transport,))
+    thread.start()
+    thread.join()
+
+    output = transport.get_payloads()
+    assert len(output) == 1
+
+    spans = json.loads(output[0])
+    assert len(spans) == 2
+    assert spans[0]['name'] == 'service1_do_stuff'
+    assert spans[1]['name'] == 'index'

--- a/tests/integration/multithreading_test.py
+++ b/tests/integration/multithreading_test.py
@@ -4,7 +4,7 @@ from threading import Thread
 
 from py_zipkin import Encoding
 from py_zipkin.zipkin import zipkin_span
-from tests.conftest import MockTransportHandler
+from tests.test_helpers import MockTransportHandler
 
 
 @zipkin_span(service_name='service1', span_name='service1_do_stuff')

--- a/tests/integration/zipkin_integration_test.py
+++ b/tests/integration/zipkin_integration_test.py
@@ -550,7 +550,7 @@ def test_memory_leak():
     # In py_zipkin >= 0.13.0 and <= 0.14.0 this test fails since the
     # span_storage contains 10 spans once you exit the for loop.
     mock_transport_handler, mock_logs = mock_logger()
-    assert len(storage.default_span_storage()) == 0
+    assert len(storage.ThreadLocalSpanStorage()) == 0
     for _ in range(10):
         with zipkin.zipkin_client_span(
             service_name='test_service_name',
@@ -566,4 +566,4 @@ def test_memory_leak():
                 pass
 
     assert len(mock_logs) == 0
-    assert len(storage.default_span_storage()) == 0
+    assert len(storage.ThreadLocalSpanStorage()) == 0

--- a/tests/integration/zipkin_integration_test.py
+++ b/tests/integration/zipkin_integration_test.py
@@ -5,9 +5,9 @@ import pytest
 
 from py_zipkin import Encoding
 from py_zipkin import Kind
-from py_zipkin import storage
 from py_zipkin import zipkin
 from py_zipkin.logging_helper import LOGGING_END_KEY
+from py_zipkin.storage.thread_local import ThreadLocalStorage
 from py_zipkin.zipkin import ZipkinAttrs
 
 
@@ -550,7 +550,7 @@ def test_memory_leak():
     # In py_zipkin >= 0.13.0 and <= 0.14.0 this test fails since the
     # span_storage contains 10 spans once you exit the for loop.
     mock_transport_handler, mock_logs = mock_logger()
-    assert len(storage.ThreadLocalSpanStorage()) == 0
+    assert len(ThreadLocalStorage().storage.span_storage) == 0
     for _ in range(10):
         with zipkin.zipkin_client_span(
             service_name='test_service_name',
@@ -566,4 +566,4 @@ def test_memory_leak():
                 pass
 
     assert len(mock_logs) == 0
-    assert len(storage.ThreadLocalSpanStorage()) == 0
+    assert len(ThreadLocalStorage().storage.span_storage) == 0

--- a/tests/logging_helper_test.py
+++ b/tests/logging_helper_test.py
@@ -4,6 +4,8 @@ import pytest
 from py_zipkin import Encoding
 from py_zipkin import Kind
 from py_zipkin import logging_helper
+from py_zipkin.encoding._encoders import get_encoder
+from py_zipkin.encoding._helpers import create_endpoint
 from py_zipkin.encoding._helpers import Endpoint
 from py_zipkin.encoding._helpers import Span
 from py_zipkin.encoding._helpers import create_endpoint

--- a/tests/stack_test.py
+++ b/tests/stack_test.py
@@ -18,7 +18,14 @@ def test_get_zipkin_attrs_returns_none_if_no_zipkin_attrs():
 
 
 def test_get_zipkin_attrs_with_context_returns_none_if_no_zipkin_attrs():
-    assert not py_zipkin.storage.Stack([]).get()
+    with mock.patch.object(py_zipkin.storage.log, 'warning', autospec=True) as log:
+        assert not py_zipkin.storage.Stack([]).get()
+        assert log.call_count == 1
+
+
+def test_storage_stack_still_works_if_you_dont_pass_in_storage():
+    # Let's make sure this still works if we don't pass in a custom storage.
+    assert not py_zipkin.storage.Stack().get()
 
 
 @mock.patch('py_zipkin.storage.thread_local._thread_local.zipkin_attrs', ['foo'])

--- a/tests/stack_test.py
+++ b/tests/stack_test.py
@@ -28,7 +28,7 @@ def test_storage_stack_still_works_if_you_dont_pass_in_storage():
     assert not py_zipkin.storage.Stack().get()
 
 
-@mock.patch('py_zipkin.storage.thread_local._thread_local.zipkin_attrs', ['foo'])
+@mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', ['foo'])
 def test_get_zipkin_attrs_returns_the_last_of_the_list():
     assert 'foo' == py_zipkin.storage.ThreadLocalStack().get()
 

--- a/tests/storage/init_test.py
+++ b/tests/storage/init_test.py
@@ -1,0 +1,16 @@
+import mock
+import pytest
+
+from py_zipkin import storage
+
+
+def test_default_span_storage_warns():
+    with mock.patch.object(storage.log, 'warning') as mock_log:
+        storage.default_span_storage()
+        assert mock_log.call_count == 1
+
+
+class TestLocalStorage(object):
+    def test_storage_raises_if_not_implemented(self):
+        with pytest.raises(NotImplementedError):
+            storage.LocalStorage().storage

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,9 +5,11 @@ import mock
 import six
 
 from py_zipkin import Kind
-from py_zipkin import zipkin
 from py_zipkin import thrift
+from py_zipkin import zipkin
 from py_zipkin.encoding._encoders import IEncoder
+from py_zipkin.storage import LocalStorage
+from py_zipkin.storage import ZipkinStorage
 from py_zipkin.thrift import zipkin_core
 from py_zipkin.transport import BaseTransportHandler
 from py_zipkin.util import generate_random_128bit_string
@@ -48,6 +50,16 @@ class MockEncoder(IEncoder):
         assert isinstance(new_span, six.string_types)
 
         return self.fits_bool
+
+
+class MockLocalStorage(LocalStorage):
+    def __init__(self, *argv, **kwargs):
+        super(MockLocalStorage, self).__init__(*argv, **kwargs)
+        self._storage = ZipkinStorage()
+
+    @property
+    def storage(self):
+        return self._storage
 
 
 def generate_list_of_spans(encoding):

--- a/tests/thread_local_test.py
+++ b/tests/thread_local_test.py
@@ -1,9 +1,11 @@
 import mock
 
 from py_zipkin import thread_local
+from py_zipkin.storage import SpanStorage
 
 # Can't patch an attribute that doesn't yet exist
 thread_local._thread_local.zipkin_attrs = []
+thread_local._thread_local.span_storage = SpanStorage()
 
 
 @mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', ['foo'])
@@ -16,6 +18,20 @@ def test_get_thread_local_zipkin_attrs_creates_empty_list_if_not_attached():
     assert not hasattr(thread_local._thread_local, "zipkin_attrs")
     assert thread_local.get_thread_local_zipkin_attrs() == []
     assert hasattr(thread_local._thread_local, "zipkin_attrs")
+
+
+@mock.patch(
+    'py_zipkin.thread_local._thread_local.span_storage', SpanStorage(['foo'])
+)
+def test_get_thread_local_span_storage_present():
+    assert thread_local.get_thread_local_span_storage() == SpanStorage(['foo'])
+
+
+def test_get_thread_local_span_storage_creates_empty_list_if_not_attached():
+    delattr(thread_local._thread_local, "span_storage")
+    assert not hasattr(thread_local._thread_local, "span_storage")
+    assert thread_local.get_thread_local_span_storage() == SpanStorage()
+    assert hasattr(thread_local._thread_local, "span_storage")
 
 
 @mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', ['foo'])

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
 basepython = python3.6
 # Remove version contraint once https://gitlab.com/python-devs/importlib_resources/issues/67 is solved
 deps = pre-commit<1.12.0
-commands = pre-commit {posargs}
+commands = pre-commit run --all-files
 
 [testenv:flake8]
 basepython = python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,7 @@ commands =
 
 [testenv:pre-commit]
 basepython = python3.6
-# Remove version contraint once https://gitlab.com/python-devs/importlib_resources/issues/67 is solved
-deps = pre-commit<1.12.0
+deps = pre-commit
 commands = pre-commit run --all-files
 
 [testenv:flake8]


### PR DESCRIPTION
This should fix both #95 and #96. @unapiedra @nullscc

I finally understood why `ThreadLocalStack` had that weird logic. The problem is that when you use a decorator, `SpanStorage` and `Stack` get created at import time. Then your code probably forks or creates different threads and any further call to `thread_local.get_thread_local_span_storage` will actually return a different object.

The easiest way to fix this is by lazily pulling `span_storage` from `thread_local` every time you need it. That will run in the current thread and get it from the correct thread_local.
This unfortunately means `ThreadLocalSpanStorage` needs to override all methods of `SpanStorage` and forward them to `self._storage`. It's not great but it works and it was the cleanest solution I could find.

------

I added a new integration test for this. Without the changes to `py_zipkin.storage` it was failing since `span_storage` would only contain 1 span (the one from the context manager).
After the `py_zipkin.storage` fix it also contains the span from the context manager.

------

@cklein @sjaensch Is the `storage` argument to `Span` useful at all? Can we just default it to an empty list? I can't tell if I'm missing some other corner case here...