### PR TITLE
Zipkin 706 prevent intermediate services to override a sample rate when doing zipkin_attrs override

### DIFF
--- a/DEPRECATIONS.rst
+++ b/DEPRECATIONS.rst
@@ -1,6 +1,37 @@
 Deprecations: how to migrate
 ============================
 
+Overriding zipkin attrs and setting sample rate
+-----------------------------------------------
+
+The following usage is deprecated when zipkin_attrs are provided and
+sample_rate is additionally specified. This is removed since zipkin_attrs
+create_attrs_for_span(trace_id=trace_id) sets the sample_rate to 100.0
+
+.. code-block:: python
+
+    with zipkin_span(
+        zipkin_attrs=create_attrs_for_span(trace_id=trace_id),
+        service_name=SERVICE_NAME,
+        span_name=span_name,
+        transport_handler=zipkin_scribe_handler,
+        firehose_handler=firehose_handler,
+        sample_rate=sample_rate,
+    ):
+
+To specify a sample_rate explicity specify it while building the zipkin_attrs
+
+.. code-block:: python
+
+    with zipkin_span(
+        zipkin_attrs=create_attrs_for_span(trace_id=trace_id, sample_rate=50.0),
+        service_name=SERVICE_NAME,
+        span_name=span_name,
+        transport_handler=zipkin_scribe_handler,
+        firehose_handler=firehose_handler,
+        sample_rate=sample_rate,
+    ):
+
 New Tracer interface
 --------------------
 

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -351,18 +351,7 @@ class zipkin_span(object):
         # child span.
         if self._is_local_root_span:
 
-            # If sample_rate is set, we need to (re)generate a trace context.
-            # If zipkin_attrs (trace context) were passed in as argument there are
-            # 2 possibilities:
-            # is_sampled = False --> we keep the same trace_id but re-roll the dice
-            #                        for is_sampled.
-            # is_sampled = True  --> we don't want to stop sampling halfway through
-            #                        a sampled trace, so we do nothing.
-            # If no zipkin_attrs were passed in, we generate new ones and start a
-            # new trace.
             if self.sample_rate is not None:
-
-                # If zipkin_attrs_override was not passed in, we simply generate
                 # new zipkin_attrs to start a new trace.
                 if not self.zipkin_attrs_override:
                     return True, create_attrs_for_span(

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -241,6 +241,10 @@ class zipkin_span(object):
                 "use the timestamp and duration parameters."
             )
 
+        if self.zipkin_attrs_override and self.sample_rate is not None:
+            raise ZipkinError(
+                'sample_rate should not be set when zipkin_attrs are provided')
+
         # Root spans have transport_handler and at least one of
         # zipkin_attrs_override or sample_rate.
         if self.zipkin_attrs_override or self.sample_rate is not None:
@@ -358,19 +362,9 @@ class zipkin_span(object):
             # new trace.
             if self.sample_rate is not None:
 
-                # If this trace is not sampled, we re-roll the dice.
-                if self.zipkin_attrs_override and \
-                        not self.zipkin_attrs_override.is_sampled:
-                    # This will be the root span of the trace, so we should
-                    # set timestamp and duration.
-                    return True, create_attrs_for_span(
-                        sample_rate=self.sample_rate,
-                        trace_id=self.zipkin_attrs_override.trace_id,
-                    )
-
                 # If zipkin_attrs_override was not passed in, we simply generate
                 # new zipkin_attrs to start a new trace.
-                elif not self.zipkin_attrs_override:
+                if not self.zipkin_attrs_override:
                     return True, create_attrs_for_span(
                         sample_rate=self.sample_rate,
                         use_128bit_trace_id=self.use_128bit_trace_id,

--- a/tests/integration/zipkin_integration_test.py
+++ b/tests/integration/zipkin_integration_test.py
@@ -335,7 +335,6 @@ def test_service_span_that_is_independently_sampled(encoding):
         zipkin_attrs=zipkin_attrs,
         transport_handler=mock_transport_handler,
         port=45,
-        sample_rate=100.0,
         firehose_handler=mock_firehose_handler,
         encoding=encoding,
     ):

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -214,7 +214,7 @@ class TestZipkinSpan(object):
                 pass
 
     def test_error_when_sample_rate_and_attrs_override(self):
-        try:
+        with pytest.raises(ZipkinError) as e:
             with zipkin.zipkin_span(
                     service_name='some_service_name',
                     span_name='span_name',
@@ -222,10 +222,8 @@ class TestZipkinSpan(object):
                     transport_handler=MockTransportHandler(),
                     zipkin_attrs=zipkin.create_attrs_for_span(),
             ):
-                pytest.fail("Raise exception when sample rate \
-                    set with zipkin_attrs")
-        except ZipkinError as e:
-            assert str(e) == "sample_rate should not be set \
+                pass
+            assert str(e.value) == "sample_rate should not be set \
                 when zipkin_attrs are provided"
 
     def test_initinvalid_sample_rate(self):

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -214,7 +214,7 @@ class TestZipkinSpan(object):
                 pass
 
     def test_error_when_sample_rate_and_attrs_override(self):
-        with pytest.raises(ZipkinError):
+        try:
             with zipkin.zipkin_span(
                     service_name='some_service_name',
                     span_name='span_name',
@@ -222,7 +222,11 @@ class TestZipkinSpan(object):
                     transport_handler=MockTransportHandler(),
                     zipkin_attrs=zipkin.create_attrs_for_span(),
             ):
-                pass
+                pytest.fail("Raise exception when sample rate \
+                    set with zipkin_attrs")
+        except ZipkinError as e:
+            assert str(e) == "sample_rate should not be set \
+                when zipkin_attrs are provided"
 
     def test_initinvalid_sample_rate(self):
         with pytest.raises(ZipkinError):


### PR DESCRIPTION
with zipkin_attrs override the sample_rate is defaulted to 100 percent if no explicit sample_rate is provided. While creating zipkin_span though there is an option to additionally provide a sample_rate. This change throughs a ZipkinError if both zipkin_attr override and sample_rate were specified at the same time. The sample_rate override should be part of the zipkin_attr creation.