### PR TITLE
Remove py34 and add py37 to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,17 @@ dist: xenial
 
 matrix:
   include:
-  - python: 3.6
+  - python: 3.7
     env: TOXENV=pre-commit
   - python: 2.7
     env: TOXENV=py27
-  - python: 3.4
-    env: TOXENV=py34
   - python: 3.5
     env: TOXENV=py35
   - python: 3.6
     env: TOXENV=py36
   - python: 3.7
     env: TOXENV=py37
-  - python: 3.6
+  - python: 3.7
     env: TOXENV=flake8
 before_install: pip install -U pip==18.0
 install: pip install tox coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pre-commit, py27, py34, py35, py36, pypy, flake8
+envlist = pre-commit, py27, py35, py36, py37, pypy, flake8
 
 [testenv]
 deps = -rrequirements-dev.txt
@@ -20,14 +20,14 @@ commands =
 install_command = python -m pip install --no-binary thriftpy2 {opts} {packages}
 
 [testenv:pre-commit]
-basepython = python3.6
+basepython = python3.7
 deps = pre-commit
 commands =
     pre-commit install -f --install-hooks
     pre-commit run --all-files {posargs}
 
 [testenv:flake8]
-basepython = python3.6
+basepython = python3.7
 deps = flake8
 commands =
     flake8 py_zipkin tests


### PR DESCRIPTION
py34 has reached EOL. Let's remove it and add py37 to the list of python
versions we test against.

This doesn't mean py_zipkin won't work on py34 anymore, just that we
don't test against it and that we don't guarantee compatibility anymore.