### PR TITLE
Replace ERROR_KEY: error_msg to ERROR_KEY: error_msg.encode('UTF-8')

### DIFF
--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -3,9 +3,7 @@ import functools
 import logging
 import random
 import time
-
-import six
-
+import sys
 from collections import namedtuple
 
 from py_zipkin import Encoding
@@ -488,7 +486,7 @@ class zipkin_span(object):
         # Add the error annotation if an exception occurred
         if any((_exc_type, _exc_value, _exc_traceback)):
             error_msg = u'{0}: {1}'.format(_exc_type.__name__, _exc_value)
-            if six.PY3:
+            if int(sys.version[0:1]) >= 3:
                 self.update_binary_annotations({
                     ERROR_KEY: error_msg,  # pragma: no cover
                 })

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -3,7 +3,7 @@ import functools
 import logging
 import random
 import time
-import sys
+import six
 from collections import namedtuple
 
 from py_zipkin import Encoding
@@ -486,7 +486,7 @@ class zipkin_span(object):
         # Add the error annotation if an exception occurred
         if any((_exc_type, _exc_value, _exc_traceback)):
             error_msg = u'{0}: {1}'.format(_exc_type.__name__, _exc_value)
-            if int(sys.version[0:1]) >= 3:
+            if six.PY3:
                 self.update_binary_annotations({
                     ERROR_KEY: error_msg,  # pragma: no cover
                 })

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -486,12 +486,14 @@ class zipkin_span(object):
         # Add the error annotation if an exception occurred
         if any((_exc_type, _exc_value, _exc_traceback)):
             error_msg = u'{0}: {1}'.format(_exc_type.__name__, _exc_value)
-            self.update_binary_annotations({
-                if int(sys.version[0:1]) >= 3:
+            if int(sys.version[0:1]) >= 3:
+                self.update_binary_annotations({
                     ERROR_KEY: error_msg,
-                else:
+                })
+            else:
+                self.update_binary_annotations({
                     ERROR_KEY: error_msg.encode('UTF-8'),
-            })
+                })
 
         # Logging context is only initialized for "root" spans of the local
         # process (i.e. this zipkin_span not inside of any other local

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -486,7 +486,7 @@ class zipkin_span(object):
         if any((_exc_type, _exc_value, _exc_traceback)):
             error_msg = u'{0}: {1}'.format(_exc_type.__name__, _exc_value)
             self.update_binary_annotations({
-                ERROR_KEY: error_msg,
+                ERROR_KEY: error_msg.encode('utf-8'),
             })
 
         # Logging context is only initialized for "root" spans of the local

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import sys
+import six
 import functools
 import logging
 import random
@@ -486,13 +486,13 @@ class zipkin_span(object):
         # Add the error annotation if an exception occurred
         if any((_exc_type, _exc_value, _exc_traceback)):
             error_msg = u'{0}: {1}'.format(_exc_type.__name__, _exc_value)
-            if int(sys.version[0:1]) >= 3:
+            if six.PY3:
                 self.update_binary_annotations({
-                    ERROR_KEY: error_msg,
+                    ERROR_KEY: error_msg,  # pragma: no cover
                 })
             else:
                 self.update_binary_annotations({
-                    ERROR_KEY: error_msg.encode('UTF-8'),
+                    ERROR_KEY: error_msg.encode('UTF-8'),  # pragma: no cover
                 })
 
         # Logging context is only initialized for "root" spans of the local

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -3,6 +3,9 @@ import functools
 import logging
 import random
 import time
+
+import six
+
 from collections import namedtuple
 
 from py_zipkin import Encoding
@@ -15,7 +18,6 @@ from py_zipkin.logging_helper import ZipkinLoggingContext
 from py_zipkin.storage import get_default_tracer
 from py_zipkin.util import generate_random_128bit_string
 from py_zipkin.util import generate_random_64bit_string
-import six
 
 log = logging.getLogger(__name__)
 

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -486,7 +486,7 @@ class zipkin_span(object):
         if any((_exc_type, _exc_value, _exc_traceback)):
             error_msg = u'{0}: {1}'.format(_exc_type.__name__, _exc_value)
             self.update_binary_annotations({
-                ERROR_KEY: error_msg.encode('utf-8'),
+                ERROR_KEY: error_msg.encode('UTF-8'),
             })
 
         # Logging context is only initialized for "root" spans of the local

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-import six
 import functools
 import logging
 import random
 import time
+import six
 from collections import namedtuple
 
 from py_zipkin import Encoding

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import sys
 import functools
 import logging
 import random
@@ -486,7 +487,10 @@ class zipkin_span(object):
         if any((_exc_type, _exc_value, _exc_traceback)):
             error_msg = u'{0}: {1}'.format(_exc_type.__name__, _exc_value)
             self.update_binary_annotations({
-                ERROR_KEY: error_msg.encode('UTF-8'),
+                if int(sys.version[0:1]) >= 3:
+                    ERROR_KEY: error_msg,
+                else:
+                    ERROR_KEY: error_msg.encode('UTF-8'),
             })
 
         # Logging context is only initialized for "root" spans of the local

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -3,7 +3,6 @@ import functools
 import logging
 import random
 import time
-import six
 from collections import namedtuple
 
 from py_zipkin import Encoding
@@ -16,6 +15,7 @@ from py_zipkin.logging_helper import ZipkinLoggingContext
 from py_zipkin.storage import get_default_tracer
 from py_zipkin.util import generate_random_128bit_string
 from py_zipkin.util import generate_random_64bit_string
+import six
 
 log = logging.getLogger(__name__)
 

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -578,22 +578,6 @@ class TestZipkinSpan(object):
             })
             assert len(span_storage) == 0
 
-         with mock.patch.object(context, 'update_binary_annotations') as mock_upd:
-            context.start()
-            context.stop(ValueError, 'おやすみ')
-            assert mock_upd.call_args == mock.call({
-                zipkin.ERROR_KEY: 'ValueError: おやすみ'
-            })
-            assert len(span_storage) == 0
-
-        with mock.patch.object(context, 'update_binary_annotations') as mock_upd:
-            context.start()
-            context.stop(ValueError, '晚安')
-            assert mock_upd.call_args == mock.call({
-                zipkin.ERROR_KEY: 'ValueError: 晚安'
-            })
-            assert len(span_storage) == 0
-
     def test_error_stopping_log_context(self):
         '''Tests if exception is raised while emitting traces that
            1. tracer is cleared

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -578,6 +578,22 @@ class TestZipkinSpan(object):
             })
             assert len(span_storage) == 0
 
+         with mock.patch.object(context, 'update_binary_annotations') as mock_upd:
+            context.start()
+            context.stop(ValueError, 'おやすみ')
+            assert mock_upd.call_args == mock.call({
+                zipkin.ERROR_KEY: 'ValueError: おやすみ'
+            })
+            assert len(span_storage) == 0
+
+        with mock.patch.object(context, 'update_binary_annotations') as mock_upd:
+            context.start()
+            context.stop(ValueError, '晚安')
+            assert mock_upd.call_args == mock.call({
+                zipkin.ERROR_KEY: 'ValueError: 晚安'
+            })
+            assert len(span_storage) == 0
+
     def test_error_stopping_log_context(self):
         '''Tests if exception is raised while emitting traces that
            1. tracer is cleared


### PR DESCRIPTION
This PR is Replace ERROR_KEY: error_msg to ERROR_KEY: error_msg.encode('UTF-8').

When I use it in my working company,my program needs to report a error at a particular time, the Japanese and Chinese error message were garbled.

After I changed ERROR_KEY: error_msg to ERROR_KEY: error_msg.encode('UTF-8'), the Japanese and Chinese error message turned to be normal.

cc @adriancole for reviewing.Thank you.