### PR TITLE
Fix import of TBinaryProtocol

### DIFF
--- a/py_zipkin/thrift/__init__.py
+++ b/py_zipkin/thrift/__init__.py
@@ -4,7 +4,7 @@ import socket
 import struct
 
 import thriftpy2
-from thriftpy2.protocol.binary import TBinaryProtocol
+from thriftpy2.protocol import TBinaryProtocol
 from thriftpy2.protocol.binary import write_list_begin
 from thriftpy2.thrift import TType
 from thriftpy2.transport import TMemoryBuffer


### PR DESCRIPTION
### Problem
Currently, py_zipkin does not use cython implementation for Thrift Binary Protocol even if it is available, because it imports python implementation directly. 

### Solution
Use another import that automatically fallbacks to python implementation when cython one is unavailable.