### PR TITLE
Ensure tags are strings

### DIFF
--- a/py_zipkin/encoding/_encoders.py
+++ b/py_zipkin/encoding/_encoders.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import json
 
+import six
+
 from py_zipkin import thrift
 from py_zipkin.encoding import protobuf
 from py_zipkin.encoding._types import Encoding
@@ -287,7 +289,10 @@ class _V2JSONEncoder(_BaseJSONEncoder):
                 False,
             )
         if span.tags and len(span.tags) > 0:
-            json_span['tags'] = span.tags
+            # Ensure that tags are all strings
+            json_span['tags'] = {
+                str(key): str(value) for key, value in six.iteritems(span.tags)
+            }
 
         if span.annotations:
             json_span['annotations'] = [


### PR DESCRIPTION
span.tags is an untyped python dictionary, meaning that the values in there could be of any type.

The schema however says that they should be strings and that's causing validation failures in other parts of our infrastructure.

@adriancole is this correct?