### PR TITLE
Pin coveragepy to avoid python3.6.0 failure

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,6 @@
-coverage
+# coveragepy==5.0 fails with `Safety level may not be changed inside a transaction`
+# on python 3.6.0 (xenial)
+coverage<5
 mock
 ordereddict
 pytest


### PR DESCRIPTION
https://github.com/nedbat/coveragepy/issues/703