### PR TITLE
log error over raise ZipkinError

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 0.18.2 (2019-03-26)
 -------------------
 - Handled exception while emitting trace and log the error
-- Ensure tracer is cleared regardless span emit outcome
+- Ensure tracer is cleared regardless span of emit outcome
 
 0.18.1 (2019-02-22)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+0.18.2 (2019-03-26)
+-------------------
+- Handled exception while emitting trace and log the error
+- Ensure tracer is cleared regardless span emit outcome
+
 0.18.1 (2019-02-22)
 -------------------
 - Fix ThreadLocalStack() bug introduced in 0.18.0

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -496,8 +496,7 @@ class zipkin_span(object):
             try:
                 self.logging_context.stop()
             except Exception as ex:
-                err_msg = 'Error emitting zipkin trace, service:{}, {}'.format(
-                    self.service_name,
+                err_msg = 'Error emitting zipkin trace. {}'.format(
                     repr(ex),
                 )
                 log.error(err_msg)

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -495,14 +495,15 @@ class zipkin_span(object):
         if self.logging_context:
             try:
                 self.logging_context.stop()
-            except Exception:
-                self.get_tracer().clear()
-                err_msg = 'Error while emitting zipkin trace. {}'.format(
+            except Exception as ex:
+                err_msg = 'Error emitting zipkin trace, service:{}, {}'.format(
                     self.service_name,
+                    repr(ex),
                 )
                 log.error(err_msg)
             finally:
                 self.logging_context = None
+                self.get_tracer().clear()
                 self.get_tracer().set_transport_configured(configured=False)
                 return
 

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -34,8 +34,6 @@ ZipkinAttrs = namedtuple(
 
 ERROR_KEY = 'error'
 
-log = logging.getLogger('py_zipkin.zipkin')
-
 
 class zipkin_span(object):
     """Context manager/decorator for all of your zipkin tracing needs.
@@ -466,11 +464,7 @@ class zipkin_span(object):
         return self
 
     def __exit__(self, _exc_type, _exc_value, _exc_traceback):
-        try:
-            self.stop(_exc_type, _exc_value, _exc_traceback)
-        except Exception:
-            log.error('ZipkinError', exc_info=True)
-            self.get_tracer().clear()
+        self.stop(_exc_type, _exc_value, _exc_traceback)
 
     def stop(self, _exc_type=None, _exc_value=None, _exc_traceback=None):
         """Exit the span context. Zipkin attrs are pushed onto the
@@ -499,10 +493,18 @@ class zipkin_span(object):
         # process (i.e. this zipkin_span not inside of any other local
         # zipkin_spans)
         if self.logging_context:
-            self.logging_context.stop()
-            self.logging_context = None
-            self.get_tracer().set_transport_configured(configured=False)
-            return
+            try:
+                self.logging_context.stop()
+            except Exception:
+                self.get_tracer().clear()
+                err_msg = 'Error while emitting zipkin trace. {}'.format(
+                    self.service_name,
+                )
+                log.error(err_msg)
+            finally:
+                self.logging_context = None
+                self.get_tracer().set_transport_configured(configured=False)
+                return
 
         # If we've gotten here, that means that this span is a child span of
         # this context's root span (i.e. it's a zipkin_span inside another

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -16,6 +16,7 @@ from py_zipkin.storage import get_default_tracer
 from py_zipkin.util import generate_random_128bit_string
 from py_zipkin.util import generate_random_64bit_string
 
+log = logging.getLogger(__name__)
 
 """
 Holds the basic attributes needed to log a zipkin trace
@@ -465,7 +466,11 @@ class zipkin_span(object):
         return self
 
     def __exit__(self, _exc_type, _exc_value, _exc_traceback):
-        self.stop(_exc_type, _exc_value, _exc_traceback)
+        try:
+            self.stop(_exc_type, _exc_value, _exc_traceback)
+        except Exception:
+            log.error('ZipkinError', exc_info=True)
+            self.get_tracer().clear()
 
     def stop(self, _exc_type=None, _exc_value=None, _exc_traceback=None):
         """Exit the span context. Zipkin attrs are pushed onto the

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.18.1'
+__version__ = '0.18.2'
 
 
 def read(f):

--- a/tests/integration/zipkin_integration_test.py
+++ b/tests/integration/zipkin_integration_test.py
@@ -11,7 +11,7 @@ from py_zipkin.logging_helper import LOGGING_END_KEY
 from py_zipkin.storage import get_default_tracer
 from py_zipkin.zipkin import log
 from py_zipkin.zipkin import ZipkinAttrs
-
+from tests.test_helpers import MockTracer
 
 USECS = 1000000
 
@@ -259,6 +259,7 @@ def test_service_exits_on_erroneous_span(log_mock):
        Services may not be handling them. Instead log an error
     """
     mock_transport_handler, mock_logs = mock_logger()
+    tracer = MockTracer()
     try:
         zipkin_attrs = ZipkinAttrs(
             trace_id='0',
@@ -267,7 +268,7 @@ def test_service_exits_on_erroneous_span(log_mock):
             flags='0',
             is_sampled=True,
         )
-        with zipkin.zipkin_span(
+        with tracer.zipkin_span(
             service_name='test_service_name',
             span_name='service_span',
             zipkin_attrs=zipkin_attrs,
@@ -282,6 +283,7 @@ def test_service_exits_on_erroneous_span(log_mock):
     finally:
         assert log_mock.call_count == 1
         assert len(mock_logs) == 0
+        assert len(tracer.get_spans()) == 0
 
 
 def test_service_span_report_timestamp_override():

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -580,7 +580,8 @@ class TestZipkinSpan(object):
 
     def test_error_stopping_log_context(self):
         '''Tests if exception is raised while emitting traces that
-           tracer is cleaned u
+           1. tracer is cleared
+           2. excpetion is not passed up
         '''
         transport = MockTransportHandler()
         tracer = MockTracer()


### PR DESCRIPTION
A ZipkinError was being raised to due to a bad span id (multiple span ids) from the service layer. Services do not explicitly handle ZipkinError. And do not want their normal functionality to fail. Although tracing will not work (emit spans), we log an error in the (py_zipkin) library.

Also in case of an error, the tracer needs to be cleaned up. Otherwise the context gets carried over.