### PR TITLE
Make ThreadLocalStack() get context from tracer

### DIFF
--- a/py_zipkin/storage.py
+++ b/py_zipkin/storage.py
@@ -3,9 +3,6 @@ import logging
 import threading
 from collections import deque
 
-from py_zipkin.thread_local import get_thread_local_span_storage
-from py_zipkin.thread_local import get_thread_local_zipkin_attrs
-
 try:  # pragma: no cover
     # Since python 3.7 threadlocal is deprecated in favor of contextvars
     # which also work in asyncio.
@@ -151,7 +148,7 @@ class ThreadLocalStack(Stack):
 
     @property
     def _storage(self):
-        return get_thread_local_zipkin_attrs()
+        return get_default_tracer()._context_stack._storage
 
 
 class SpanStorage(deque):
@@ -167,7 +164,7 @@ class SpanStorage(deque):
 def default_span_storage():
     log.warning('default_span_storage is deprecated. See DEPRECATIONS.rst for'
                 'details on how to migrate to using Tracer.')
-    return get_thread_local_span_storage()
+    return get_default_tracer()._span_storage
 
 
 def get_default_tracer():

--- a/py_zipkin/thread_local.py
+++ b/py_zipkin/thread_local.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
-import threading
 
-_thread_local = threading.local()
+from py_zipkin.storage import get_default_tracer
 
 log = logging.getLogger('py_zipkin.thread_local')
 
@@ -22,9 +21,7 @@ def get_thread_local_zipkin_attrs():
     """
     log.warning('get_thread_local_zipkin_attrs is deprecated. See DEPRECATIONS.rst'
                 ' for details on how to migrate to using Tracer.')
-    if not hasattr(_thread_local, 'zipkin_attrs'):
-        _thread_local.zipkin_attrs = []
-    return _thread_local.zipkin_attrs
+    return get_default_tracer()._context_stack._storage
 
 
 def get_thread_local_span_storage():
@@ -43,10 +40,7 @@ def get_thread_local_span_storage():
     """
     log.warning('get_thread_local_span_storage is deprecated. See DEPRECATIONS.rst'
                 ' for details on how to migrate to using Tracer.')
-    if not hasattr(_thread_local, 'span_storage'):
-        from py_zipkin.storage import SpanStorage
-        _thread_local.span_storage = SpanStorage()
-    return _thread_local.span_storage
+    return get_default_tracer()._span_storage
 
 
 def get_zipkin_attrs():

--- a/tests/stack_test.py
+++ b/tests/stack_test.py
@@ -11,10 +11,11 @@ def create_zipkin_attrs():
     py_zipkin.storage.ThreadLocalStack().get()
 
 
-@mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', [])
 def test_get_zipkin_attrs_returns_none_if_no_zipkin_attrs():
-    assert not py_zipkin.storage.ThreadLocalStack().get()
-    assert not py_zipkin.storage.ThreadLocalStack().get()
+    tracer = py_zipkin.storage.get_default_tracer()
+    with mock.patch.object(tracer._context_stack, '_storage', []):
+        assert not py_zipkin.storage.ThreadLocalStack().get()
+        assert not py_zipkin.storage.ThreadLocalStack().get()
 
 
 def test_get_zipkin_attrs_with_context_returns_none_if_no_zipkin_attrs():
@@ -28,30 +29,31 @@ def test_storage_stack_still_works_if_you_dont_pass_in_storage():
     assert not py_zipkin.storage.Stack().get()
 
 
-@mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', ['foo'])
 def test_get_zipkin_attrs_returns_the_last_of_the_list():
-    assert 'foo' == py_zipkin.storage.ThreadLocalStack().get()
+    tracer = py_zipkin.storage.get_default_tracer()
+    with mock.patch.object(tracer._context_stack, '_storage', ['foo']):
+        assert 'foo' == py_zipkin.storage.ThreadLocalStack().get()
 
 
 def test_get_zipkin_attrs_with_context_returns_the_last_of_the_list():
     assert 'foo' == py_zipkin.storage.Stack(['bar', 'foo']).get()
 
 
-@mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', [])
 def test_pop_zipkin_attrs_does_nothing_if_no_requests():
-    assert not py_zipkin.storage.ThreadLocalStack().pop()
+    tracer = py_zipkin.storage.get_default_tracer()
+    with mock.patch.object(tracer._context_stack, '_storage', []):
+        assert not py_zipkin.storage.ThreadLocalStack().pop()
 
 
 def test_pop_zipkin_attrs_with_context_does_nothing_if_no_requests():
     assert not py_zipkin.storage.Stack([]).pop()
 
 
-@mock.patch(
-    'py_zipkin.thread_local._thread_local.zipkin_attrs', ['foo', 'bar']
-)
 def test_pop_zipkin_attrs_removes_the_last_zipkin_attrs():
-    assert 'bar' == py_zipkin.storage.ThreadLocalStack().pop()
-    assert 'foo' == py_zipkin.storage.ThreadLocalStack().get()
+    tracer = py_zipkin.storage.get_default_tracer()
+    with mock.patch.object(tracer._context_stack, '_storage', ['foo', 'bar']):
+        assert 'bar' == py_zipkin.storage.ThreadLocalStack().pop()
+        assert 'foo' == py_zipkin.storage.ThreadLocalStack().get()
 
 
 def test_pop_zipkin_attrs_with_context_removes_the_last_zipkin_attrs():
@@ -60,11 +62,12 @@ def test_pop_zipkin_attrs_with_context_removes_the_last_zipkin_attrs():
     assert 'foo' == context_stack.get()
 
 
-@mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', ['foo'])
 def test_push_zipkin_attrs_adds_new_zipkin_attrs_to_list():
-    assert 'foo' == py_zipkin.storage.ThreadLocalStack().get()
-    py_zipkin.storage.ThreadLocalStack().push('bar')
-    assert 'bar' == py_zipkin.storage.ThreadLocalStack().get()
+    tracer = py_zipkin.storage.get_default_tracer()
+    with mock.patch.object(tracer._context_stack, '_storage', ['foo']):
+        assert 'foo' == py_zipkin.storage.ThreadLocalStack().get()
+        py_zipkin.storage.ThreadLocalStack().push('bar')
+        assert 'bar' == py_zipkin.storage.ThreadLocalStack().get()
 
 
 def test_push_zipkin_attrs_with_context_adds_new_zipkin_attrs_to_list():

--- a/tests/thread_local_test.py
+++ b/tests/thread_local_test.py
@@ -1,54 +1,38 @@
 import mock
 
+from py_zipkin import storage
 from py_zipkin import thread_local
 from py_zipkin.storage import SpanStorage
 
-# Can't patch an attribute that doesn't yet exist
-thread_local._thread_local.zipkin_attrs = []
-thread_local._thread_local.span_storage = SpanStorage()
 
-
-@mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', ['foo'])
 def test_get_thread_local_zipkin_attrs_returns_back_zipkin_attrs_if_present():
-    assert thread_local.get_thread_local_zipkin_attrs() == ['foo']
+    tracer = storage.get_default_tracer()
+    with mock.patch.object(tracer._context_stack, '_storage', ['foo']):
+        assert thread_local.get_thread_local_zipkin_attrs() == ['foo']
 
 
-def test_get_thread_local_zipkin_attrs_creates_empty_list_if_not_attached():
-    delattr(thread_local._thread_local, "zipkin_attrs")
-    assert not hasattr(thread_local._thread_local, "zipkin_attrs")
-    assert thread_local.get_thread_local_zipkin_attrs() == []
-    assert hasattr(thread_local._thread_local, "zipkin_attrs")
-
-
-@mock.patch(
-    'py_zipkin.thread_local._thread_local.span_storage', SpanStorage(['foo'])
-)
 def test_get_thread_local_span_storage_present():
-    assert thread_local.get_thread_local_span_storage() == SpanStorage(['foo'])
+    tracer = storage.get_default_tracer()
+    with mock.patch.object(tracer, '_span_storage', SpanStorage(['foo'])):
+        assert thread_local.get_thread_local_span_storage() == SpanStorage(['foo'])
 
 
-def test_get_thread_local_span_storage_creates_empty_list_if_not_attached():
-    delattr(thread_local._thread_local, "span_storage")
-    assert not hasattr(thread_local._thread_local, "span_storage")
-    assert thread_local.get_thread_local_span_storage() == SpanStorage()
-    assert hasattr(thread_local._thread_local, "span_storage")
-
-
-@mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', ['foo'])
 def test_get_zipkin_attrs_returns_the_last_of_the_list():
-    assert 'foo' == thread_local.get_zipkin_attrs()
+    tracer = storage.get_default_tracer()
+    with mock.patch.object(tracer._context_stack, '_storage', ['foo']):
+        assert 'foo' == thread_local.get_zipkin_attrs()
 
 
-@mock.patch(
-    'py_zipkin.thread_local._thread_local.zipkin_attrs', ['foo', 'bar']
-)
 def test_pop_zipkin_attrs_removes_the_last_zipkin_attrs():
-    assert 'bar' == thread_local.pop_zipkin_attrs()
-    assert 'foo' == thread_local.get_zipkin_attrs()
+    tracer = storage.get_default_tracer()
+    with mock.patch.object(tracer._context_stack, '_storage', ['foo', 'bar']):
+        assert 'bar' == thread_local.pop_zipkin_attrs()
+        assert 'foo' == thread_local.get_zipkin_attrs()
 
 
-@mock.patch('py_zipkin.thread_local._thread_local.zipkin_attrs', ['foo'])
 def test_push_zipkin_attrs_adds_new_zipkin_attrs_to_list():
-    assert 'foo' == thread_local.get_zipkin_attrs()
-    thread_local.push_zipkin_attrs('bar')
-    assert 'bar' == thread_local.get_zipkin_attrs()
+    tracer = storage.get_default_tracer()
+    with mock.patch.object(tracer._context_stack, '_storage', ['foo']):
+        assert 'foo' == thread_local.get_zipkin_attrs()
+        thread_local.push_zipkin_attrs('bar')
+        assert 'bar' == thread_local.get_zipkin_attrs()

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,11 @@ envlist = pre-commit, py27, py34, py35, py36, pypy, flake8
 
 [testenv]
 deps = -rrequirements-dev.txt
+# Don't use wheel for thriftpy2. When creating the pypy virtualenv pip generates a generic
+# py2-py3 wheel that gets put in the cache and from then on reused also for CPython. That causes
+# thriftpy2 imports to fail with `ModuleNotFoundError: No module named 'thriftpy2.protocol.cybin'`
+# since those expect those modules to have been compiled to `.so`.
+install_command = python -m pip install --no-binary thriftpy2 {opts} {packages}
 commands =
     coverage erase
     # Check that we have 100% unit test coverage, without counting integration tests
@@ -15,7 +20,9 @@ commands =
 [testenv:pre-commit]
 basepython = python3.6
 deps = pre-commit
-commands = pre-commit run --all-files {posargs}
+commands =
+    pre-commit install -f --install-hooks
+    pre-commit run --all-files {posargs}
 
 [testenv:flake8]
 basepython = python3.6


### PR DESCRIPTION
py-zipkin 0.18.0 broke `ThreadLocalStack().get()` since that's now using a different thread_local variable than the tracer.

The only real change here is to make the thread_local module use the same thread_local variables as the tracer. The rest is just tests updates.

Plus a small bug fix for tox.ini so that it doesn't build the wheel for thriftpy2 since that wheel doesn't get built correctly under pypy and pollutes the local cache.