### PR TITLE
Fix multithreading issues

### DIFF
--- a/DEPRECATIONS.rst
+++ b/DEPRECATIONS.rst
@@ -5,21 +5,21 @@ New Tracer interface
 --------------------
 
 The following classes and methods are deprecated and should not be used.
-Please use the Thread interface instead.
+Please use the Tracer interface instead.
 They will be removed in version 1.0.
 
 REASON: they don't work well in multi-threaded environments and can cause
 dropped spans or memory leaks.
 
-- py_zipkin.storage.Stack
-- py_zipkin.storage.ThreadLocalStack
-- py_zipkin.storage.SpanStorage
-- py_zipkin.storage.default_span_storage
-- py_zipkin.thread_local.get_thread_local_zipkin_attrs
-- py_zipkin.thread_local.get_thread_local_span_storage
-- py_zipkin.thread_local.get_zipkin_attrs
-- py_zipkin.thread_local.pop_zipkin_attrs
-- py_zipkin.thread_local.push_zipkin_attrs
+- `py_zipkin.storage.Stack`
+- `py_zipkin.storage.ThreadLocalStack`
+- `py_zipkin.storage.SpanStorage`
+- `py_zipkin.storage.default_span_storage`
+- `py_zipkin.thread_local.get_thread_local_zipkin_attrs`
+- `py_zipkin.thread_local.get_thread_local_span_storage`
+- `py_zipkin.thread_local.get_zipkin_attrs`
+- `py_zipkin.thread_local.pop_zipkin_attrs`
+- `py_zipkin.thread_local.push_zipkin_attrs`
 
 To access the current zipkin_attrs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/DEPRECATIONS.rst
+++ b/DEPRECATIONS.rst
@@ -43,12 +43,11 @@ your own.
     from py_zipkin import Tracer
 
     tracer = Tracer()
-    with zipkin_span(
+    with tracer.zipkin_span(
         service_name="homepage",
         span_name="get /home",
         transport=MockTransport(),
         sample_rate=100.0,
-        get_tracer=lambda: tracer,
     ):
         # do stuff
 

--- a/DEPRECATIONS.rst
+++ b/DEPRECATIONS.rst
@@ -1,0 +1,101 @@
+Deprecations: how to migrate
+============================
+
+New Tracer interface
+--------------------
+
+The following classes and methods are deprecated and should not be used.
+Please use the Thread interface instead.
+They will be removed in version 1.0.
+
+REASON: they don't work well in multi-threaded environments and can cause
+dropped spans or memory leaks.
+
+- py_zipkin.storage.Stack
+- py_zipkin.storage.ThreadLocalStack
+- py_zipkin.storage.SpanStorage
+- py_zipkin.storage.default_span_storage
+- py_zipkin.thread_local.get_thread_local_zipkin_attrs
+- py_zipkin.thread_local.get_thread_local_span_storage
+- py_zipkin.thread_local.get_zipkin_attrs
+- py_zipkin.thread_local.pop_zipkin_attrs
+- py_zipkin.thread_local.push_zipkin_attrs
+
+To access the current zipkin_attrs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from py_zipkin import get_default_tracer
+
+    zipkin_attrs = get_default_tracer().get_zipkin_attrs()
+    get_default_tracer().push_zipkin_attrs(zipkin_attrs)
+
+To override the default tracer and provide your own in a multi-threaded env
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can instantiate your own Tracer instance and pass it to ALL your zipkin_span
+context managers and decorators. You'll need to propagate the tracer around on
+your own.
+
+.. code-block:: python
+
+    from py_zipkin import Tracer
+
+    tracer = Tracer()
+    with zipkin_span(
+        service_name="homepage",
+        span_name="get /home",
+        transport=MockTransport(),
+        sample_rate=100.0,
+        get_tracer=lambda: tracer,
+    ):
+        # do stuff
+
+Alternatively you can use the `get_default_tracer` and `set_default_tracer`
+functions to reset the default tracer every time you switch thread or
+coroutine. In this case you won't need to pass the tracer to every `zipkin_span`
+but they'll be able to pull the right one automatically.
+
+.. code-block:: python
+
+    from py_zipkin import get_default_tracer
+    from py_zipkin import set_default_tracer
+
+    def fn(tracer):
+        set_default_tracer(tracer)
+        # do stuff
+
+    def main():
+        tracer = get_default_tracer()
+        return await asyncio.get_event_loop().run_in_executor(None, fn, tracer)
+
+
+Kind
+----
+
+`zipkin_span`'s `include` argument is deprecated. You should set `kind` instead.
+
+REASON: Zipkin V2 data format uses kind to distinguish between client and
+server spans.
+
+.. code-block:: python
+
+    from py_zipkin import Kind
+    from py_zipkin.zipkin import zipkin_span
+
+    # Old code, uses include
+    with zipkin_span(
+        service_name="homepage",
+        span_name="get /home",
+        include=('server',),
+    ):
+        pass
+
+    # New code, uses Kind
+    with zipkin_span(
+        service_name="homepage",
+        span_name="get /home",
+        kind=Kind.SERVER,
+    ):
+        pass

--- a/py_zipkin/__init__.py
+++ b/py_zipkin/__init__.py
@@ -1,3 +1,5 @@
 # Export useful functions and types from private modules.
 from py_zipkin.encoding._types import Encoding  # noqa
 from py_zipkin.encoding._types import Kind  # noqa
+from py_zipkin.storage import get_default_tracer  # noqa
+from py_zipkin.storage import Tracer  # noqa

--- a/py_zipkin/storage.py
+++ b/py_zipkin/storage.py
@@ -104,7 +104,7 @@ class Stack(object):
     The latter two return None if the stack is empty.
 
     .. deprecated::
-       Use the Thread interface which offers better multi-threading support.
+       Use the Tracer interface which offers better multi-threading support.
        Stack will be removed in version 1.0.
     """
 
@@ -136,7 +136,7 @@ class ThreadLocalStack(Stack):
     Every instance shares the same thread local data.
 
     .. deprecated::
-       Use the Thread interface which offers better multi-threading support.
+       Use the Tracer interface which offers better multi-threading support.
        ThreadLocalStack will be removed in version 1.0.
     """
 
@@ -153,7 +153,7 @@ class SpanStorage(deque):
     """Stores the list of completed spans ready to be sent.
 
     .. deprecated::
-       Use the Thread interface which offers better multi-threading support.
+       Use the Tracer interface which offers better multi-threading support.
        SpanStorage will be removed in version 1.0.
     """
     pass

--- a/py_zipkin/storage.py
+++ b/py_zipkin/storage.py
@@ -1,32 +1,67 @@
+# -*- coding: utf-8 -*-
 import logging
+import threading
 from collections import deque
 
-from py_zipkin import thread_local
 from py_zipkin.thread_local import get_thread_local_span_storage
 from py_zipkin.thread_local import get_thread_local_zipkin_attrs
+
 try:  # pragma: no cover
+    # Since python 3.7 threadlocal is deprecated in favor of contextvars
+    # which also work in asyncio.
     import contextvars
     _contextvars_tracer = contextvars.ContextVar('py_zipkin.Tracer object')
 except ImportError:  # pragma: no cover
     # The contextvars module was added in python 3.7
     _contextvars_tracer = None
+_thread_local_tracer = threading.local()
 
 
 log = logging.getLogger('py_zipkin.storage')
 
 
-def get_thread_local_tracer():
-    if not hasattr(thread_local._thread_local, 'tracer'):
-        thread_local._thread_local.tracer = Tracer()
-    return thread_local._thread_local.tracer
+def _get_thread_local_tracer():
+    """Returns the current tracer from thread-local.
+
+    If there's no current tracer it'll create a new one.
+    :returns: current tracer.
+    :rtype: Tracer
+    """
+    if not hasattr(_thread_local_tracer, 'tracer'):
+        _thread_local_tracer.tracer = Tracer()
+    return _thread_local_tracer.tracer
 
 
-def get_contextvar_tracer():  # pragma: no cover
+def _set_thread_local_tracer(tracer):
+    """Sets the current tracer in thread-local.
+
+    :param tracer: current tracer.
+    :type tracer: Tracer
+    """
+    _thread_local_tracer.tracer = tracer
+
+
+def _get_contextvars_tracer():  # pragma: no cover
+    """Returns the current tracer from contextvars.
+
+    If there's no current tracer it'll create a new one.
+    :returns: current tracer.
+    :rtype: Tracer
+    """
     try:
         return _contextvars_tracer.get()
     except LookupError:
         _contextvars_tracer.set(Tracer())
         return _contextvars_tracer.get()
+
+
+def _set_contextvars_tracer(tracer):  # pragma: no cover
+    """Sets the current tracer in contextvars.
+
+    :param tracer: current tracer.
+    :type tracer: Tracer
+    """
+    _contextvars_tracer.set(tracer)
 
 
 class Tracer(object):
@@ -67,6 +102,10 @@ class Stack(object):
 
     It offers the operations push, pop and get.
     The latter two return None if the stack is empty.
+
+    .. deprecated::
+       Use the Thread interface which offers better multi-threading support.
+       Stack will be removed in version 1.0.
     """
 
     def __init__(self, storage=None):
@@ -89,17 +128,21 @@ class Stack(object):
 
 
 class ThreadLocalStack(Stack):
-    """
-    ThreadLocalStack is variant of Stack that uses a thread local storage.
+    """ThreadLocalStack is variant of Stack that uses a thread local storage.
 
     The thread local storage is accessed lazily in every method call,
     so the thread that calls the method matters, not the thread that
     instantiated the class.
     Every instance shares the same thread local data.
+
+    .. deprecated::
+       Use the Thread interface which offers better multi-threading support.
+       ThreadLocalStack will be removed in version 1.0.
     """
 
     def __init__(self):
-        log.warning('ThreadLocalStack is deprecated. Set local_storage instead.')
+        log.warning('ThreadLocalStack is deprecated. See DEPRECATIONS.rst for'
+                    'details on how to migrate to using Tracer.')
 
     @property
     def _storage(self):
@@ -107,16 +150,46 @@ class ThreadLocalStack(Stack):
 
 
 class SpanStorage(deque):
+    """Stores the list of completed spans ready to be sent.
+
+    .. deprecated::
+       Use the Thread interface which offers better multi-threading support.
+       SpanStorage will be removed in version 1.0.
+    """
     pass
 
 
 def default_span_storage():
-    log.warning('default_span_storage is deprecated. Set local_storage instead.')
+    log.warning('default_span_storage is deprecated. See DEPRECATIONS.rst for'
+                'details on how to migrate to using Tracer.')
     return get_thread_local_span_storage()
 
 
 def get_default_tracer():
-    if _contextvars_tracer:
-        return get_contextvar_tracer()
+    """Return the current default Tracer.
 
-    return get_thread_local_tracer()
+    For now it'll get it from thread-local in Python 2.7 to 3.6 and from
+    contextvars since Python 3.7.
+
+    :returns: current default tracer.
+    :rtype: Tracer
+    """
+    if _contextvars_tracer:
+        return _get_contextvars_tracer()
+
+    return _get_thread_local_tracer()
+
+
+def set_default_tracer(tracer):
+    """Sets the current default Tracer.
+
+    For now it'll get it from thread-local in Python 2.7 to 3.6 and from
+    contextvars since Python 3.7.
+
+    :returns: current default tracer.
+    :rtype: Tracer
+    """
+    if _contextvars_tracer:
+        return _set_contextvars_tracer(tracer)
+
+    return _set_thread_local_tracer(tracer)

--- a/py_zipkin/storage.py
+++ b/py_zipkin/storage.py
@@ -95,6 +95,11 @@ class Tracer(object):
     def is_transport_configured(self):
         return self._is_transport_configured
 
+    def zipkin_span(self, *argv, **kwargs):
+        from py_zipkin.zipkin import zipkin_span
+        kwargs['_tracer'] = self
+        return zipkin_span(*argv, **kwargs)
+
 
 class Stack(object):
     """

--- a/py_zipkin/thread_local.py
+++ b/py_zipkin/thread_local.py
@@ -13,9 +13,15 @@ def get_thread_local_zipkin_attrs():
     Returns a list of ZipkinAttrs objects, used for intra-process context
     propagation.
 
+    .. deprecated::
+       Use the Thread interface which offers better multi-threading support.
+       get_thread_local_zipkin_attrs will be removed in version 1.0.
+
     :returns: list that may contain zipkin attribute tuples
     :rtype: list
     """
+    log.warning('get_thread_local_zipkin_attrs is deprecated. See DEPRECATIONS.rst'
+                ' for details on how to migrate to using Tracer.')
     if not hasattr(_thread_local, 'zipkin_attrs'):
         _thread_local.zipkin_attrs = []
     return _thread_local.zipkin_attrs
@@ -28,9 +34,15 @@ def get_thread_local_span_storage():
     the current process. The transport handlers will pull from this storage when
     they emit the spans.
 
+    .. deprecated::
+       Use the Thread interface which offers better multi-threading support.
+       get_thread_local_span_storage will be removed in version 1.0.
+
     :returns: SpanStore object containing all non-root spans.
     :rtype: py_zipkin.storage.SpanStore
     """
+    log.warning('get_thread_local_span_storage is deprecated. See DEPRECATIONS.rst'
+                ' for details on how to migrate to using Tracer.')
     if not hasattr(_thread_local, 'span_storage'):
         from py_zipkin.storage import SpanStorage
         _thread_local.span_storage = SpanStorage()
@@ -40,34 +52,46 @@ def get_thread_local_span_storage():
 def get_zipkin_attrs():
     """Get the topmost level zipkin attributes stored.
 
+    .. deprecated::
+       Use the Thread interface which offers better multi-threading support.
+       get_zipkin_attrs will be removed in version 1.0.
+
     :returns: tuple containing zipkin attrs
     :rtype: :class:`zipkin.ZipkinAttrs`
     """
     from py_zipkin.storage import ThreadLocalStack
-    log.warning('get_zipkin_attrs is deprecated. '
-                'Use py_zipkin.storage.ThreadLocalStack().get')
+    log.warning('get_zipkin_attrs is deprecated. See DEPRECATIONS.rst for'
+                'details on how to migrate to using Tracer.')
     return ThreadLocalStack().get()
 
 
 def pop_zipkin_attrs():
     """Pop the topmost level zipkin attributes, if present.
 
+    .. deprecated::
+       Use the Thread interface which offers better multi-threading support.
+       pop_zipkin_attrs will be removed in version 1.0.
+
     :returns: tuple containing zipkin attrs
     :rtype: :class:`zipkin.ZipkinAttrs`
     """
     from py_zipkin.storage import ThreadLocalStack
-    log.warning('pop_zipkin_attrs is deprecated. '
-                'Use py_zipkin.storage.ThreadLocalStack().pop')
+    log.warning('pop_zipkin_attrs is deprecated. See DEPRECATIONS.rst for'
+                'details on how to migrate to using Tracer.')
     return ThreadLocalStack().pop()
 
 
 def push_zipkin_attrs(zipkin_attr):
     """Stores the zipkin attributes to thread local.
 
+    .. deprecated::
+       Use the Thread interface which offers better multi-threading support.
+       push_zipkin_attrs will be removed in version 1.0.
+
     :param zipkin_attr: tuple containing zipkin related attrs
     :type zipkin_attr: :class:`zipkin.ZipkinAttrs`
     """
     from py_zipkin.storage import ThreadLocalStack
-    log.warning('push_zipkin_attrs is deprecated. '
-                'Use py_zipkin.storage.ThreadLocalStack().push')
+    log.warning('push_zipkin_attrs is deprecated. See DEPRECATIONS.rst for'
+                'details on how to migrate to using Tracer.')
     return ThreadLocalStack().push(zipkin_attr)

--- a/py_zipkin/thread_local.py
+++ b/py_zipkin/thread_local.py
@@ -14,7 +14,7 @@ def get_thread_local_zipkin_attrs():
     propagation.
 
     .. deprecated::
-       Use the Thread interface which offers better multi-threading support.
+       Use the Tracer interface which offers better multi-threading support.
        get_thread_local_zipkin_attrs will be removed in version 1.0.
 
     :returns: list that may contain zipkin attribute tuples
@@ -35,7 +35,7 @@ def get_thread_local_span_storage():
     they emit the spans.
 
     .. deprecated::
-       Use the Thread interface which offers better multi-threading support.
+       Use the Tracer interface which offers better multi-threading support.
        get_thread_local_span_storage will be removed in version 1.0.
 
     :returns: SpanStore object containing all non-root spans.
@@ -53,7 +53,7 @@ def get_zipkin_attrs():
     """Get the topmost level zipkin attributes stored.
 
     .. deprecated::
-       Use the Thread interface which offers better multi-threading support.
+       Use the Tracer interface which offers better multi-threading support.
        get_zipkin_attrs will be removed in version 1.0.
 
     :returns: tuple containing zipkin attrs
@@ -69,7 +69,7 @@ def pop_zipkin_attrs():
     """Pop the topmost level zipkin attributes, if present.
 
     .. deprecated::
-       Use the Thread interface which offers better multi-threading support.
+       Use the Tracer interface which offers better multi-threading support.
        pop_zipkin_attrs will be removed in version 1.0.
 
     :returns: tuple containing zipkin attrs
@@ -85,7 +85,7 @@ def push_zipkin_attrs(zipkin_attr):
     """Stores the zipkin attributes to thread local.
 
     .. deprecated::
-       Use the Thread interface which offers better multi-threading support.
+       Use the Tracer interface which offers better multi-threading support.
        push_zipkin_attrs will be removed in version 1.0.
 
     :param zipkin_attr: tuple containing zipkin related attrs

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -12,7 +12,7 @@ from py_zipkin.encoding._helpers import create_endpoint
 from py_zipkin.encoding._helpers import Span
 from py_zipkin.exception import ZipkinError
 from py_zipkin.logging_helper import ZipkinLoggingContext
-from py_zipkin.storage import ThreadLocalStack
+from py_zipkin.storage import get_default_tracer
 from py_zipkin.util import generate_random_128bit_string
 from py_zipkin.util import generate_random_64bit_string
 
@@ -116,6 +116,7 @@ class zipkin_span(object):
         timestamp=None,
         duration=None,
         encoding=Encoding.V1_THRIFT,
+        get_tracer=None,
     ):
         """Logs a zipkin span. If this is the root span, then a zipkin
         trace is started as well.
@@ -186,6 +187,8 @@ class zipkin_span(object):
         :type duration: float
         :param encoding: Output encoding format, defaults to V1 thrift spans.
         :type encoding: Encoding
+        :param get_tracer:
+        :type tracer: function
         """
         self.service_name = service_name
         self.span_name = span_name
@@ -200,16 +203,17 @@ class zipkin_span(object):
         self.report_root_timestamp_override = report_root_timestamp
         self.use_128bit_trace_id = use_128bit_trace_id
         self.host = host
-        self._context_stack = context_stack or ThreadLocalStack()
-        if span_storage is not None:
-            self._span_storage = span_storage
-        else:
-            self._span_storage = storage.default_span_storage()
+        self._context_stack = context_stack
+        self._span_storage = span_storage
         self.firehose_handler = firehose_handler
         self.kind = self._generate_kind(kind, include)
         self.timestamp = timestamp
         self.duration = duration
         self.encoding = encoding
+        if get_tracer is not None:
+            self.get_tracer = get_tracer
+        else:
+            self.get_tracer = get_default_tracer
 
         self._is_local_root_span = False
         self.logging_context = None
@@ -257,9 +261,22 @@ class zipkin_span(object):
         if self.sample_rate is not None and not (0.0 <= self.sample_rate <= 100.0):
             raise ZipkinError('Sample rate must be between 0.0 and 100.0')
 
-        if not isinstance(self._span_storage, storage.SpanStorage):
+        if self._span_storage is not None and \
+                not isinstance(self._span_storage, storage.SpanStorage):
             raise ZipkinError('span_storage should be an instance '
                               'of py_zipkin.storage.SpanStorage')
+
+        if not callable(self.get_tracer):
+            raise ZipkinError('get_tracer should be a funtion that '
+                              'returns a Tracer object')
+
+        if self._span_storage is not None:
+            log.warning('span_storage is deprecated. Set local_storage instead.')
+            self.get_tracer()._span_storage = self._span_storage
+
+        if self._context_stack is not None:
+            log.warning('context_stack is deprecated. Set local_storage instead.')
+            self.get_tracer()._context_stack = self._context_stack
 
     def __call__(self, f):
         @functools.wraps(f)
@@ -286,6 +303,7 @@ class zipkin_span(object):
                 timestamp=self.timestamp,
                 duration=self.duration,
                 encoding=self.encoding,
+                get_tracer=self.get_tracer,
             ):
                 return f(*args, **kwargs)
         return decorated
@@ -369,7 +387,7 @@ class zipkin_span(object):
 
         else:
             # Check if there's already a trace context in _context_stack.
-            existing_zipkin_attrs = self._context_stack.get()
+            existing_zipkin_attrs = self.get_tracer().get_zipkin_attrs()
             # If there's an existing context, let's create new zipkin_attrs
             # with that context as parent.
             if existing_zipkin_attrs:
@@ -404,7 +422,7 @@ class zipkin_span(object):
         if not self.zipkin_attrs:
             return self
 
-        self._context_stack.push(self.zipkin_attrs)
+        self.get_tracer().push_zipkin_attrs(self.zipkin_attrs)
         self.do_pop_attrs = True
 
         self.start_timestamp = time.time()
@@ -416,7 +434,7 @@ class zipkin_span(object):
             # If transport is already configured don't override it. Doing so would
             # cause all previously recorded spans to never be emitted as exiting
             # the inner logging context will reset transport_configured to False.
-            if self._span_storage.is_transport_configured():
+            if self.get_tracer().is_transport_configured():
                 log.info('Transport was already configured, ignoring override'
                          'from span {}'.format(self.span_name))
                 return self
@@ -427,7 +445,7 @@ class zipkin_span(object):
                 self.span_name,
                 self.transport_handler,
                 report_root_timestamp or self.report_root_timestamp_override,
-                self._span_storage,
+                self.get_tracer,
                 self.service_name,
                 binary_annotations=self.binary_annotations,
                 add_logging_annotation=self.add_logging_annotation,
@@ -437,7 +455,7 @@ class zipkin_span(object):
                 encoding=self.encoding,
             )
             self.logging_context.start()
-            self._span_storage.set_transport_configured(configured=True)
+            self.get_tracer().set_transport_configured(configured=True)
 
         return self
 
@@ -452,12 +470,12 @@ class zipkin_span(object):
         """
 
         if self.do_pop_attrs:
-            self._context_stack.pop()
+            self.get_tracer().pop_zipkin_attrs()
 
         # If no transport is configured, there's no reason to create a new Span.
         # This also helps avoiding memory leaks since without a transport nothing
-        # would pull spans out of _span_storage.
-        if not self._span_storage.is_transport_configured():
+        # would pull spans out of get_tracer().
+        if not self.get_tracer().is_transport_configured():
             return
 
         # Add the error annotation if an exception occurred
@@ -473,7 +491,7 @@ class zipkin_span(object):
         if self.logging_context:
             self.logging_context.stop()
             self.logging_context = None
-            self._span_storage.set_transport_configured(configured=False)
+            self.get_tracer().set_transport_configured(configured=False)
             return
 
         # If we've gotten here, that means that this span is a child span of
@@ -487,7 +505,7 @@ class zipkin_span(object):
             duration = end_timestamp - self.start_timestamp
 
         endpoint = create_endpoint(self.port, self.service_name, self.host)
-        self._span_storage.append(Span(
+        self.get_tracer().add_span(Span(
             trace_id=self.zipkin_attrs.trace_id,
             name=self.span_name,
             parent_id=self.zipkin_attrs.parent_span_id,
@@ -650,7 +668,7 @@ def create_attrs_for_span(
     )
 
 
-def create_http_headers_for_new_span(context_stack=None):
+def create_http_headers_for_new_span(context_stack=None, tracer=None):
     """
     Generate the headers for a new zipkin span.
 
@@ -662,9 +680,13 @@ def create_http_headers_for_new_span(context_stack=None):
     :returns: dict containing (X-B3-TraceId, X-B3-SpanId, X-B3-ParentSpanId,
                 X-B3-Flags and X-B3-Sampled) keys OR an empty dict.
     """
-    if context_stack is None:
-        context_stack = ThreadLocalStack()
-    zipkin_attrs = context_stack.get()
+    if tracer:
+        zipkin_attrs = tracer.get_zipkin_attrs()
+    elif context_stack:
+        zipkin_attrs = context_stack.get()
+    else:
+        zipkin_attrs = get_default_tracer().get_zipkin_attrs()
+
     if not zipkin_attrs:
         return {}
 

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -187,8 +187,9 @@ class zipkin_span(object):
         :type duration: float
         :param encoding: Output encoding format, defaults to V1 thrift spans.
         :type encoding: Encoding
-        :param get_tracer:
-        :type tracer: function
+        :param get_tracer: getter function that returns the current Tracer. Will be
+            invoked at runtime every time we need to access the tracer object.
+        :type get_tracer: function
         """
         self.service_name = service_name
         self.span_name = span_name
@@ -337,6 +338,11 @@ class zipkin_span(object):
         return Kind.LOCAL
 
     def _get_current_context(self):
+        """Returns the current ZipkinAttrs and generates new ones if needed.
+
+        :returns: (report_root_timestamp, zipkin_attrs)
+        :rtype: (bool, ZipkinAttrs)
+        """
         # This check is technically not necessary since only root spans will have
         # sample_rate, zipkin_attrs or a transport set. But it helps making the
         # code clearer by separating the logic for a root span from the one for a

--- a/tests/integration/multithreading_test.py
+++ b/tests/integration/multithreading_test.py
@@ -3,8 +3,11 @@ import json
 from threading import Thread
 
 from py_zipkin import Encoding
+from py_zipkin.storage import get_default_tracer
 from py_zipkin.zipkin import zipkin_span
 from tests.test_helpers import MockTransportHandler
+
+tracer = get_default_tracer()
 
 
 @zipkin_span(service_name='service1', span_name='service1_do_stuff')
@@ -20,7 +23,7 @@ def run_inside_another_thread(transport):
         need a way to return the results to the main thread.
     :type transport: MockTransportHandler
     """
-    with zipkin_span(
+    with get_default_tracer().zipkin_span(
         service_name='webapp',
         span_name='index',
         transport_handler=transport,

--- a/tests/integration/multithreading_test.py
+++ b/tests/integration/multithreading_test.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+import json
+from threading import Thread
+
+from py_zipkin import Encoding
+from py_zipkin.zipkin import zipkin_span
+from tests.test_helpers import MockTransportHandler
+
+
+@zipkin_span(service_name='service1', span_name='service1_do_stuff')
+def do_stuff():
+    return 'OK'
+
+
+def run_inside_another_thread(transport):
+    """Run this function inside a different thread.
+
+    :param transport: transport handler. We need to pass it in since any
+        assertion we do inside this thread gets silently swallowed, so we
+        need a way to return the results to the main thread.
+    :type transport: MockTransportHandler
+    """
+    with zipkin_span(
+        service_name='webapp',
+        span_name='index',
+        transport_handler=transport,
+        sample_rate=100.0,
+        encoding=Encoding.V2_JSON,
+    ):
+        do_stuff()
+
+
+def test_decorator_works_in_a_new_thread():
+    """The zipkin_span decorator is instanciated in a thread and then run in
+    another. Let's verify that it works and that it stores the span in the
+    right thread's thread-storage.
+    """
+    transport = MockTransportHandler()
+    thread = Thread(target=run_inside_another_thread, args=(transport,))
+    thread.start()
+    thread.join()
+
+    output = transport.get_payloads()
+    assert len(output) == 1
+
+    spans = json.loads(output[0])
+    assert len(spans) == 2
+    assert spans[0]['name'] == 'service1_do_stuff'
+    assert spans[1]['name'] == 'index'

--- a/tests/integration/zipkin_integration_test.py
+++ b/tests/integration/zipkin_integration_test.py
@@ -5,9 +5,9 @@ import pytest
 
 from py_zipkin import Encoding
 from py_zipkin import Kind
-from py_zipkin import storage
 from py_zipkin import zipkin
 from py_zipkin.logging_helper import LOGGING_END_KEY
+from py_zipkin.storage import get_default_tracer
 from py_zipkin.zipkin import ZipkinAttrs
 
 
@@ -550,7 +550,7 @@ def test_memory_leak():
     # In py_zipkin >= 0.13.0 and <= 0.14.0 this test fails since the
     # span_storage contains 10 spans once you exit the for loop.
     mock_transport_handler, mock_logs = mock_logger()
-    assert len(storage.default_span_storage()) == 0
+    assert len(get_default_tracer().get_spans()) == 0
     for _ in range(10):
         with zipkin.zipkin_client_span(
             service_name='test_service_name',
@@ -566,4 +566,4 @@ def test_memory_leak():
                 pass
 
     assert len(mock_logs) == 0
-    assert len(storage.default_span_storage()) == 0
+    assert len(get_default_tracer().get_spans()) == 0

--- a/tests/stack_test.py
+++ b/tests/stack_test.py
@@ -18,10 +18,17 @@ def test_get_zipkin_attrs_returns_none_if_no_zipkin_attrs():
 
 
 def test_get_zipkin_attrs_with_context_returns_none_if_no_zipkin_attrs():
-    assert not py_zipkin.storage.Stack([]).get()
+    with mock.patch.object(py_zipkin.storage.log, 'warning', autospec=True) as log:
+        assert not py_zipkin.storage.Stack([]).get()
+        assert log.call_count == 1
 
 
-@mock.patch('py_zipkin.storage.thread_local._thread_local.zipkin_attrs', ['foo'])
+def test_storage_stack_still_works_if_you_dont_pass_in_storage():
+    # Let's make sure this still works if we don't pass in a custom storage.
+    assert not py_zipkin.storage.Stack().get()
+
+
+@mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', ['foo'])
 def test_get_zipkin_attrs_returns_the_last_of_the_list():
     assert 'foo' == py_zipkin.storage.ThreadLocalStack().get()
 

--- a/tests/storage_test.py
+++ b/tests/storage_test.py
@@ -1,22 +1,31 @@
 import mock
 
 from py_zipkin import storage
+from tests.test_helpers import MockTracer
 
 
-@mock.patch.object(storage.thread_local, '_thread_local')
+@mock.patch.object(storage, '_thread_local_tracer')
 @mock.patch.object(storage, 'Tracer')
 def test_get_thread_local_tracer_no_tracer(mock_tracer, mock_tl):
     del mock_tl.tracer
-    tracer = storage.get_thread_local_tracer()
+    tracer = storage._get_thread_local_tracer()
 
     assert mock_tracer.call_count == 1
     assert tracer == mock_tracer.return_value
 
 
-@mock.patch.object(storage.thread_local, '_thread_local')
+@mock.patch.object(storage, '_thread_local_tracer')
+def test_set_thread_local_tracer(mock_tl):
+    tracer = MockTracer()
+    storage._set_thread_local_tracer(tracer)
+
+    assert storage._get_thread_local_tracer() == tracer
+
+
+@mock.patch.object(storage, '_thread_local_tracer')
 @mock.patch.object(storage, 'Tracer')
 def test_get_thread_local_tracer_existing_tracer(mock_tracer, mock_tl):
-    tracer = storage.get_thread_local_tracer()
+    tracer = storage._get_thread_local_tracer()
 
     assert mock_tracer.call_count == 0
     assert tracer == mock_tl.tracer
@@ -37,4 +46,18 @@ def test_get_default_tracer(mock_contextvar):
 
     # We're in python 2.7 to 3.6
     assert storage.get_default_tracer() == \
-        storage.thread_local._thread_local.tracer
+        storage._thread_local_tracer.tracer
+
+
+@mock.patch.object(storage, '_contextvars_tracer')
+def test_set_default_tracer(mock_contextvar):
+    tracer = MockTracer()
+    # We're in python 3.7+
+    storage.set_default_tracer(tracer)
+    assert mock_contextvar.set.call_args == mock.call(tracer)
+
+    storage._contextvars_tracer = None
+
+    # We're in python 2.7 to 3.6
+    storage.set_default_tracer(tracer)
+    assert storage._thread_local_tracer.tracer == tracer

--- a/tests/storage_test.py
+++ b/tests/storage_test.py
@@ -1,0 +1,40 @@
+import mock
+
+from py_zipkin import storage
+
+
+@mock.patch.object(storage.thread_local, '_thread_local')
+@mock.patch.object(storage, 'Tracer')
+def test_get_thread_local_tracer_no_tracer(mock_tracer, mock_tl):
+    del mock_tl.tracer
+    tracer = storage.get_thread_local_tracer()
+
+    assert mock_tracer.call_count == 1
+    assert tracer == mock_tracer.return_value
+
+
+@mock.patch.object(storage.thread_local, '_thread_local')
+@mock.patch.object(storage, 'Tracer')
+def test_get_thread_local_tracer_existing_tracer(mock_tracer, mock_tl):
+    tracer = storage.get_thread_local_tracer()
+
+    assert mock_tracer.call_count == 0
+    assert tracer == mock_tl.tracer
+
+
+def test_default_span_storage_warns():
+    with mock.patch.object(storage.log, 'warning') as mock_log:
+        storage.default_span_storage()
+        assert mock_log.call_count == 1
+
+
+@mock.patch.object(storage, '_contextvars_tracer')
+def test_get_default_tracer(mock_contextvar):
+    # We're in python 3.7+
+    assert storage.get_default_tracer() == storage._contextvars_tracer.get()
+
+    storage._contextvars_tracer = None
+
+    # We're in python 2.7 to 3.6
+    assert storage.get_default_tracer() == \
+        storage.thread_local._thread_local.tracer

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,6 +8,7 @@ from py_zipkin import Kind
 from py_zipkin import thrift
 from py_zipkin import zipkin
 from py_zipkin.encoding._encoders import IEncoder
+from py_zipkin.storage import Tracer
 from py_zipkin.thrift import zipkin_core
 from py_zipkin.transport import BaseTransportHandler
 from py_zipkin.util import generate_random_128bit_string
@@ -48,6 +49,11 @@ class MockEncoder(IEncoder):
         assert isinstance(new_span, six.string_types)
 
         return self.fits_bool
+
+
+class MockTracer(Tracer):
+    def get_context(self):
+        return self._context_stack
 
 
 def generate_list_of_spans(encoding):

--- a/tests/thread_local_test.py
+++ b/tests/thread_local_test.py
@@ -1,9 +1,11 @@
 import mock
 
 from py_zipkin import thread_local
+from py_zipkin.storage import SpanStorage
 
 # Can't patch an attribute that doesn't yet exist
 thread_local._thread_local.zipkin_attrs = []
+thread_local._thread_local.span_storage = SpanStorage()
 
 
 @mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', ['foo'])
@@ -16,6 +18,20 @@ def test_get_thread_local_zipkin_attrs_creates_empty_list_if_not_attached():
     assert not hasattr(thread_local._thread_local, "zipkin_attrs")
     assert thread_local.get_thread_local_zipkin_attrs() == []
     assert hasattr(thread_local._thread_local, "zipkin_attrs")
+
+
+@mock.patch(
+    'py_zipkin.thread_local._thread_local.span_storage', SpanStorage(['foo'])
+)
+def test_get_thread_local_span_storage_present():
+    assert thread_local.get_thread_local_span_storage() == SpanStorage(['foo'])
+
+
+def test_get_thread_local_span_storage_creates_empty_list_if_not_attached():
+    delattr(thread_local._thread_local, "span_storage")
+    assert not hasattr(thread_local._thread_local, "span_storage")
+    assert thread_local.get_thread_local_span_storage() == SpanStorage()
+    assert hasattr(thread_local._thread_local, "span_storage")
 
 
 @mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', ['foo'])

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -13,15 +13,17 @@ from py_zipkin.encoding._helpers import create_endpoint
 from py_zipkin.encoding._helpers import Span
 from py_zipkin.exception import ZipkinError
 from py_zipkin.storage import default_span_storage
+from py_zipkin.storage import get_default_tracer
 from py_zipkin.storage import SpanStorage
 from py_zipkin.storage import Stack
 from py_zipkin.storage import ThreadLocalStack
 from py_zipkin.util import generate_random_64bit_string
 from py_zipkin.zipkin import ZipkinAttrs
+from tests.test_helpers import MockTracer
 from tests.test_helpers import MockTransportHandler
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def clean_thread_local():
     yield
 
@@ -30,6 +32,10 @@ def clean_thread_local():
         pass
 
     default_span_storage().clear()
+
+    while get_default_tracer().pop_zipkin_attrs():
+        pass
+    get_default_tracer()._span_storage.clear()
 
 
 class TestZipkinSpan(object):
@@ -42,6 +48,7 @@ class TestZipkinSpan(object):
         firehose = MockTransportHandler()
         stack = Stack([])
         span_storage = SpanStorage()
+        tracer = MockTracer()
 
         context = zipkin.zipkin_span(
             service_name='test_service',
@@ -65,6 +72,7 @@ class TestZipkinSpan(object):
             timestamp=1234,
             duration=10,
             encoding=Encoding.V2_JSON,
+            get_tracer=lambda: tracer,
         )
 
         assert context.service_name == 'test_service'
@@ -92,13 +100,15 @@ class TestZipkinSpan(object):
         assert context.timestamp == 1234
         assert context.duration == 10
         assert context.encoding == Encoding.V2_JSON
+        # Check for backward compatibility
+        assert tracer.get_spans() == span_storage
+        assert tracer.get_context() == stack
 
-    @mock.patch.object(zipkin, 'ThreadLocalStack', autospec=True)
+    @mock.patch.object(zipkin, 'get_default_tracer', autospec=True)
     @mock.patch.object(zipkin.storage, 'default_span_storage', autospec=True)
     @mock.patch.object(zipkin.zipkin_span, '_generate_kind', autospec=True)
-    def test_init_defaults(self, mock_generate_kind, mock_storage, mock_stack):
+    def test_init_defaults(self, mock_generate_kind, mock_storage, mock_tracer):
         # Test that special arguments are properly defaulted
-        mock_stack.return_value = Stack([])
         mock_storage.return_value = SpanStorage()
         context = zipkin.zipkin_span(
             service_name='test_service',
@@ -109,8 +119,7 @@ class TestZipkinSpan(object):
         assert context.span_name == 'test_span'
         assert context.annotations == {}
         assert context.binary_annotations == {}
-        assert context._context_stack == mock_stack.return_value
-        assert context._span_storage == mock_storage.return_value
+        assert context.get_tracer == mock_tracer
         assert mock_generate_kind.call_args == mock.call(
             context,
             None,
@@ -205,6 +214,19 @@ class TestZipkinSpan(object):
                     port=5,
                     sample_rate=100.0,
                     span_storage=[],
+            ):
+                pass
+
+    def test_init_get_tracer_not_callable(self):
+        # Missing transport_handler
+        with pytest.raises(ZipkinError):
+            with zipkin.zipkin_span(
+                    service_name='some_service_name',
+                    span_name='span_name',
+                    transport_handler=MockTransportHandler(),
+                    port=5,
+                    sample_rate=100.0,
+                    get_tracer=MockTracer(),
             ):
                 pass
 
@@ -389,12 +411,12 @@ class TestZipkinSpan(object):
             service_name='test_service',
             span_name='test_span',
         )
-        context._context_stack.push(zipkin_attrs)
+        context.get_tracer()._context_stack.push(zipkin_attrs)
 
         _, current_attrs = context._get_current_context()
 
         # clean up the stack to not pollute other tests
-        context._context_stack.pop()
+        context.get_tracer()._context_stack.pop()
 
         assert mock_create_attr.call_count == 0
         assert current_attrs == ZipkinAttrs(
@@ -425,7 +447,8 @@ class TestZipkinSpan(object):
         # No current context in the stack, let's exit immediately
         context = zipkin.zipkin_span('test_service', 'test_span')
 
-        with mock.patch.object(context._context_stack, 'push') as mock_push:
+        with mock.patch.object(context.get_tracer()._context_stack, 'push') \
+                as mock_push:
             context.start()
             assert mock_push.call_count == 0
 
@@ -434,7 +457,9 @@ class TestZipkinSpan(object):
     def test_start_root_span(self, mock_time, mock_log_ctx):
         transport = MockTransportHandler()
         firehose = MockTransportHandler()
-        span_storage = SpanStorage()
+        tracer = MockTracer()
+
+        def get_tracer(): return tracer
         context = zipkin.zipkin_span(
             service_name='test_service',
             span_name='test_span',
@@ -442,8 +467,8 @@ class TestZipkinSpan(object):
             firehose_handler=firehose,
             sample_rate=100.0,
             max_span_batch_size=50,
-            span_storage=span_storage,
             encoding=Encoding.V2_JSON,
+            get_tracer=get_tracer,
         )
 
         context.start()
@@ -456,7 +481,7 @@ class TestZipkinSpan(object):
             'test_span',
             transport,
             True,
-            context._span_storage,
+            get_tracer,
             'test_service',
             binary_annotations={},
             add_logging_annotation=False,
@@ -466,25 +491,25 @@ class TestZipkinSpan(object):
             encoding=Encoding.V2_JSON,
         )
         assert mock_log_ctx.return_value.start.call_count == 1
-        assert span_storage.is_transport_configured() is True
+        assert tracer.is_transport_configured() is True
 
     @mock.patch.object(zipkin, 'ZipkinLoggingContext', autospec=True)
     def test_start_root_span_not_sampled(self, mock_log_ctx):
         transport = MockTransportHandler()
-        span_storage = SpanStorage()
+        tracer = MockTracer()
         context = zipkin.zipkin_span(
             service_name='test_service',
             span_name='test_span',
             transport_handler=transport,
             sample_rate=0.0,
-            span_storage=span_storage,
+            get_tracer=lambda: tracer,
         )
 
         context.start()
 
         assert context.zipkin_attrs is not None
         assert mock_log_ctx.call_count == 0
-        assert span_storage.is_transport_configured() is False
+        assert tracer.is_transport_configured() is False
 
     @mock.patch.object(zipkin, 'ZipkinLoggingContext', autospec=True)
     def test_start_root_span_not_sampled_firehose(self, mock_log_ctx):
@@ -492,14 +517,14 @@ class TestZipkinSpan(object):
         # setup the transport anyway.
         transport = MockTransportHandler()
         firehose = MockTransportHandler()
-        span_storage = SpanStorage()
+        tracer = MockTracer()
         context = zipkin.zipkin_span(
             service_name='test_service',
             span_name='test_span',
             transport_handler=transport,
             firehose_handler=firehose,
             sample_rate=0.0,
-            span_storage=span_storage,
+            get_tracer=lambda: tracer,
         )
 
         context.start()
@@ -507,7 +532,7 @@ class TestZipkinSpan(object):
         assert context.zipkin_attrs is not None
         assert mock_log_ctx.call_count == 1
         assert mock_log_ctx.return_value.start.call_count == 1
-        assert span_storage.is_transport_configured() is True
+        assert tracer.is_transport_configured() is True
 
     @mock.patch.object(zipkin, 'ZipkinLoggingContext', autospec=True)
     @mock.patch.object(zipkin.log, 'info', autospec=True)
@@ -515,22 +540,22 @@ class TestZipkinSpan(object):
         # Transport is already setup, so we should not override it
         # and log a message to inform the user.
         transport = MockTransportHandler()
-        span_storage = SpanStorage()
+        tracer = MockTracer()
         context = zipkin.zipkin_span(
             service_name='test_service',
             span_name='test_span',
             transport_handler=transport,
             sample_rate=100.0,
-            span_storage=span_storage,
+            get_tracer=lambda: tracer,
         )
 
-        span_storage.set_transport_configured(configured=True)
+        tracer.set_transport_configured(configured=True)
 
         context.start()
 
         assert context.zipkin_attrs is not None
         assert mock_log_ctx.call_count == 0
-        assert span_storage.is_transport_configured() is True
+        assert tracer.is_transport_configured() is True
         assert mock_log.call_count == 1
 
     def test_exit(self):
@@ -578,13 +603,13 @@ class TestZipkinSpan(object):
     def test_stop_root(self):
         # Transport is not setup, exit immediately
         transport = MockTransportHandler()
-        span_storage = SpanStorage()
+        tracer = MockTracer()
         context = zipkin.zipkin_span(
             service_name='test_service',
             span_name='test_span',
             transport_handler=transport,
             sample_rate=100.0,
-            span_storage=span_storage,
+            get_tracer=lambda: tracer,
         )
         context.start()
 
@@ -593,25 +618,26 @@ class TestZipkinSpan(object):
             assert mock_log_ctx.stop.call_count == 1
             # Test that we reset evverything after calling stop()
             assert context.logging_context is None
-            assert span_storage.is_transport_configured() is False
-            assert len(span_storage) == 0
+            assert tracer.is_transport_configured() is False
+            assert len(tracer.get_spans()) == 0
 
     @mock.patch('time.time', autospec=True, return_value=123)
     def test_stop_non_root(self, mock_time):
         # Transport is not setup, exit immediately
-        span_storage = SpanStorage()
-        span_storage.set_transport_configured(configured=True)
+        tracer = MockTracer()
+        tracer.set_transport_configured(configured=True)
+        tracer.get_context().push(zipkin.create_attrs_for_span())
         context = zipkin.zipkin_span(
             service_name='test_service',
             span_name='test_span',
-            span_storage=span_storage,
+            get_tracer=lambda: tracer,
         )
         context.start()
 
         context.stop()
-        assert len(span_storage) == 1
+        assert len(tracer.get_spans()) == 1
         endpoint = create_endpoint(service_name='test_service')
-        assert span_storage[0] == Span(
+        assert tracer.get_spans()[0] == Span(
             trace_id=context.zipkin_attrs.trace_id,
             name='test_span',
             parent_id=context.zipkin_attrs.parent_span_id,
@@ -625,26 +651,27 @@ class TestZipkinSpan(object):
             tags={},
         )
 
-        assert span_storage.is_transport_configured() is True
+        assert tracer.is_transport_configured() is True
 
     def test_stop_non_root_ts_duration_overridden(self):
         # Transport is not setup, exit immediately
-        span_storage = SpanStorage()
-        span_storage.set_transport_configured(configured=True)
+        tracer = MockTracer()
+        tracer.set_transport_configured(configured=True)
+        tracer.get_context().push(zipkin.create_attrs_for_span())
         ts = time.time()
         context = zipkin.zipkin_span(
             service_name='test_service',
             span_name='test_span',
-            span_storage=span_storage,
             timestamp=ts,
             duration=25,
+            get_tracer=lambda: tracer,
         )
         context.start()
 
         context.stop()
-        assert len(span_storage) == 1
+        assert len(tracer.get_spans()) == 1
         endpoint = create_endpoint(service_name='test_service')
-        assert span_storage[0] == Span(
+        assert tracer.get_spans()[0] == Span(
             trace_id=context.zipkin_attrs.trace_id,
             name='test_span',
             parent_id=context.zipkin_attrs.parent_span_id,
@@ -658,9 +685,9 @@ class TestZipkinSpan(object):
             tags={},
         )
 
-        assert span_storage.is_transport_configured() is True
+        assert tracer.is_transport_configured() is True
 
-    def test_update_binary_annotations_root(self, clean_thread_local):
+    def test_update_binary_annotations_root(self):
         with zipkin.zipkin_span(
             service_name='test_service',
             span_name='test_span',
@@ -682,7 +709,7 @@ class TestZipkinSpan(object):
             span_name='test_span',
             binary_annotations={'region': 'uswest-1'}
         )
-        context._context_stack.push(zipkin.create_attrs_for_span())
+        context.get_tracer()._context_stack.push(zipkin.create_attrs_for_span())
         with context as span:
             span.update_binary_annotations({'status': '200'})
 
@@ -726,7 +753,7 @@ class TestZipkinSpan(object):
             with pytest.raises(ValueError):
                 span.add_sa_binary_annotation(80, 'remote_service', '10.1.2.3')
 
-    def test_add_sa_binary_annotation_root(self, clean_thread_local):
+    def test_add_sa_binary_annotation_root(self):
         # Nothing happens if this is not a client span
         with zipkin.zipkin_client_span(
             service_name='test_service',
@@ -744,7 +771,7 @@ class TestZipkinSpan(object):
             with pytest.raises(ValueError):
                 span.add_sa_binary_annotation(80, 'remote_service', '10.1.2.3')
 
-    def test_override_span_name(self, clean_thread_local):
+    def test_override_span_name(self):
         with zipkin.zipkin_client_span(
                 service_name='test_service',
                 span_name='test_span',
@@ -815,10 +842,10 @@ def test_create_attrs_for_span(random_64bit_mock, random_128bit_mock):
     )
 
 
-@mock.patch('py_zipkin.storage.ThreadLocalStack', autospec=True)
-def test_create_headers_for_new_span_empty_if_no_active_request(mock_stack):
-    mock_stack.return_value.get.return_value = None
-    assert {} == zipkin.create_http_headers_for_new_span()
+def test_create_headers_for_new_span_empty_if_no_active_request():
+    with mock.patch.object(get_default_tracer(), 'get_zipkin_attrs') as mock_ctx:
+        mock_ctx.return_value = None
+        assert {} == zipkin.create_http_headers_for_new_span()
 
 
 @mock.patch('py_zipkin.zipkin.generate_random_64bit_string', autospec=True)
@@ -839,4 +866,25 @@ def test_create_headers_for_new_span_returns_header_if_active_request(gen_mock):
     }
     assert expected == zipkin.create_http_headers_for_new_span(
         context_stack=mock_context_stack,
+    )
+
+
+@mock.patch('py_zipkin.zipkin.generate_random_64bit_string', autospec=True)
+def test_create_headers_for_new_span_custom_tracer(gen_mock):
+    tracer = MockTracer()
+    tracer.push_zipkin_attrs(mock.Mock(
+        trace_id='27133d482ba4f605',
+        span_id='37133d482ba4f605',
+        is_sampled=True,
+    ))
+    gen_mock.return_value = '17133d482ba4f605'
+    expected = {
+        'X-B3-TraceId': '27133d482ba4f605',
+        'X-B3-SpanId': '17133d482ba4f605',
+        'X-B3-ParentSpanId': '37133d482ba4f605',
+        'X-B3-Flags': '0',
+        'X-B3-Sampled': '1',
+    }
+    assert expected == zipkin.create_http_headers_for_new_span(
+        tracer=tracer,
     )


### PR DESCRIPTION
This is an alternative implementation for #111.

I didn't particularly like that everything was called *Storage which was
very confusing. Also having to subclass LocalStorage (or SpanStorage)
and override a property felt weird and error prone.
Also the suggested way of getting the current zipkin_attrs by calling
ThreadLocalStack().get() felt weird since why do I need to create a new
object every time?

This PR takes a different approach. Users will need to pass in a
`get_tracer` function, which will be invoked at runtime every time we
need to access the tracer. That makes it work in multithreaded
environments.
Also instead of calling it storage I called the new class Tracer. In the
future I'll probably attach also the transport handlers to it,
completely removing the need for the logging_context.

If users want to access the current context they can just call the
`get_zipkin_attrs()` tracer's function. To access the tracer it's enough
to use `get_default_tracer()` which will return the correct one.