### PR TITLE
Add py_zipkin.testing helper functions.

### DIFF
--- a/py_zipkin/testing/__init__.py
+++ b/py_zipkin/testing/__init__.py
@@ -1,0 +1,1 @@
+from py_zipkin.testing.mock_transport import MockTransportHandler  # noqa: F401

--- a/py_zipkin/testing/mock_transport.py
+++ b/py_zipkin/testing/mock_transport.py
@@ -1,0 +1,57 @@
+from py_zipkin.transport import BaseTransportHandler
+
+
+class MockTransportHandler(BaseTransportHandler):
+    """Mock transport for use in tests.
+
+    It doesn't emit anything and just stores the generated spans in memory.
+    To check what has been emitted you can use `get_payloads` and get back
+    the list of encoded spans that were emitted.
+    To use it:
+
+    .. code-block:: python
+
+        transport = MockTransportHandler()
+        with zipkin.zipkin_span(
+            service_name='test_service_name',
+            span_name='test_span_name',
+            transport_handler=transport,
+            sample_rate=100.0,
+            encoding=Encoding.V2_JSON,
+        ):
+            do_something()
+
+        spans = transport.get_payloads()
+        assert len(spans) == 1
+        decoded_spans = json.loads(spans[0])
+        assert decoded_spans == [{}]
+    """
+
+    def __init__(self, max_payload_bytes=None):
+        """Creates a new MockTransportHandler.
+
+        :param max_payload_bytes: max payload size in bytes. You often don't
+            need to set this in tests unless you want to test what happens
+            when your spans are bigger than the maximum payload size.
+        :type max_payload_bytes: int
+        """
+        self.max_payload_bytes = max_payload_bytes
+        self.payloads = []
+
+    def send(self, payload):
+        """Overrides the real send method. Should not be called directly."""
+        self.payloads.append(payload)
+        return payload
+
+    def get_max_payload_bytes(self):
+        """Overrides the real method. Should not be called directly."""
+        return self.max_payload_bytes
+
+    def get_payloads(self):
+        """Returns the encoded spans that were sent.
+
+        Spans are batched before being sent, so most of the time the returned
+        list will contain only one element. Each element is gonna be an encoded
+        list of spans.
+        """
+        return self.payloads

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -9,28 +9,11 @@ from py_zipkin import thrift
 from py_zipkin import zipkin
 from py_zipkin.encoding._encoders import IEncoder
 from py_zipkin.storage import Tracer
+from py_zipkin.testing import MockTransportHandler
 from py_zipkin.thrift import zipkin_core
-from py_zipkin.transport import BaseTransportHandler
 from py_zipkin.util import generate_random_128bit_string
 from py_zipkin.util import generate_random_64bit_string
 from py_zipkin.zipkin import ZipkinAttrs
-
-
-class MockTransportHandler(BaseTransportHandler):
-
-    def __init__(self, max_payload_bytes=None):
-        self.max_payload_bytes = max_payload_bytes
-        self.payloads = []
-
-    def send(self, payload):
-        self.payloads.append(payload)
-        return payload
-
-    def get_max_payload_bytes(self):
-        return self.max_payload_bytes
-
-    def get_payloads(self):
-        return self.payloads
 
 
 class MockEncoder(IEncoder):


### PR DESCRIPTION
For now that includes only the MockTransportHandler. I got bored of
having to copy paste it in every other library when running integration
tests. It's much better to just export it from here.