### PR TITLE
Add an extract_zipkin_attrs_from_headers() helper

### DIFF
--- a/py_zipkin/request_helpers.py
+++ b/py_zipkin/request_helpers.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from py_zipkin.util import _should_sample
+from py_zipkin.zipkin import create_attrs_for_span
+from py_zipkin.zipkin import ZipkinAttrs
+
+log = logging.getLogger(__name__)
+
+
+def _parse_single_header(b3_header):
+    """
+    Parse out and return the data necessary for generating ZipkinAttrs.
+
+    Returns a dict with the following keys:
+        'trace_id':             str or None
+        'span_id':              str or None
+        'parent_span_id':       str or None
+        'sampled_str':          '0', '1', 'd', or None (defer)
+    """
+    parsed = dict.fromkeys(("trace_id", "span_id", "parent_span_id", "sampled_str"))
+
+    # b3={TraceId}-{SpanId}-{SamplingState}-{ParentSpanId}
+    #      (last 2 fields optional)
+    # OR
+    # b3={SamplingState}
+    bits = b3_header.split("-")
+
+    # Handle the lone-sampling-decision case:
+    if len(bits) == 1:
+        if bits[0] in ("0", "1", "d"):
+            parsed["sampled_str"] = bits[0]
+            return parsed
+        raise ValueError("Invalid sample-only value: %r" % bits[0])
+    if len(bits) > 4:
+        # Too many segments
+        raise ValueError("Too many segments in b3 header: %r" % b3_header)
+    parsed["trace_id"] = bits[0]
+    if not parsed["trace_id"]:
+        raise ValueError("Bad or missing TraceId")
+    parsed["span_id"] = bits[1]
+    if not parsed["span_id"]:
+        raise ValueError("Bad or missing SpanId")
+    if len(bits) > 3:
+        parsed["parent_span_id"] = bits[3]
+        if not parsed["parent_span_id"]:
+            raise ValueError("Got empty ParentSpanId")
+    if len(bits) > 2:
+        # Empty-string means "missing" which means "Defer"
+        if bits[2]:
+            parsed["sampled_str"] = bits[2]
+            if parsed["sampled_str"] not in ("0", "1", "d"):
+                raise ValueError("Bad SampledState: %r" % parsed["sampled_str"])
+    return parsed
+
+
+def _parse_multi_header(headers):
+    """
+    Parse out and return the data necessary for generating ZipkinAttrs.
+
+    Returns a dict with the following keys:
+        'trace_id':             str or None
+        'span_id':              str or None
+        'parent_span_id':       str or None
+        'sampled_str':          '0', '1', 'd', or None (defer)
+    """
+    parsed = {
+        "trace_id": headers.get("X-B3-TraceId", None),
+        "span_id": headers.get("X-B3-SpanId", None),
+        "parent_span_id": headers.get("X-B3-ParentSpanId", None),
+        "sampled_str": headers.get("X-B3-Sampled", None),
+    }
+    # Normalize X-B3-Flags and X-B3-Sampled to None, '0', '1', or 'd'
+    if headers.get("X-B3-Flags") == "1":
+        parsed["sampled_str"] = "d"
+    if parsed["sampled_str"] == "true":
+        parsed["sampled_str"] = "1"
+    elif parsed["sampled_str"] == "false":
+        parsed["sampled_str"] = "0"
+    if parsed["sampled_str"] not in (None, "1", "0", "d"):
+        raise ValueError("Got invalid X-B3-Sampled: %s" % parsed["sampled_str"])
+    for k in ("trace_id", "span_id", "parent_span_id"):
+        if parsed[k] == "":
+            raise ValueError("Got empty-string %r" % k)
+    if parsed["trace_id"] and not parsed["span_id"]:
+        raise ValueError("Got X-B3-TraceId but not X-B3-SpanId")
+    elif parsed["span_id"] and not parsed["trace_id"]:
+        raise ValueError("Got X-B3-SpanId but not X-B3-TraceId")
+
+    # Handle the common case of no headers at all
+    if not parsed["trace_id"] and not parsed["sampled_str"]:
+        raise ValueError()  # won't trigger a log message
+
+    return parsed
+
+
+def extract_zipkin_attrs_from_headers(
+    headers, sample_rate=100.0, use_128bit_trace_id=False
+):
+    """
+    Implements extraction of B3 headers per:
+        https://github.com/openzipkin/b3-propagation
+
+    The input headers can be any dict-like container that supports "in"
+    membership test and a .get() method that accepts a default value.
+
+    Returns a ZipkinAttrs instance or None
+    """
+    try:
+        if "b3" in headers:
+            parsed = _parse_single_header(headers["b3"])
+        else:
+            parsed = _parse_multi_header(headers)
+    except ValueError as e:
+        if str(e):
+            log.warning(e)
+        return None
+
+    # Handle the lone-sampling-decision case:
+    if not parsed["trace_id"]:
+        if parsed["sampled_str"] in ("1", "d"):
+            sample_rate = 100.0
+        else:
+            sample_rate = 0.0
+        attrs = create_attrs_for_span(
+            sample_rate=sample_rate,
+            use_128bit_trace_id=use_128bit_trace_id,
+            flags="1" if parsed["sampled_str"] == "d" else "0",
+        )
+        return attrs
+
+    # Handle any sampling decision, including if it was deferred
+    if parsed["sampled_str"]:
+        # We have 1==Accept, 0==Deny, d==Debug
+        if parsed["sampled_str"] in ("1", "d"):
+            is_sampled = True
+        else:
+            is_sampled = False
+    else:
+        # sample flag missing; means "Defer" and we're responsible for
+        # rolling fresh dice
+        is_sampled = _should_sample(sample_rate)
+
+    return ZipkinAttrs(
+        parsed["trace_id"],
+        parsed["span_id"],
+        parsed["parent_span_id"],
+        "1" if parsed["sampled_str"] == "d" else "0",
+        is_sampled,
+    )

--- a/py_zipkin/util.py
+++ b/py_zipkin/util.py
@@ -58,3 +58,11 @@ def signed_int_to_unsigned_hex(signed_int):
     if hex_string.endswith("L"):
         return hex_string[:-1]
     return hex_string
+
+
+def _should_sample(sample_rate):
+    if sample_rate == 0.0:
+        return False  # save a die roll
+    elif sample_rate == 100.0:
+        return True  # ditto
+    return (random.random() * 100) < sample_rate

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import functools
 import logging
-import random
 import time
 from collections import namedtuple
 
@@ -13,6 +12,7 @@ from py_zipkin.encoding._helpers import Span
 from py_zipkin.exception import ZipkinError
 from py_zipkin.logging_helper import ZipkinLoggingContext
 from py_zipkin.storage import get_default_tracer
+from py_zipkin.util import _should_sample
 from py_zipkin.util import generate_random_128bit_string
 from py_zipkin.util import generate_random_64bit_string
 
@@ -668,7 +668,11 @@ class zipkin_server_span(zipkin_span):
 
 
 def create_attrs_for_span(
-    sample_rate=100.0, trace_id=None, span_id=None, use_128bit_trace_id=False,
+    sample_rate=100.0,
+    trace_id=None,
+    span_id=None,
+    use_128bit_trace_id=False,
+    flags=None,
 ):
     """Creates a set of zipkin attributes for a span.
 
@@ -691,16 +695,13 @@ def create_attrs_for_span(
             trace_id = generate_random_64bit_string()
     if span_id is None:
         span_id = generate_random_64bit_string()
-    if sample_rate == 0.0:
-        is_sampled = False
-    else:
-        is_sampled = (random.random() * 100) < sample_rate
+    is_sampled = _should_sample(sample_rate)
 
     return ZipkinAttrs(
         trace_id=trace_id,
         span_id=span_id,
         parent_span_id=None,
-        flags="0",
+        flags=flags or "0",
         is_sampled=is_sampled,
     )
 

--- a/tests/request_helpers_test.py
+++ b/tests/request_helpers_test.py
@@ -1,0 +1,389 @@
+# -*- coding: utf-8 -*-
+import mock
+import pytest
+
+from py_zipkin import request_helpers
+from py_zipkin.request_helpers import ZipkinAttrs
+
+
+def test_extract_zipkin_attrs_from_headers_single_sample_only():
+    attrs = request_helpers.extract_zipkin_attrs_from_headers(
+        {"b3": "0"}, use_128bit_trace_id=False
+    )
+    assert 16 == len(attrs.trace_id)
+    assert not attrs.is_sampled
+
+    attrs = request_helpers.extract_zipkin_attrs_from_headers(
+        {"b3": "0"}, use_128bit_trace_id=True
+    )
+    assert 32 == len(attrs.trace_id)
+    assert not attrs.is_sampled
+
+    # I _think_ from reading https://github.com/openzipkin/b3-propagation that
+    # sending only a "yes" sampling decision is legit and should, I guess,
+    # result in a fresh trace with a sample_rate pegged to 1.0
+    attrs = request_helpers.extract_zipkin_attrs_from_headers(
+        {"b3": "1"}, use_128bit_trace_id=False
+    )
+    assert 16 == len(attrs.trace_id)
+    assert attrs.is_sampled
+
+    attrs = request_helpers.extract_zipkin_attrs_from_headers(
+        {"b3": "1"}, use_128bit_trace_id=True
+    )
+    assert 32 == len(attrs.trace_id)
+    assert attrs.is_sampled
+
+    # Gibberish gets a None
+    assert None is request_helpers.extract_zipkin_attrs_from_headers({"b3": "yakka!"})
+
+
+@pytest.mark.parametrize(
+    "no_sample_string,yes_sample_string", [("0", "1"), ("false", "true")]
+)
+def test_extract_zipkin_attrs_from_headers_multi_sample_only(
+    no_sample_string, yes_sample_string
+):
+    # While you shouldn't encode X-B3-Sampled as true or false, a lenient
+    # implementation may accept them
+    attrs = request_helpers.extract_zipkin_attrs_from_headers(
+        {"X-B3-Sampled": no_sample_string}, use_128bit_trace_id=False
+    )
+    assert 16 == len(attrs.trace_id)
+    assert not attrs.is_sampled
+
+    attrs = request_helpers.extract_zipkin_attrs_from_headers(
+        {"X-B3-Sampled": no_sample_string}, use_128bit_trace_id=True
+    )
+    assert 32 == len(attrs.trace_id)
+    assert not attrs.is_sampled
+
+    # A specified debug flag should probably override any sample header,
+    # though this is a bit pathological of the sender to send us.
+    attrs = request_helpers.extract_zipkin_attrs_from_headers(
+        {"X-B3-Sampled": no_sample_string, "X-B3-Flags": "1"},
+        use_128bit_trace_id=False,
+    )
+    assert 16 == len(attrs.trace_id)
+    assert attrs.is_sampled
+
+    # I _think_ from reading https://github.com/openzipkin/b3-propagation that
+    # sending only a "yes" sampling decision is legit and should, I guess,
+    # result in a fresh trace with a sample_rate pegged to 1.0
+    attrs = request_helpers.extract_zipkin_attrs_from_headers(
+        {"X-B3-Sampled": yes_sample_string}, use_128bit_trace_id=False
+    )
+    assert 16 == len(attrs.trace_id)
+    assert attrs.is_sampled
+
+    attrs = request_helpers.extract_zipkin_attrs_from_headers(
+        {"X-B3-Sampled": yes_sample_string}, use_128bit_trace_id=True
+    )
+    assert 32 == len(attrs.trace_id)
+    assert attrs.is_sampled
+
+    attrs = request_helpers.extract_zipkin_attrs_from_headers(
+        {"X-B3-Flags": "1"}, use_128bit_trace_id=False
+    )
+    assert 16 == len(attrs.trace_id)
+    assert attrs.is_sampled
+
+    attrs = request_helpers.extract_zipkin_attrs_from_headers(
+        {"X-B3-Flags": "1"}, use_128bit_trace_id=True
+    )
+    assert 32 == len(attrs.trace_id)
+    assert attrs.is_sampled
+
+    # Gibberish gets a None
+    assert None is request_helpers.extract_zipkin_attrs_from_headers(
+        {"X-B3-Sampled": "yakka!"}
+    )
+
+
+def test_extract_zipkin_attrs_from_headers_invalids():
+    span_id = "7e5991634df0c66e"
+    parent_span_id = "987d98239475e0a8"
+
+    for invalid in [
+        "",
+        "a",
+        "-".join(("a", "")),
+        "-".join(("", "b")),
+        "-".join(("a", "", "whee")),
+        "-".join(("a", span_id, "whee")),
+        "-".join(("a", span_id, "whee", parent_span_id)),
+        "-".join(("a", span_id, "whee", "")),
+        "-".join(("a", span_id, "1", "c", "d?!")),
+    ]:
+        print("bad b3 header: %r" % invalid)
+        assert None is request_helpers.extract_zipkin_attrs_from_headers(
+            {"b3": invalid}, sample_rate=88.2
+        ), invalid
+
+        # Convert the (bad) input b3 header into multiple-header format input
+        bits = invalid.split("-")
+        if len(bits) == 1:
+            bad_headers = {"X-B3-TraceId": bits[0]}
+        elif len(bits) == 2:
+            bad_headers = {"X-B3-TraceId": bits[0], "X-B3-SpanId": bits[1]}
+        elif len(bits) == 3:
+            bad_headers = {
+                "X-B3-TraceId": bits[0],
+                "X-B3-SpanId": bits[1],
+                "X-B3-Sampled": bits[2],
+            }
+        elif len(bits) == 4:
+            bad_headers = {
+                "X-B3-TraceId": bits[0],
+                "X-B3-SpanId": bits[1],
+                "X-B3-Sampled": bits[2],
+                "X-B3-ParentSpanId": bits[3],
+            }
+
+        print("bad_headers: %r" % bad_headers)
+        assert None is request_helpers.extract_zipkin_attrs_from_headers(
+            bad_headers, sample_rate=88.2,
+        )
+
+    # I'm pretty sure a provided X-B3-Sampled with empty-string "value" should
+    # be considered invalid (bit of an edge case).
+    assert None is request_helpers.extract_zipkin_attrs_from_headers(
+        {
+            "X-B3-TraceId": "a",
+            "X-B3-SpanId": span_id,
+            "X-B3-Sampled": "",
+            "X-B3-ParentSpanId": parent_span_id,
+        },
+        sample_rate=88.2,
+    )
+
+    # Catch edge case of SpanId provided but not TraceId
+    assert None is request_helpers.extract_zipkin_attrs_from_headers(
+        {"X-B3-SpanId": span_id}, sample_rate=88.2
+    )
+
+
+@pytest.mark.parametrize("no_trace_str,yes_trace_str", [("0", "1"), ("false", "true")])
+@mock.patch("py_zipkin.util.random.random")
+def test_extract_zipkin_attrs_from_headers_multi(
+    mock_random, no_trace_str, yes_trace_str
+):
+    trace_id = "not_actually_validated"
+    span_id = "7e5991634df0c66e"
+    parent_span_id = "987d98239475e0a8"
+
+    # No B3-headers; return None to get a new local-root span
+    assert None is request_helpers.extract_zipkin_attrs_from_headers(
+        {}, sample_rate=88.2
+    )
+
+    # Just 2 bits is a sample-rate defer; die-roll is "no":
+    mock_random.return_value = 0.883
+    assert ZipkinAttrs(
+        trace_id, span_id, None, "0", False,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {"X-B3-TraceId": trace_id, "X-B3-SpanId": span_id}, sample_rate=88.2
+    )
+
+    # Just 2 bits is a sample-rate defer; die-roll is "yes":
+    mock_random.return_value = 0.881
+    assert ZipkinAttrs(
+        trace_id, span_id, None, "0", True,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {"X-B3-TraceId": trace_id, "X-B3-SpanId": span_id}, sample_rate=88.2
+    )
+
+    # defer with a parent span; die-roll is "no":
+    mock_random.return_value = 0.883
+    assert ZipkinAttrs(
+        trace_id, span_id, parent_span_id, "0", False,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {
+            "X-B3-TraceId": trace_id,
+            "X-B3-SpanId": span_id,
+            "X-B3-ParentSpanId": parent_span_id,
+        },
+        sample_rate=88.2,
+    )
+
+    # defer with a parent span; die-roll is "yes":
+    mock_random.return_value = 0.881
+    assert ZipkinAttrs(
+        trace_id, span_id, parent_span_id, "0", True,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {
+            "X-B3-TraceId": trace_id,
+            "X-B3-SpanId": span_id,
+            "X-B3-ParentSpanId": parent_span_id,
+        },
+        sample_rate=88.2,
+    )
+
+    # non-defer no-trace, no parent span
+    mock_random.return_value = 0.881  # a "yes" if it were used
+    assert ZipkinAttrs(
+        trace_id, span_id, None, "0", False,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {
+            "X-B3-TraceId": trace_id,
+            "X-B3-SpanId": span_id,
+            "X-B3-Sampled": no_trace_str,
+        },
+        sample_rate=88.2,
+    )
+
+    # non-defer yes-trace, no parent span
+    mock_random.return_value = 0.883  # a "no" if it were used
+    assert ZipkinAttrs(
+        trace_id, span_id, None, "0", True,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {
+            "X-B3-TraceId": trace_id,
+            "X-B3-SpanId": span_id,
+            "X-B3-Sampled": yes_trace_str,
+        },
+        sample_rate=88.2,
+    )
+
+    # non-defer debug-trace, no parent span
+    mock_random.return_value = 0.883  # a "no" if it were used
+    assert ZipkinAttrs(
+        trace_id, span_id, None, "1", True,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {"X-B3-TraceId": trace_id, "X-B3-SpanId": span_id, "X-B3-Flags": "1"},
+        sample_rate=88.2,
+    )
+
+    # non-defer no-trace, yes parent span
+    mock_random.return_value = 0.881  # a "yes" if it were used
+    assert ZipkinAttrs(
+        trace_id, span_id, parent_span_id, "0", False,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {
+            "X-B3-TraceId": trace_id,
+            "X-B3-SpanId": span_id,
+            "X-B3-Sampled": no_trace_str,
+            "X-B3-ParentSpanId": parent_span_id,
+        },
+        sample_rate=88.2,
+    )
+
+    # non-defer yes-trace, yes parent span
+    mock_random.return_value = 0.883  # a "no" if it were used
+    assert ZipkinAttrs(
+        trace_id, span_id, parent_span_id, "0", True,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {
+            "X-B3-TraceId": trace_id,
+            "X-B3-SpanId": span_id,
+            "X-B3-Sampled": yes_trace_str,
+            "X-B3-ParentSpanId": parent_span_id,
+        },
+        sample_rate=88.2,
+    )
+
+    # non-defer debug-trace, yes parent span
+    mock_random.return_value = 0.883  # a "no" if it were used
+    assert ZipkinAttrs(
+        trace_id, span_id, parent_span_id, "1", True,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {
+            "X-B3-TraceId": trace_id,
+            "X-B3-SpanId": span_id,
+            "X-B3-Flags": "1",
+            "X-B3-ParentSpanId": parent_span_id,
+        },
+        sample_rate=88.2,
+    )
+
+    # flags (debug) trump Sampled, if they conflict--another edge case
+    mock_random.return_value = 0.883  # a "no" if it were used
+    assert ZipkinAttrs(
+        trace_id, span_id, parent_span_id, "1", True,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {
+            "X-B3-TraceId": trace_id,
+            "X-B3-SpanId": span_id,
+            "X-B3-Flags": "1",
+            "X-B3-Sampled": no_trace_str,
+            "X-B3-ParentSpanId": parent_span_id,
+        },
+        sample_rate=88.2,
+    )
+
+
+@pytest.mark.parametrize("yes_trace_str", ("1", "d"))
+@mock.patch("py_zipkin.util.random.random")
+def test_extract_zipkin_attrs_from_headers_single(mock_random, yes_trace_str):
+    # b3={TraceId}-{SpanId}-{SamplingState}-{ParentSpanId}
+    # where the last two fields are optional.
+    # The header can also just transmit a sample decision, but that's tested
+    # elsewhere.
+    trace_id = "not_actually_validated"
+    span_id = "7e5991634df0c66e"
+    parent_span_id = "987d98239475e0a8"
+
+    # Just 2 bits is a sample-rate defer; die-roll is "no":
+    mock_random.return_value = 0.883
+    assert ZipkinAttrs(
+        trace_id, span_id, None, "0", False,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {"b3": "-".join((trace_id, span_id))}, sample_rate=88.2
+    )
+
+    # Just 2 bits is a sample-rate defer; die-roll is "yes":
+    mock_random.return_value = 0.881
+    assert ZipkinAttrs(
+        trace_id, span_id, None, "0", True,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {"b3": "-".join((trace_id, span_id))}, sample_rate=88.2
+    )
+
+    # defer with a parent span; die-roll is "no":
+    mock_random.return_value = 0.883
+    assert ZipkinAttrs(
+        trace_id, span_id, parent_span_id, "0", False,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {"b3": "-".join((trace_id, span_id, "", parent_span_id))}, sample_rate=88.2
+    )
+
+    # defer with a parent span; die-roll is "yes":
+    mock_random.return_value = 0.881
+    assert ZipkinAttrs(
+        trace_id, span_id, parent_span_id, "0", True,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {"b3": "-".join((trace_id, span_id, "", parent_span_id))}, sample_rate=88.2
+    )
+
+    # non-defer no-trace, no parent span
+    mock_random.return_value = 0.881  # a "yes" if it were used
+    assert ZipkinAttrs(
+        trace_id, span_id, None, "0", False,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {"b3": "-".join((trace_id, span_id, "0"))}, sample_rate=88.2
+    )
+
+    # non-defer yes/debug-trace, no parent span
+    mock_random.return_value = 0.883  # a "no" if it were used
+    assert ZipkinAttrs(
+        trace_id, span_id, None, "1" if yes_trace_str == "d" else "0", True,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {"b3": "-".join((trace_id, span_id, yes_trace_str))}, sample_rate=88.2
+    )
+
+    # non-defer no-trace, yes parent span
+    mock_random.return_value = 0.881  # a "yes" if it were used
+    assert ZipkinAttrs(
+        trace_id, span_id, parent_span_id, "0", False,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {"b3": "-".join((trace_id, span_id, "0", parent_span_id))}, sample_rate=88.2
+    )
+
+    # non-defer yes/debug-trace, yes parent span
+    mock_random.return_value = 0.883  # a "no" if it were used
+    assert ZipkinAttrs(
+        trace_id, span_id, parent_span_id, "1" if yes_trace_str == "d" else "0", True,
+    ) == request_helpers.extract_zipkin_attrs_from_headers(
+        {"b3": "-".join((trace_id, span_id, yes_trace_str, parent_span_id))},
+        sample_rate=88.2,
+    )


### PR DESCRIPTION
It turns out that extracting B3 headers correctly is harder than it
sounds.  This helper function implements the standard as specified at:
https://github.com/openzipkin/b3-propagation

You can pass a dict or dict-like object to the new
extract_zipkin_attrs_from_headers() function, and get back a
ZipkinAttrs instance you can trust.

In some cases, a sample_rate float and a use_128bit_trace_id flag are
required, so they appear in the function signature as well.

This should take care of single-header extraction, which is part of
Issue #98.

This may help with Issue #73 (missing or empty X-B3-Sampled).