### PR TITLE
Expose encoding.create_endpoint function

### DIFF
--- a/py_zipkin/encoding/__init__.py
+++ b/py_zipkin/encoding/__init__.py
@@ -5,6 +5,7 @@ import six
 
 from py_zipkin.encoding._decoders import get_decoder
 from py_zipkin.encoding._encoders import get_encoder
+from py_zipkin.encoding._helpers import create_endpoint  # noqa: F401
 from py_zipkin.encoding._helpers import Endpoint  # noqa: F401
 from py_zipkin.encoding._helpers import Span  # noqa: F401
 from py_zipkin.encoding._types import Encoding


### PR DESCRIPTION
We currently import in py_zipkin/encoding/__init__.py and expose Span
and Endpoint. We should also include the create_endpoint helper since
that's the easiest way to create and initialize the Endpoint object.