### PR TITLE
Support python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: python
+# sudo and xenial are required to install py37
+# https://github.com/travis-ci/travis-ci/issues/9069
+sudo: required
+dist: xenial
+
 matrix:
   include:
   - python: 3.6
@@ -11,6 +16,8 @@ matrix:
     env: TOXENV=py35
   - python: 3.6
     env: TOXENV=py36
+  - python: 3.7
+    env: TOXENV=py37
   - python: 3.6
     env: TOXENV=flake8
 before_install: pip install -U pip==18.0

--- a/py_zipkin/encoding/_decoders.py
+++ b/py_zipkin/encoding/_decoders.py
@@ -4,10 +4,10 @@ import socket
 import struct
 
 import six
-from thriftpy.protocol.binary import read_list_begin
-from thriftpy.protocol.binary import TBinaryProtocol
-from thriftpy.thrift import TType
-from thriftpy.transport import TMemoryBuffer
+from thriftpy2.protocol.binary import read_list_begin
+from thriftpy2.protocol.binary import TBinaryProtocol
+from thriftpy2.thrift import TType
+from thriftpy2.transport import TMemoryBuffer
 
 from py_zipkin.encoding._types import Encoding
 from py_zipkin.encoding._types import Kind

--- a/py_zipkin/thrift/__init__.py
+++ b/py_zipkin/thrift/__init__.py
@@ -3,17 +3,17 @@ import os
 import socket
 import struct
 
-import thriftpy
-from thriftpy.protocol.binary import TBinaryProtocol
-from thriftpy.protocol.binary import write_list_begin
-from thriftpy.thrift import TType
-from thriftpy.transport import TMemoryBuffer
+import thriftpy2
+from thriftpy2.protocol.binary import TBinaryProtocol
+from thriftpy2.protocol.binary import write_list_begin
+from thriftpy2.thrift import TType
+from thriftpy2.transport import TMemoryBuffer
 
 from py_zipkin.util import unsigned_hex_to_signed_int
 
 
 thrift_filepath = os.path.join(os.path.dirname(__file__), 'zipkinCore.thrift')
-zipkin_core = thriftpy.load(thrift_filepath, module_name="zipkinCore_thrift")
+zipkin_core = thriftpy2.load(thrift_filepath, module_name="zipkinCore_thrift")
 
 SERVER_ADDR_VAL = '\x01'
 LIST_HEADER_SIZE = 5  # size in bytes of the encoded list header
@@ -145,7 +145,7 @@ def create_span(
     timestamp_s,
     duration_s,
 ):
-    """Takes a bunch of span attributes and returns a thriftpy representation
+    """Takes a bunch of span attributes and returns a thriftpy2 representation
     of the span. Timestamps passed in are in seconds, they're converted to
     microseconds before thrift encoding.
     """

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     package_data={'': ['*.thrift']},
     install_requires=[
         'six',
-        'thriftpy',
+        'thriftpy2',
     ],
     extras_require={':python_version=="2.7"': ['enum34']},
     classifiers=[
@@ -40,5 +40,6 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/tests/integration/encoding_test.py
+++ b/tests/integration/encoding_test.py
@@ -5,9 +5,9 @@ from collections import OrderedDict
 
 import mock
 import pytest
-from thriftpy.protocol.binary import read_list_begin
-from thriftpy.protocol.binary import TBinaryProtocol
-from thriftpy.transport import TMemoryBuffer
+from thriftpy2.protocol.binary import read_list_begin
+from thriftpy2.protocol.binary import TBinaryProtocol
+from thriftpy2.transport import TMemoryBuffer
 
 from py_zipkin import Encoding
 from py_zipkin import Kind


### PR DESCRIPTION
`thriftpy` is deprecated and doesn't compile on `python 3.7`. `thriftpy2` is
the new version which is still under support and it works fine on `py37`.

Upstream issue: https://github.com/Thriftpy/thriftpy/issues/333
Related issue: https://github.com/pantsbuild/pants/issues/7147

cc @stuhood @illicitonion