### PR TITLE
Rename SpanBuilder to Span and support 'ca' annotation.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,9 @@
 repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v2.1.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
-    -   id: autopep8-wrapper
     -   id: check-json
         files: \.(bowerrc|jshintrc|json)$
     -   id: check-yaml
@@ -17,7 +16,11 @@ repos:
         exclude: docs/source/conf.py
     -   id: requirements-txt-fixer
 -   repo: https://github.com/asottile/reorder_python_imports.git
-    rev: v1.3.2
+    rev: v1.3.5
     hooks:
     -   id: reorder-python-imports
         language_version: python2.7
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.4.3
+    hooks:
+    -   id: autopep8

--- a/py_zipkin/encoding/__init__.py
+++ b/py_zipkin/encoding/__init__.py
@@ -3,9 +3,11 @@ import json
 
 import six
 
-from py_zipkin.encoding._types import Encoding
 from py_zipkin.encoding._decoders import get_decoder
 from py_zipkin.encoding._encoders import get_encoder
+from py_zipkin.encoding._helpers import Endpoint  # noqa: F401
+from py_zipkin.encoding._helpers import Span  # noqa: F401
+from py_zipkin.encoding._types import Encoding
 from py_zipkin.exception import ZipkinError
 
 _V2_ATTRIBUTES = ["tags", "localEndpoint", "remoteEndpoint", "shared", "kind"]
@@ -85,12 +87,12 @@ def convert_spans(spans, output_encoding, input_encoding=None):
 
     decoder = get_decoder(input_encoding)
     encoder = get_encoder(output_encoding)
-    span_builders = decoder.decode_spans(spans)
+    decoded_spans = decoder.decode_spans(spans)
     output_spans = []
 
     # Encode each indivicual span
-    for sb in span_builders:
-        output_spans.append(encoder.encode_span(sb))
+    for span in decoded_spans:
+        output_spans.append(encoder.encode_span(span))
 
     # Outputs from encoder.encode_span() can be easily concatenated in a list
     return encoder.encode_queue(output_spans)

--- a/py_zipkin/encoding/_decoders.py
+++ b/py_zipkin/encoding/_decoders.py
@@ -9,12 +9,12 @@ from thriftpy2.protocol.binary import TBinaryProtocol
 from thriftpy2.thrift import TType
 from thriftpy2.transport import TMemoryBuffer
 
+from py_zipkin.encoding._helpers import Endpoint
+from py_zipkin.encoding._helpers import Span
 from py_zipkin.encoding._types import Encoding
 from py_zipkin.encoding._types import Kind
 from py_zipkin.exception import ZipkinError
 from py_zipkin.thrift import zipkin_core
-from py_zipkin.encoding._helpers import Endpoint
-from py_zipkin.encoding._helpers import Span
 
 _HEX_DIGITS = "0123456789abcdef"
 _DROP_ANNOTATIONS = {'cs', 'sr', 'ss', 'cr'}
@@ -229,7 +229,7 @@ class _V1ThriftDecoder(IDecoder):
             duration=self.seconds(duration or thrift_span.duration),
             local_endpoint=local_endpoint,
             remote_endpoint=remote_endpoint,
-            shared=thrift_span.timestamp is None,
+            shared=(kind == Kind.SERVER and thrift_span.timestamp is None),
             annotations=annotations,
             tags=tags,
         )

--- a/py_zipkin/encoding/_encoders.py
+++ b/py_zipkin/encoding/_encoders.py
@@ -198,7 +198,7 @@ class _V1JSONEncoder(_BaseJSONEncoder):
 
         binary_annotations.append({
             'key': key,
-            'value': '1',
+            'value': True,
             'endpoint': json_remote_endpoint,
         })
 

--- a/py_zipkin/encoding/_encoders.py
+++ b/py_zipkin/encoding/_encoders.py
@@ -3,6 +3,7 @@ import json
 
 from py_zipkin import thrift
 from py_zipkin.encoding._types import Encoding
+from py_zipkin.encoding._types import Kind
 from py_zipkin.exception import ZipkinError
 
 
@@ -42,11 +43,11 @@ class IEncoder(object):
         """
         raise NotImplementedError()
 
-    def encode_span(self, span_builder):
+    def encode_span(self, span):
         """Encodes a single span.
 
-        :param span_builder: span_builder object representing the span.
-        :type span_builder: SpanBuilder
+        :param span: Span object representing the span.
+        :type span: Span
         :return: encoded span.
         :rtype: str or bytes
         """
@@ -74,9 +75,28 @@ class _V1ThriftEncoder(IEncoder):
         """
         return thrift.LIST_HEADER_SIZE + current_size + len(new_span) <= max_size
 
-    def encode_span(self, span_builder):
+    def encode_remote_endpoint(self, remote_endpoint, kind, binary_annotations):
+        thrift_remote_endpoint = thrift.create_endpoint(
+            remote_endpoint.port,
+            remote_endpoint.service_name,
+            remote_endpoint.ipv4,
+            remote_endpoint.ipv6,
+        )
+        if kind == Kind.CLIENT:
+            key = thrift.zipkin_core.SERVER_ADDR
+        elif kind == Kind.SERVER:
+            key = thrift.zipkin_core.CLIENT_ADDR
+
+        binary_annotations.append(thrift.create_binary_annotation(
+            key=key,
+            value=thrift.SERVER_ADDR_VAL,
+            annotation_type=thrift.zipkin_core.AnnotationType.BOOL,
+            host=thrift_remote_endpoint,
+        ))
+
+    def encode_span(self, v2_span):
         """Encodes the current span to thrift."""
-        span = span_builder.build_v1_span()
+        span = v2_span.build_v1_span()
 
         thrift_endpoint = thrift.create_endpoint(
             span.endpoint.port,
@@ -95,20 +115,13 @@ class _V1ThriftEncoder(IEncoder):
             thrift_endpoint,
         )
 
-        # Add sa binary annotation
-        if span.sa_endpoint is not None:
-            thrift_sa_endpoint = thrift.create_endpoint(
-                span.sa_endpoint.port,
-                span.sa_endpoint.service_name,
-                span.sa_endpoint.ipv4,
-                span.sa_endpoint.ipv6,
+        # Add sa/ca binary annotations
+        if v2_span.remote_endpoint:
+            self.encode_remote_endpoint(
+                v2_span.remote_endpoint,
+                v2_span.kind,
+                thrift_binary_annotations,
             )
-            thrift_binary_annotations.append(thrift.create_binary_annotation(
-                key=thrift.zipkin_core.SERVER_ADDR,
-                value=thrift.SERVER_ADDR_VAL,
-                annotation_type=thrift.zipkin_core.AnnotationType.BOOL,
-                host=thrift_sa_endpoint,
-            ))
 
         thrift_span = thrift.create_span(
             span.id,
@@ -176,9 +189,22 @@ class _BaseJSONEncoder(IEncoder):
 class _V1JSONEncoder(_BaseJSONEncoder):
     """JSON encoder for V1 spans."""
 
-    def encode_span(self, span_builder):
+    def encode_remote_endpoint(self, remote_endpoint, kind, binary_annotations):
+        json_remote_endpoint = self._create_json_endpoint(remote_endpoint, True)
+        if kind == Kind.CLIENT:
+            key = 'sa'
+        elif kind == Kind.SERVER:
+            key = 'ca'
+
+        binary_annotations.append({
+            'key': key,
+            'value': '1',
+            'endpoint': json_remote_endpoint,
+        })
+
+    def encode_span(self, v2_span):
         """Encodes a single span to JSON."""
-        span = span_builder.build_v1_span()
+        span = v2_span.build_v1_span()
 
         json_span = {
             'traceId': span.trace_id,
@@ -211,14 +237,13 @@ class _V1JSONEncoder(_BaseJSONEncoder):
                 'endpoint': v1_endpoint,
             })
 
-        # Add sa binary annotations
-        if span.sa_endpoint is not None:
-            json_sa_endpoint = self._create_json_endpoint(span.sa_endpoint, True)
-            json_span['binaryAnnotations'].append({
-                'key': 'sa',
-                'value': '1',
-                'endpoint': json_sa_endpoint,
-            })
+        # Add sa/ca binary annotations
+        if v2_span.remote_endpoint:
+            self.encode_remote_endpoint(
+                v2_span.remote_endpoint,
+                v2_span.kind,
+                json_span['binaryAnnotations'],
+            )
 
         encoded_span = json.dumps(json_span)
 
@@ -228,13 +253,12 @@ class _V1JSONEncoder(_BaseJSONEncoder):
 class _V2JSONEncoder(_BaseJSONEncoder):
     """JSON encoder for V2 spans."""
 
-    def encode_span(self, span_builder):
+    def encode_span(self, span):
         """Encodes a single span to JSON."""
-        span = span_builder.build_v2_span()
 
         json_span = {
             'traceId': span.trace_id,
-            'id': span.id,
+            'id': span.span_id,
         }
 
         if span.name:

--- a/py_zipkin/encoding/_helpers.py
+++ b/py_zipkin/encoding/_helpers.py
@@ -16,15 +16,7 @@ Endpoint = namedtuple(
 _V1Span = namedtuple(
     'V1Span',
     ['trace_id', 'name', 'parent_id', 'id', 'timestamp', 'duration', 'endpoint',
-     'annotations', 'binary_annotations', 'sa_endpoint'],
-)
-
-
-_V2Span = namedtuple(
-    'V2Span',
-    ['trace_id', 'name', 'parent_id', 'id', 'kind', 'timestamp',
-     'duration', 'debug', 'shared', 'local_endpoint', 'remote_endpoint',
-     'annotations', 'tags'],
+     'annotations', 'binary_annotations', 'remote_endpoint'],
 )
 
 
@@ -34,7 +26,7 @@ _DROP_ANNOTATIONS_BY_KIND = {
 }
 
 
-class SpanBuilder(object):
+class Span(object):
     """Internal Span representation. It can generate both v1 and v2 spans.
 
     It doesn't exactly map to either V1 or V2, since an intermediate format
@@ -47,17 +39,17 @@ class SpanBuilder(object):
         name,
         parent_id,
         span_id,
+        kind,
         timestamp,
         duration,
-        annotations,
-        tags,
-        kind,
         local_endpoint=None,
-        service_name=None,
-        sa_endpoint=None,
-        report_timestamp=True,
+        remote_endpoint=None,
+        debug=False,
+        shared=False,
+        annotations=None,
+        tags=None,
     ):
-        """Creates a new SpanBuilder.
+        """Creates a new Span.
 
         :param trace_id: Trace id.
         :type trace_id: str
@@ -67,25 +59,26 @@ class SpanBuilder(object):
         :type parent_id: str
         :param span_id: Span id.
         :type span_id: str
+        :param kind: Span type (client, server, local, etc...)
+        :type kind: Kind
         :param timestamp: start timestamp in seconds.
         :type timestamp: float
         :param duration: span duration in seconds.
         :type duration: float
+        :param local_endpoint: the host that recorded this span.
+        :type local_endpoint: Endpoint
+        :param remote_endpoint: the remote service.
+        :type remote_endpoint: Endpoint
+        :param debug: True is a request to store this span even if it
+            overrides sampling policy.
+        :type debug: bool
+        :param shared: True if we are contributing to a span started by
+            another tracer (ex on a different host).
+        :type shared: bool
         :param annotations: Optional dict of str -> timestamp annotations.
         :type annotations: dict
         :param tags: Optional dict of str -> str span tags.
         :type tags: dict
-        :param kind: Span type (client, server, local, etc...)
-        :type kind: Kind
-        :param local_endpoint: The host that recorded this span.
-        :type local_endpoint: Endpoint
-        :param service_name: The name of the called service
-        :type service_name: str
-        :param sa_endpoint: Remote server in client spans.
-        :type sa_endpoint: Endpoint
-        :param report_timestamp: Whether the span should report
-            timestamp and duration.
-        :type report_timestamp: bool
         """
         self.trace_id = trace_id
         self.name = name
@@ -94,16 +87,24 @@ class SpanBuilder(object):
         self.kind = kind
         self.timestamp = timestamp
         self.duration = duration
-        self.annotations = annotations
-        self.tags = tags
         self.local_endpoint = local_endpoint
-        self.service_name = service_name
-        self.sa_endpoint = sa_endpoint
-        self.report_timestamp = report_timestamp
+        self.remote_endpoint = remote_endpoint
+        self.debug = debug
+        self.shared = shared
+        self.annotations = annotations or {}
+        self.tags = tags or {}
 
         if not isinstance(kind, Kind):
             raise ZipkinError(
                 'Invalid kind value {}. Must be of type Kind.'.format(kind))
+
+        if local_endpoint and not isinstance(local_endpoint, Endpoint):
+            raise ZipkinError(
+                'Invalid local_endpoint value. Must be of type Endpoint.')
+
+        if remote_endpoint and not isinstance(remote_endpoint, Endpoint):
+            raise ZipkinError(
+                'Invalid remote_endpoint value. Must be of type Endpoint.')
 
     def build_v1_span(self):
         """Builds and returns a V1 Span.
@@ -135,38 +136,12 @@ class SpanBuilder(object):
             name=self.name,
             parent_id=self.parent_id,
             id=self.span_id,
-            timestamp=self.timestamp if self.report_timestamp else None,
-            duration=self.duration if self.report_timestamp else None,
+            timestamp=self.timestamp if self.shared is False else None,
+            duration=self.duration if self.shared is False else None,
             endpoint=self.local_endpoint,
             annotations=full_annotations,
             binary_annotations=self.tags,
-            sa_endpoint=self.sa_endpoint,
-        )
-
-    def build_v2_span(self):
-        """Builds and returns a V2 Span.
-
-        :return: newly generated _V2Span
-        :rtype: _V2Span
-        """
-        remote_endpoint = None
-        if self.sa_endpoint:
-            remote_endpoint = self.sa_endpoint
-
-        return _V2Span(
-            trace_id=self.trace_id,
-            name=self.name,
-            parent_id=self.parent_id,
-            id=self.span_id,
-            kind=self.kind,
-            timestamp=self.timestamp,
-            duration=self.duration,
-            debug=False,
-            shared=self.report_timestamp is False,
-            local_endpoint=self.local_endpoint,
-            remote_endpoint=remote_endpoint,
-            annotations=self.annotations,
-            tags=self.tags,
+            remote_endpoint=self.remote_endpoint,
         )
 
 

--- a/py_zipkin/encoding/_helpers.py
+++ b/py_zipkin/encoding/_helpers.py
@@ -27,11 +27,7 @@ _DROP_ANNOTATIONS_BY_KIND = {
 
 
 class Span(object):
-    """Internal Span representation. It can generate both v1 and v2 spans.
-
-    It doesn't exactly map to either V1 or V2, since an intermediate format
-    makes it easier to convert to either format.
-    """
+    """Internal V2 Span representation."""
 
     def __init__(
         self,

--- a/tests/encoding/_encoders_test.py
+++ b/tests/encoding/_encoders_test.py
@@ -5,10 +5,10 @@ import pytest
 
 from py_zipkin import Encoding
 from py_zipkin import thrift
-from py_zipkin.encoding._encoders import IEncoder
 from py_zipkin.encoding._encoders import _V1JSONEncoder
 from py_zipkin.encoding._encoders import _V1ThriftEncoder
 from py_zipkin.encoding._encoders import get_encoder
+from py_zipkin.encoding._encoders import IEncoder
 from py_zipkin.encoding._helpers import create_endpoint
 from py_zipkin.encoding._types import Kind
 from py_zipkin.exception import ZipkinError
@@ -174,7 +174,7 @@ class TestV1JSONEncoder(object):
         assert binary_annotations == [{
             'endpoint': {'ipv4': '127.0.0.1', 'serviceName': 'test_server'},
             'key': 'ca',
-            'value': '1',
+            'value': True,
         }]
 
         # For client spans, the remote endpoint is encoded as 'sa'
@@ -187,7 +187,7 @@ class TestV1JSONEncoder(object):
         assert binary_annotations == [{
             'endpoint': {'ipv4': '127.0.0.1', 'serviceName': 'test_server'},
             'key': 'sa',
-            'value': '1',
+            'value': True,
         }]
 
 

--- a/tests/encoding/_helpers_test.py
+++ b/tests/encoding/_helpers_test.py
@@ -1,8 +1,60 @@
 import socket
 
 import mock
+import pytest
 
 from py_zipkin.encoding._helpers import create_endpoint
+from py_zipkin.encoding._helpers import Span
+from py_zipkin.encoding._types import Kind
+from py_zipkin.exception import ZipkinError
+from py_zipkin.util import generate_random_64bit_string
+
+
+def test_create_span_with_bad_kind():
+    with pytest.raises(ZipkinError) as e:
+        Span(
+            trace_id=generate_random_64bit_string(),
+            name='test span',
+            parent_id=generate_random_64bit_string(),
+            span_id=generate_random_64bit_string(),
+            kind='client',
+            timestamp=26.0,
+            duration=4.0,
+        )
+
+    assert 'Invalid kind value client. Must be of type Kind.' in str(e)
+
+
+def test_create_span_with_bad_local_endpoint():
+    with pytest.raises(ZipkinError) as e:
+        Span(
+            trace_id=generate_random_64bit_string(),
+            name='test span',
+            parent_id=generate_random_64bit_string(),
+            span_id=generate_random_64bit_string(),
+            kind=Kind.CLIENT,
+            timestamp=26.0,
+            duration=4.0,
+            local_endpoint='my_service',
+        )
+
+    assert 'Invalid local_endpoint value. Must be of type Endpoint.' in str(e)
+
+
+def test_create_span_with_bad_remote_endpoint():
+    with pytest.raises(ZipkinError) as e:
+        Span(
+            trace_id=generate_random_64bit_string(),
+            name='test span',
+            parent_id=generate_random_64bit_string(),
+            span_id=generate_random_64bit_string(),
+            kind=Kind.CLIENT,
+            timestamp=26.0,
+            duration=4.0,
+            remote_endpoint='my_service',
+        )
+
+    assert 'Invalid remote_endpoint value. Must be of type Endpoint.' in str(e)
 
 
 @mock.patch('socket.gethostbyname', autospec=True)

--- a/tests/integration/decoding_test.py
+++ b/tests/integration/decoding_test.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-import json
 
+import json
 
 from py_zipkin import Encoding
 from py_zipkin.encoding import convert_spans
@@ -28,7 +28,6 @@ def test_encoding():
         'timestamp': us(ts),
         'duration': us(10),
         'kind': 'CLIENT',
-        'shared': True,
         'localEndpoint': {
             'ipv4': '10.0.0.0',
             'port': 8080,

--- a/tests/integration/encoding_test.py
+++ b/tests/integration/encoding_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+
 import json
 from collections import OrderedDict
 
@@ -11,9 +12,9 @@ from thriftpy2.transport import TMemoryBuffer
 
 from py_zipkin import Encoding
 from py_zipkin import Kind
+from py_zipkin import thrift
 from py_zipkin import zipkin
 from py_zipkin.thrift import zipkin_core
-from py_zipkin import thrift
 from py_zipkin.util import generate_random_64bit_string
 from py_zipkin.zipkin import ZipkinAttrs
 from tests.test_helpers import MockTransportHandler
@@ -60,7 +61,7 @@ def check_v1_json(obj, zipkin_attrs, inner_span_id, ts):
                     'serviceName': 'sa_service',
                 },
                 'key': 'sa',
-                'value': '1',
+                'value': True,
             },
         ],
         'annotations': [

--- a/tests/integration/zipkin_integration_test.py
+++ b/tests/integration/zipkin_integration_test.py
@@ -535,7 +535,7 @@ def test_can_set_sa_annotation(encoding):
 
     if encoding == Encoding.V1_JSON:
         assert client_span['binaryAnnotations'][0]['key'] == 'sa'
-        assert client_span['binaryAnnotations'][0]['value'] == '1'
+        assert client_span['binaryAnnotations'][0]['value'] is True
         host = client_span['binaryAnnotations'][0]['endpoint']
     elif encoding == Encoding.V2_JSON:
         host = client_span['remoteEndpoint']


### PR DESCRIPTION
I'm renaming and exposing py_zipkin.encoding.Span and
py_zipkin.encoding.Endpoint. The next step will be to have `with
zipkin_span` return the Span instance rather than the context manager
itself. That way it'll be possible to update the span fields directly
without need to have setters for all the properties.

```
with zipkin_span(...) as span:
    span.remote_endpoint = create_endpoint(service_name='mysql')
    span.tags.update({'key': 'value'})
```

SpanBuilder was already almost a V2 span, so the changes to it were
minimal.

As a side effect, with this change we also support the 'ca' binary
annotation.

cc @adriancole @amitmokal