### PR TITLE
Don't crash if the timestamp is null

### DIFF
--- a/py_zipkin/encoding/_decoders.py
+++ b/py_zipkin/encoding/_decoders.py
@@ -178,6 +178,8 @@ class _V1ThriftDecoder(IDecoder):
         return tags, local_endpoint, remote_endpoint
 
     def seconds(self, us):
+        if us is None:
+            return None
         return round(float(us) / 1000 / 1000, 6)
 
     def _decode_thrift_span(self, thrift_span):

--- a/tests/encoding/_decoders_test.py
+++ b/tests/encoding/_decoders_test.py
@@ -169,6 +169,11 @@ class TestV1ThriftDecoder(object):
         assert local_endpoint == Endpoint('test_service', '10.0.0.1', None, 8888)
         assert remote_endpoint == Endpoint('rem_service', '10.0.0.2', None, 9999)
 
+    def test_seconds_doesnt_crash_with_none(self):
+        decoder = _V1ThriftDecoder()
+        assert decoder.seconds(6000000) == 6.0
+        assert decoder.seconds(None) is None
+
     @pytest.mark.parametrize('trace_id_generator', [
         (generate_random_64bit_string),
         (generate_random_128bit_string),


### PR DESCRIPTION
I'm not sure why the timestamp would ever be null as that seems an
invalid span, however it seems we have a few spans like that and we
shouldn't crash on that.