### PR TITLE
Use black to format code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '^py_zipkin/encoding/protobuf/zipkin_pb2.py$'
 repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.1.0
+    rev: v2.5.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -12,16 +12,16 @@ repos:
     -   id: name-tests-test
         exclude: tests/test_helpers.py
     -   id: flake8
-        args:
-        - --max-line-length=83
-        exclude: docs/source/conf.py
     -   id: requirements-txt-fixer
 -   repo: https://github.com/asottile/reorder_python_imports.git
-    rev: v1.3.5
+    rev: v1.9.0
     hooks:
     -   id: reorder-python-imports
         language_version: python2.7
--   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.4.3
+-   repo: https://github.com/psf/black
+    rev: 19.10b0
     hooks:
-    -   id: autopep8
+    -   id: black
+        language_version: python3.7
+        exclude: setup.py
+        args: [--target-version, py27]

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ matrix:
   include:
   - python: 3.7
     env: TOXENV=pre-commit
+  - python: 3.7
+    env: TOXENV=flake8
+  - python: 3.7
+    env: TOXENV=black
   - python: 2.7
     env: TOXENV=py27
   - python: 3.5
@@ -16,13 +20,10 @@ matrix:
     env: TOXENV=py36
   - python: 3.7
     env: TOXENV=py37
-  - python: 3.7
-    env: TOXENV=flake8
 before_install: pip install -U pip==18.0
 install: pip install tox coveralls
 script: tox
 after_success: coveralls
-sudo: false
 deploy:
   provider: pypi
   user: yelplabs

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,7 @@ clean:
 
 update-protobuf:
 	$(MAKE) -C py_zipkin/encoding/protobuf update-protobuf
+
+.PHONY: black
+black:
+	tox -e black

--- a/py_zipkin/encoding/__init__.py
+++ b/py_zipkin/encoding/__init__.py
@@ -33,7 +33,7 @@ def detect_span_version_and_encoding(message):
         if six.PY2:
             message = six.b(message)  # pragma: no cover
         else:
-            message = message.encode('utf-8')  # pragma: no cover
+            message = message.encode("utf-8")  # pragma: no cover
 
     if len(message) < 2:
         raise ZipkinError("Invalid span format. Message too short.")
@@ -44,10 +44,10 @@ def detect_span_version_and_encoding(message):
             return Encoding.V2_PROTO3
         return Encoding.V1_THRIFT
 
-    str_msg = message.decode('utf-8')
+    str_msg = message.decode("utf-8")
 
     # JSON case for list of spans
-    if str_msg[0] == '[':
+    if str_msg[0] == "[":
         span_list = json.loads(str_msg)
         if len(span_list) > 0:
             # Assumption: All spans in a list are the same version
@@ -57,12 +57,8 @@ def detect_span_version_and_encoding(message):
             for span in span_list:
                 if any(word in span for word in _V2_ATTRIBUTES):
                     return Encoding.V2_JSON
-                elif (
-                    'binaryAnnotations' in span or
-                    (
-                        'annotations' in span and
-                        'endpoint' in span['annotations']
-                    )
+                elif "binaryAnnotations" in span or (
+                    "annotations" in span and "endpoint" in span["annotations"]
                 ):
                     return Encoding.V1_JSON
             return Encoding.V2_JSON

--- a/py_zipkin/encoding/_helpers.py
+++ b/py_zipkin/encoding/_helpers.py
@@ -7,22 +7,29 @@ from py_zipkin.encoding._types import Kind
 from py_zipkin.exception import ZipkinError
 
 
-Endpoint = namedtuple(
-    'Endpoint',
-    ['service_name', 'ipv4', 'ipv6', 'port'],
-)
+Endpoint = namedtuple("Endpoint", ["service_name", "ipv4", "ipv6", "port"])
 
 
 _V1Span = namedtuple(
-    'V1Span',
-    ['trace_id', 'name', 'parent_id', 'id', 'timestamp', 'duration', 'endpoint',
-     'annotations', 'binary_annotations', 'remote_endpoint'],
+    "V1Span",
+    [
+        "trace_id",
+        "name",
+        "parent_id",
+        "id",
+        "timestamp",
+        "duration",
+        "endpoint",
+        "annotations",
+        "binary_annotations",
+        "remote_endpoint",
+    ],
 )
 
 
 _DROP_ANNOTATIONS_BY_KIND = {
-    Kind.CLIENT: {'ss', 'sr'},
-    Kind.SERVER: {'cs', 'cr'},
+    Kind.CLIENT: {"ss", "sr"},
+    Kind.SERVER: {"cs", "cr"},
 }
 
 
@@ -92,15 +99,16 @@ class Span(object):
 
         if not isinstance(kind, Kind):
             raise ZipkinError(
-                'Invalid kind value {}. Must be of type Kind.'.format(kind))
+                "Invalid kind value {}. Must be of type Kind.".format(kind)
+            )
 
         if local_endpoint and not isinstance(local_endpoint, Endpoint):
-            raise ZipkinError(
-                'Invalid local_endpoint value. Must be of type Endpoint.')
+            raise ZipkinError("Invalid local_endpoint value. Must be of type Endpoint.")
 
         if remote_endpoint and not isinstance(remote_endpoint, Endpoint):
             raise ZipkinError(
-                'Invalid remote_endpoint value. Must be of type Endpoint.')
+                "Invalid remote_endpoint value. Must be of type Endpoint."
+            )
 
     def __eq__(self, other):  # pragma: no cover
         """Compare function to help assert span1 == span2 in py3"""
@@ -121,12 +129,14 @@ class Span(object):
         :rtype: _V1Span
         """
         # We are simulating a full two-part span locally, so set cs=sr and ss=cr
-        full_annotations = OrderedDict([
-            ('cs', self.timestamp),
-            ('sr', self.timestamp),
-            ('ss', self.timestamp + self.duration),
-            ('cr', self.timestamp + self.duration),
-        ])
+        full_annotations = OrderedDict(
+            [
+                ("cs", self.timestamp),
+                ("sr", self.timestamp),
+                ("ss", self.timestamp + self.duration),
+                ("cr", self.timestamp + self.duration),
+            ]
+        )
 
         if self.kind != Kind.LOCAL:
             # If kind is not LOCAL, then we only want client or
@@ -171,12 +181,12 @@ def create_endpoint(port=None, service_name=None, host=None, use_defaults=True):
         if port is None:
             port = 0
         if service_name is None:
-            service_name = 'unknown'
+            service_name = "unknown"
         if host is None:
             try:
                 host = socket.gethostbyname(socket.gethostname())
             except socket.gaierror:
-                host = '127.0.0.1'
+                host = "127.0.0.1"
 
     ipv4 = None
     ipv6 = None
@@ -195,12 +205,7 @@ def create_endpoint(port=None, service_name=None, host=None, use_defaults=True):
                 # If it's neither ipv4 or ipv6, leave both ip addresses unset.
                 pass
 
-    return Endpoint(
-        ipv4=ipv4,
-        ipv6=ipv6,
-        port=port,
-        service_name=service_name,
-    )
+    return Endpoint(ipv4=ipv4, ipv6=ipv6, port=port, service_name=service_name)
 
 
 def copy_endpoint_with_new_service_name(endpoint, new_service_name):

--- a/py_zipkin/encoding/_types.py
+++ b/py_zipkin/encoding/_types.py
@@ -4,16 +4,18 @@ from enum import Enum
 
 class Encoding(Enum):
     """Supported output encodings."""
-    V1_THRIFT = 'V1_THRIFT'
-    V1_JSON = 'V1_JSON'
-    V2_JSON = 'V2_JSON'
-    V2_PROTO3 = 'V2_PROTO3'
+
+    V1_THRIFT = "V1_THRIFT"
+    V1_JSON = "V1_JSON"
+    V2_JSON = "V2_JSON"
+    V2_PROTO3 = "V2_PROTO3"
 
 
 class Kind(Enum):
     """Type of Span."""
-    CLIENT = 'CLIENT'
-    SERVER = 'SERVER'
-    PRODUCER = 'PRODUCER'
-    CONSUMER = 'CONSUMER'
+
+    CLIENT = "CLIENT"
+    SERVER = "SERVER"
+    PRODUCER = "PRODUCER"
+    CONSUMER = "CONSUMER"
     LOCAL = None

--- a/py_zipkin/encoding/protobuf/__init__.py
+++ b/py_zipkin/encoding/protobuf/__init__.py
@@ -4,6 +4,7 @@ import struct
 
 from py_zipkin.encoding._types import Kind
 from py_zipkin.util import unsigned_hex_to_signed_int
+
 try:
     from py_zipkin.encoding.protobuf import zipkin_pb2
 except ImportError:  # pragma: no cover
@@ -47,41 +48,41 @@ def create_protobuf_span(span):
     # Instead we just create the kwargs and pass them in to the Span constructor.
     pb_kwargs = {}
 
-    pb_kwargs['trace_id'] = _hex_to_bytes(span.trace_id)
+    pb_kwargs["trace_id"] = _hex_to_bytes(span.trace_id)
 
     if span.parent_id:
-        pb_kwargs['parent_id'] = _hex_to_bytes(span.parent_id)
+        pb_kwargs["parent_id"] = _hex_to_bytes(span.parent_id)
 
-    pb_kwargs['id'] = _hex_to_bytes(span.span_id)
+    pb_kwargs["id"] = _hex_to_bytes(span.span_id)
 
     pb_kind = _get_protobuf_kind(span.kind)
     if pb_kind:
-        pb_kwargs['kind'] = pb_kind
+        pb_kwargs["kind"] = pb_kind
 
     if span.name:
-        pb_kwargs['name'] = span.name
+        pb_kwargs["name"] = span.name
     if span.timestamp:
-        pb_kwargs['timestamp'] = int(span.timestamp * 1000 * 1000)
+        pb_kwargs["timestamp"] = int(span.timestamp * 1000 * 1000)
     if span.duration:
-        pb_kwargs['duration'] = int(span.duration * 1000 * 1000)
+        pb_kwargs["duration"] = int(span.duration * 1000 * 1000)
 
     if span.local_endpoint:
-        pb_kwargs['local_endpoint'] = _convert_endpoint(span.local_endpoint)
+        pb_kwargs["local_endpoint"] = _convert_endpoint(span.local_endpoint)
 
     if span.remote_endpoint:
-        pb_kwargs['remote_endpoint'] = _convert_endpoint(span.remote_endpoint)
+        pb_kwargs["remote_endpoint"] = _convert_endpoint(span.remote_endpoint)
 
     if len(span.annotations) > 0:
-        pb_kwargs['annotations'] = _convert_annotations(span.annotations)
+        pb_kwargs["annotations"] = _convert_annotations(span.annotations)
 
     if len(span.tags) > 0:
-        pb_kwargs['tags'] = span.tags
+        pb_kwargs["tags"] = span.tags
 
     if span.debug:
-        pb_kwargs['debug'] = span.debug
+        pb_kwargs["debug"] = span.debug
 
     if span.shared:
-        pb_kwargs['shared'] = span.shared
+        pb_kwargs["shared"] = span.shared
 
     return zipkin_pb2.Span(**pb_kwargs)
 
@@ -96,7 +97,7 @@ def _hex_to_bytes(hex_id):
     """
     if len(hex_id) <= 16:
         int_id = unsigned_hex_to_signed_int(hex_id)
-        return struct.pack('>q', int_id)
+        return struct.pack(">q", int_id)
     else:
         # There's no 16-bytes encoding in Python's struct. So we convert the
         # id as 2 64 bit ids and then concatenate the result.
@@ -104,10 +105,10 @@ def _hex_to_bytes(hex_id):
         # NOTE: we count 16 chars from the right (:-16) rather than the left so
         # that ids with less than 32 chars will be correctly pre-padded with 0s.
         high_id = unsigned_hex_to_signed_int(hex_id[:-16])
-        high_bin = struct.pack('>q', high_id)
+        high_bin = struct.pack(">q", high_id)
 
         low_id = unsigned_hex_to_signed_int(hex_id[-16:])
-        low_bin = struct.pack('>q', low_id)
+        low_bin = struct.pack(">q", low_id)
 
         return high_bin + low_bin
 
@@ -163,8 +164,7 @@ def _convert_annotations(annotations):
     """
     pb_annotations = []
     for value, ts in annotations.items():
-        pb_annotations.append(zipkin_pb2.Annotation(
-            timestamp=int(ts * 1000 * 1000),
-            value=value,
-        ))
+        pb_annotations.append(
+            zipkin_pb2.Annotation(timestamp=int(ts * 1000 * 1000), value=value)
+        )
     return pb_annotations

--- a/py_zipkin/encoding/protobuf/zipkin_pb2.py
+++ b/py_zipkin/encoding/protobuf/zipkin_pb2.py
@@ -2,384 +2,628 @@
 # source: zipkin.proto
 
 import sys
-_b=sys.version_info[0]<3 and (lambda x:x) or (lambda x:x.encode('latin1'))
+
+_b = sys.version_info[0] < 3 and (lambda x: x) or (lambda x: x.encode("latin1"))
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
+
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
 
 
-
-
 DESCRIPTOR = _descriptor.FileDescriptor(
-  name='zipkin.proto',
-  package='zipkin.proto3',
-  syntax='proto3',
-  serialized_options=_b('\n\016zipkin2.proto3P\001'),
-  serialized_pb=_b('\n\x0czipkin.proto\x12\rzipkin.proto3\"\xf5\x03\n\x04Span\x12\x10\n\x08trace_id\x18\x01 \x01(\x0c\x12\x11\n\tparent_id\x18\x02 \x01(\x0c\x12\n\n\x02id\x18\x03 \x01(\x0c\x12&\n\x04kind\x18\x04 \x01(\x0e\x32\x18.zipkin.proto3.Span.Kind\x12\x0c\n\x04name\x18\x05 \x01(\t\x12\x11\n\ttimestamp\x18\x06 \x01(\x06\x12\x10\n\x08\x64uration\x18\x07 \x01(\x04\x12/\n\x0elocal_endpoint\x18\x08 \x01(\x0b\x32\x17.zipkin.proto3.Endpoint\x12\x30\n\x0fremote_endpoint\x18\t \x01(\x0b\x32\x17.zipkin.proto3.Endpoint\x12.\n\x0b\x61nnotations\x18\n \x03(\x0b\x32\x19.zipkin.proto3.Annotation\x12+\n\x04tags\x18\x0b \x03(\x0b\x32\x1d.zipkin.proto3.Span.TagsEntry\x12\r\n\x05\x64\x65\x62ug\x18\x0c \x01(\x08\x12\x0e\n\x06shared\x18\r \x01(\x08\x1a+\n\tTagsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"U\n\x04Kind\x12\x19\n\x15SPAN_KIND_UNSPECIFIED\x10\x00\x12\n\n\x06\x43LIENT\x10\x01\x12\n\n\x06SERVER\x10\x02\x12\x0c\n\x08PRODUCER\x10\x03\x12\x0c\n\x08\x43ONSUMER\x10\x04\"J\n\x08\x45ndpoint\x12\x14\n\x0cservice_name\x18\x01 \x01(\t\x12\x0c\n\x04ipv4\x18\x02 \x01(\x0c\x12\x0c\n\x04ipv6\x18\x03 \x01(\x0c\x12\x0c\n\x04port\x18\x04 \x01(\x05\".\n\nAnnotation\x12\x11\n\ttimestamp\x18\x01 \x01(\x06\x12\r\n\x05value\x18\x02 \x01(\t\"1\n\x0bListOfSpans\x12\"\n\x05spans\x18\x01 \x03(\x0b\x32\x13.zipkin.proto3.SpanB\x12\n\x0ezipkin2.proto3P\x01\x62\x06proto3')
+    name="zipkin.proto",
+    package="zipkin.proto3",
+    syntax="proto3",
+    serialized_options=_b("\n\016zipkin2.proto3P\001"),
+    serialized_pb=_b(
+        '\n\x0czipkin.proto\x12\rzipkin.proto3"\xf5\x03\n\x04Span\x12\x10\n\x08trace_id\x18\x01 \x01(\x0c\x12\x11\n\tparent_id\x18\x02 \x01(\x0c\x12\n\n\x02id\x18\x03 \x01(\x0c\x12&\n\x04kind\x18\x04 \x01(\x0e\x32\x18.zipkin.proto3.Span.Kind\x12\x0c\n\x04name\x18\x05 \x01(\t\x12\x11\n\ttimestamp\x18\x06 \x01(\x06\x12\x10\n\x08\x64uration\x18\x07 \x01(\x04\x12/\n\x0elocal_endpoint\x18\x08 \x01(\x0b\x32\x17.zipkin.proto3.Endpoint\x12\x30\n\x0fremote_endpoint\x18\t \x01(\x0b\x32\x17.zipkin.proto3.Endpoint\x12.\n\x0b\x61nnotations\x18\n \x03(\x0b\x32\x19.zipkin.proto3.Annotation\x12+\n\x04tags\x18\x0b \x03(\x0b\x32\x1d.zipkin.proto3.Span.TagsEntry\x12\r\n\x05\x64\x65\x62ug\x18\x0c \x01(\x08\x12\x0e\n\x06shared\x18\r \x01(\x08\x1a+\n\tTagsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01"U\n\x04Kind\x12\x19\n\x15SPAN_KIND_UNSPECIFIED\x10\x00\x12\n\n\x06\x43LIENT\x10\x01\x12\n\n\x06SERVER\x10\x02\x12\x0c\n\x08PRODUCER\x10\x03\x12\x0c\n\x08\x43ONSUMER\x10\x04"J\n\x08\x45ndpoint\x12\x14\n\x0cservice_name\x18\x01 \x01(\t\x12\x0c\n\x04ipv4\x18\x02 \x01(\x0c\x12\x0c\n\x04ipv6\x18\x03 \x01(\x0c\x12\x0c\n\x04port\x18\x04 \x01(\x05".\n\nAnnotation\x12\x11\n\ttimestamp\x18\x01 \x01(\x06\x12\r\n\x05value\x18\x02 \x01(\t"1\n\x0bListOfSpans\x12"\n\x05spans\x18\x01 \x03(\x0b\x32\x13.zipkin.proto3.SpanB\x12\n\x0ezipkin2.proto3P\x01\x62\x06proto3'
+    ),
 )
 
 
-
 _SPAN_KIND = _descriptor.EnumDescriptor(
-  name='Kind',
-  full_name='zipkin.proto3.Span.Kind',
-  filename=None,
-  file=DESCRIPTOR,
-  values=[
-    _descriptor.EnumValueDescriptor(
-      name='SPAN_KIND_UNSPECIFIED', index=0, number=0,
-      serialized_options=None,
-      type=None),
-    _descriptor.EnumValueDescriptor(
-      name='CLIENT', index=1, number=1,
-      serialized_options=None,
-      type=None),
-    _descriptor.EnumValueDescriptor(
-      name='SERVER', index=2, number=2,
-      serialized_options=None,
-      type=None),
-    _descriptor.EnumValueDescriptor(
-      name='PRODUCER', index=3, number=3,
-      serialized_options=None,
-      type=None),
-    _descriptor.EnumValueDescriptor(
-      name='CONSUMER', index=4, number=4,
-      serialized_options=None,
-      type=None),
-  ],
-  containing_type=None,
-  serialized_options=None,
-  serialized_start=448,
-  serialized_end=533,
+    name="Kind",
+    full_name="zipkin.proto3.Span.Kind",
+    filename=None,
+    file=DESCRIPTOR,
+    values=[
+        _descriptor.EnumValueDescriptor(
+            name="SPAN_KIND_UNSPECIFIED",
+            index=0,
+            number=0,
+            serialized_options=None,
+            type=None,
+        ),
+        _descriptor.EnumValueDescriptor(
+            name="CLIENT", index=1, number=1, serialized_options=None, type=None
+        ),
+        _descriptor.EnumValueDescriptor(
+            name="SERVER", index=2, number=2, serialized_options=None, type=None
+        ),
+        _descriptor.EnumValueDescriptor(
+            name="PRODUCER", index=3, number=3, serialized_options=None, type=None
+        ),
+        _descriptor.EnumValueDescriptor(
+            name="CONSUMER", index=4, number=4, serialized_options=None, type=None
+        ),
+    ],
+    containing_type=None,
+    serialized_options=None,
+    serialized_start=448,
+    serialized_end=533,
 )
 _sym_db.RegisterEnumDescriptor(_SPAN_KIND)
 
 
 _SPAN_TAGSENTRY = _descriptor.Descriptor(
-  name='TagsEntry',
-  full_name='zipkin.proto3.Span.TagsEntry',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='key', full_name='zipkin.proto3.Span.TagsEntry.key', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='value', full_name='zipkin.proto3.Span.TagsEntry.value', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=_b('8\001'),
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=403,
-  serialized_end=446,
+    name="TagsEntry",
+    full_name="zipkin.proto3.Span.TagsEntry",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="key",
+            full_name="zipkin.proto3.Span.TagsEntry.key",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="value",
+            full_name="zipkin.proto3.Span.TagsEntry.value",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=_b("8\001"),
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=403,
+    serialized_end=446,
 )
 
 _SPAN = _descriptor.Descriptor(
-  name='Span',
-  full_name='zipkin.proto3.Span',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='trace_id', full_name='zipkin.proto3.Span.trace_id', index=0,
-      number=1, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b(""),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='parent_id', full_name='zipkin.proto3.Span.parent_id', index=1,
-      number=2, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b(""),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='id', full_name='zipkin.proto3.Span.id', index=2,
-      number=3, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b(""),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='kind', full_name='zipkin.proto3.Span.kind', index=3,
-      number=4, type=14, cpp_type=8, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='name', full_name='zipkin.proto3.Span.name', index=4,
-      number=5, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='timestamp', full_name='zipkin.proto3.Span.timestamp', index=5,
-      number=6, type=6, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='duration', full_name='zipkin.proto3.Span.duration', index=6,
-      number=7, type=4, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='local_endpoint', full_name='zipkin.proto3.Span.local_endpoint', index=7,
-      number=8, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='remote_endpoint', full_name='zipkin.proto3.Span.remote_endpoint', index=8,
-      number=9, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='annotations', full_name='zipkin.proto3.Span.annotations', index=9,
-      number=10, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='tags', full_name='zipkin.proto3.Span.tags', index=10,
-      number=11, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='debug', full_name='zipkin.proto3.Span.debug', index=11,
-      number=12, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='shared', full_name='zipkin.proto3.Span.shared', index=12,
-      number=13, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[_SPAN_TAGSENTRY, ],
-  enum_types=[
-    _SPAN_KIND,
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=32,
-  serialized_end=533,
+    name="Span",
+    full_name="zipkin.proto3.Span",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="trace_id",
+            full_name="zipkin.proto3.Span.trace_id",
+            index=0,
+            number=1,
+            type=12,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b(""),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="parent_id",
+            full_name="zipkin.proto3.Span.parent_id",
+            index=1,
+            number=2,
+            type=12,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b(""),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="id",
+            full_name="zipkin.proto3.Span.id",
+            index=2,
+            number=3,
+            type=12,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b(""),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="kind",
+            full_name="zipkin.proto3.Span.kind",
+            index=3,
+            number=4,
+            type=14,
+            cpp_type=8,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="name",
+            full_name="zipkin.proto3.Span.name",
+            index=4,
+            number=5,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="timestamp",
+            full_name="zipkin.proto3.Span.timestamp",
+            index=5,
+            number=6,
+            type=6,
+            cpp_type=4,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="duration",
+            full_name="zipkin.proto3.Span.duration",
+            index=6,
+            number=7,
+            type=4,
+            cpp_type=4,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="local_endpoint",
+            full_name="zipkin.proto3.Span.local_endpoint",
+            index=7,
+            number=8,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="remote_endpoint",
+            full_name="zipkin.proto3.Span.remote_endpoint",
+            index=8,
+            number=9,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="annotations",
+            full_name="zipkin.proto3.Span.annotations",
+            index=9,
+            number=10,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="tags",
+            full_name="zipkin.proto3.Span.tags",
+            index=10,
+            number=11,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="debug",
+            full_name="zipkin.proto3.Span.debug",
+            index=11,
+            number=12,
+            type=8,
+            cpp_type=7,
+            label=1,
+            has_default_value=False,
+            default_value=False,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="shared",
+            full_name="zipkin.proto3.Span.shared",
+            index=12,
+            number=13,
+            type=8,
+            cpp_type=7,
+            label=1,
+            has_default_value=False,
+            default_value=False,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+    ],
+    extensions=[],
+    nested_types=[_SPAN_TAGSENTRY,],
+    enum_types=[_SPAN_KIND,],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=32,
+    serialized_end=533,
 )
 
 
 _ENDPOINT = _descriptor.Descriptor(
-  name='Endpoint',
-  full_name='zipkin.proto3.Endpoint',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='service_name', full_name='zipkin.proto3.Endpoint.service_name', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='ipv4', full_name='zipkin.proto3.Endpoint.ipv4', index=1,
-      number=2, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b(""),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='ipv6', full_name='zipkin.proto3.Endpoint.ipv6', index=2,
-      number=3, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b(""),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='port', full_name='zipkin.proto3.Endpoint.port', index=3,
-      number=4, type=5, cpp_type=1, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=535,
-  serialized_end=609,
+    name="Endpoint",
+    full_name="zipkin.proto3.Endpoint",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="service_name",
+            full_name="zipkin.proto3.Endpoint.service_name",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="ipv4",
+            full_name="zipkin.proto3.Endpoint.ipv4",
+            index=1,
+            number=2,
+            type=12,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b(""),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="ipv6",
+            full_name="zipkin.proto3.Endpoint.ipv6",
+            index=2,
+            number=3,
+            type=12,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b(""),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="port",
+            full_name="zipkin.proto3.Endpoint.port",
+            index=3,
+            number=4,
+            type=5,
+            cpp_type=1,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=535,
+    serialized_end=609,
 )
 
 
 _ANNOTATION = _descriptor.Descriptor(
-  name='Annotation',
-  full_name='zipkin.proto3.Annotation',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='timestamp', full_name='zipkin.proto3.Annotation.timestamp', index=0,
-      number=1, type=6, cpp_type=4, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='value', full_name='zipkin.proto3.Annotation.value', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=611,
-  serialized_end=657,
+    name="Annotation",
+    full_name="zipkin.proto3.Annotation",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="timestamp",
+            full_name="zipkin.proto3.Annotation.timestamp",
+            index=0,
+            number=1,
+            type=6,
+            cpp_type=4,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+        _descriptor.FieldDescriptor(
+            name="value",
+            full_name="zipkin.proto3.Annotation.value",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=_b("").decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=611,
+    serialized_end=657,
 )
 
 
 _LISTOFSPANS = _descriptor.Descriptor(
-  name='ListOfSpans',
-  full_name='zipkin.proto3.ListOfSpans',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='spans', full_name='zipkin.proto3.ListOfSpans.spans', index=0,
-      number=1, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=659,
-  serialized_end=708,
+    name="ListOfSpans",
+    full_name="zipkin.proto3.ListOfSpans",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="spans",
+            full_name="zipkin.proto3.ListOfSpans.spans",
+            index=0,
+            number=1,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=659,
+    serialized_end=708,
 )
 
 _SPAN_TAGSENTRY.containing_type = _SPAN
-_SPAN.fields_by_name['kind'].enum_type = _SPAN_KIND
-_SPAN.fields_by_name['local_endpoint'].message_type = _ENDPOINT
-_SPAN.fields_by_name['remote_endpoint'].message_type = _ENDPOINT
-_SPAN.fields_by_name['annotations'].message_type = _ANNOTATION
-_SPAN.fields_by_name['tags'].message_type = _SPAN_TAGSENTRY
+_SPAN.fields_by_name["kind"].enum_type = _SPAN_KIND
+_SPAN.fields_by_name["local_endpoint"].message_type = _ENDPOINT
+_SPAN.fields_by_name["remote_endpoint"].message_type = _ENDPOINT
+_SPAN.fields_by_name["annotations"].message_type = _ANNOTATION
+_SPAN.fields_by_name["tags"].message_type = _SPAN_TAGSENTRY
 _SPAN_KIND.containing_type = _SPAN
-_LISTOFSPANS.fields_by_name['spans'].message_type = _SPAN
-DESCRIPTOR.message_types_by_name['Span'] = _SPAN
-DESCRIPTOR.message_types_by_name['Endpoint'] = _ENDPOINT
-DESCRIPTOR.message_types_by_name['Annotation'] = _ANNOTATION
-DESCRIPTOR.message_types_by_name['ListOfSpans'] = _LISTOFSPANS
+_LISTOFSPANS.fields_by_name["spans"].message_type = _SPAN
+DESCRIPTOR.message_types_by_name["Span"] = _SPAN
+DESCRIPTOR.message_types_by_name["Endpoint"] = _ENDPOINT
+DESCRIPTOR.message_types_by_name["Annotation"] = _ANNOTATION
+DESCRIPTOR.message_types_by_name["ListOfSpans"] = _LISTOFSPANS
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
-Span = _reflection.GeneratedProtocolMessageType('Span', (_message.Message,), dict(
-
-  TagsEntry = _reflection.GeneratedProtocolMessageType('TagsEntry', (_message.Message,), dict(
-    DESCRIPTOR = _SPAN_TAGSENTRY,
-    __module__ = 'zipkin_pb2'
-    # @@protoc_insertion_point(class_scope:zipkin.proto3.Span.TagsEntry)
-    ))
-  ,
-  DESCRIPTOR = _SPAN,
-  __module__ = 'zipkin_pb2'
-  # @@protoc_insertion_point(class_scope:zipkin.proto3.Span)
-  ))
+Span = _reflection.GeneratedProtocolMessageType(
+    "Span",
+    (_message.Message,),
+    dict(
+        TagsEntry=_reflection.GeneratedProtocolMessageType(
+            "TagsEntry",
+            (_message.Message,),
+            dict(
+                DESCRIPTOR=_SPAN_TAGSENTRY,
+                __module__="zipkin_pb2"
+                # @@protoc_insertion_point(class_scope:zipkin.proto3.Span.TagsEntry)
+            ),
+        ),
+        DESCRIPTOR=_SPAN,
+        __module__="zipkin_pb2"
+        # @@protoc_insertion_point(class_scope:zipkin.proto3.Span)
+    ),
+)
 _sym_db.RegisterMessage(Span)
 _sym_db.RegisterMessage(Span.TagsEntry)
 
-Endpoint = _reflection.GeneratedProtocolMessageType('Endpoint', (_message.Message,), dict(
-  DESCRIPTOR = _ENDPOINT,
-  __module__ = 'zipkin_pb2'
-  # @@protoc_insertion_point(class_scope:zipkin.proto3.Endpoint)
-  ))
+Endpoint = _reflection.GeneratedProtocolMessageType(
+    "Endpoint",
+    (_message.Message,),
+    dict(
+        DESCRIPTOR=_ENDPOINT,
+        __module__="zipkin_pb2"
+        # @@protoc_insertion_point(class_scope:zipkin.proto3.Endpoint)
+    ),
+)
 _sym_db.RegisterMessage(Endpoint)
 
-Annotation = _reflection.GeneratedProtocolMessageType('Annotation', (_message.Message,), dict(
-  DESCRIPTOR = _ANNOTATION,
-  __module__ = 'zipkin_pb2'
-  # @@protoc_insertion_point(class_scope:zipkin.proto3.Annotation)
-  ))
+Annotation = _reflection.GeneratedProtocolMessageType(
+    "Annotation",
+    (_message.Message,),
+    dict(
+        DESCRIPTOR=_ANNOTATION,
+        __module__="zipkin_pb2"
+        # @@protoc_insertion_point(class_scope:zipkin.proto3.Annotation)
+    ),
+)
 _sym_db.RegisterMessage(Annotation)
 
-ListOfSpans = _reflection.GeneratedProtocolMessageType('ListOfSpans', (_message.Message,), dict(
-  DESCRIPTOR = _LISTOFSPANS,
-  __module__ = 'zipkin_pb2'
-  # @@protoc_insertion_point(class_scope:zipkin.proto3.ListOfSpans)
-  ))
+ListOfSpans = _reflection.GeneratedProtocolMessageType(
+    "ListOfSpans",
+    (_message.Message,),
+    dict(
+        DESCRIPTOR=_LISTOFSPANS,
+        __module__="zipkin_pb2"
+        # @@protoc_insertion_point(class_scope:zipkin.proto3.ListOfSpans)
+    ),
+)
 _sym_db.RegisterMessage(ListOfSpans)
 
 

--- a/py_zipkin/storage.py
+++ b/py_zipkin/storage.py
@@ -7,14 +7,15 @@ try:  # pragma: no cover
     # Since python 3.7 threadlocal is deprecated in favor of contextvars
     # which also work in asyncio.
     import contextvars
-    _contextvars_tracer = contextvars.ContextVar('py_zipkin.Tracer object')
+
+    _contextvars_tracer = contextvars.ContextVar("py_zipkin.Tracer object")
 except ImportError:  # pragma: no cover
     # The contextvars module was added in python 3.7
     _contextvars_tracer = None
 _thread_local_tracer = threading.local()
 
 
-log = logging.getLogger('py_zipkin.storage')
+log = logging.getLogger("py_zipkin.storage")
 
 
 def _get_thread_local_tracer():
@@ -24,7 +25,7 @@ def _get_thread_local_tracer():
     :returns: current tracer.
     :rtype: Tracer
     """
-    if not hasattr(_thread_local_tracer, 'tracer'):
+    if not hasattr(_thread_local_tracer, "tracer"):
         _thread_local_tracer.tracer = Tracer()
     return _thread_local_tracer.tracer
 
@@ -62,7 +63,6 @@ def _set_contextvars_tracer(tracer):  # pragma: no cover
 
 
 class Tracer(object):
-
     def __init__(self):
         self._is_transport_configured = False
         self._span_storage = SpanStorage()
@@ -94,7 +94,8 @@ class Tracer(object):
 
     def zipkin_span(self, *argv, **kwargs):
         from py_zipkin.zipkin import zipkin_span
-        kwargs['_tracer'] = self
+
+        kwargs["_tracer"] = self
         return zipkin_span(*argv, **kwargs)
 
 
@@ -112,7 +113,7 @@ class Stack(object):
 
     def __init__(self, storage=None):
         if storage is not None:
-            log.warning('Passing a storage object to Stack is deprecated.')
+            log.warning("Passing a storage object to Stack is deprecated.")
             self._storage = storage
         else:
             self._storage = []
@@ -143,8 +144,10 @@ class ThreadLocalStack(Stack):
     """
 
     def __init__(self):
-        log.warning('ThreadLocalStack is deprecated. See DEPRECATIONS.rst for'
-                    'details on how to migrate to using Tracer.')
+        log.warning(
+            "ThreadLocalStack is deprecated. See DEPRECATIONS.rst for"
+            "details on how to migrate to using Tracer."
+        )
 
     @property
     def _storage(self):
@@ -158,12 +161,15 @@ class SpanStorage(deque):
        Use the Tracer interface which offers better multi-threading support.
        SpanStorage will be removed in version 1.0.
     """
+
     pass
 
 
 def default_span_storage():
-    log.warning('default_span_storage is deprecated. See DEPRECATIONS.rst for'
-                'details on how to migrate to using Tracer.')
+    log.warning(
+        "default_span_storage is deprecated. See DEPRECATIONS.rst for"
+        "details on how to migrate to using Tracer."
+    )
     return get_default_tracer()._span_storage
 
 

--- a/py_zipkin/thread_local.py
+++ b/py_zipkin/thread_local.py
@@ -3,7 +3,7 @@ import logging
 
 from py_zipkin.storage import get_default_tracer
 
-log = logging.getLogger('py_zipkin.thread_local')
+log = logging.getLogger("py_zipkin.thread_local")
 
 
 def get_thread_local_zipkin_attrs():
@@ -19,8 +19,10 @@ def get_thread_local_zipkin_attrs():
     :returns: list that may contain zipkin attribute tuples
     :rtype: list
     """
-    log.warning('get_thread_local_zipkin_attrs is deprecated. See DEPRECATIONS.rst'
-                ' for details on how to migrate to using Tracer.')
+    log.warning(
+        "get_thread_local_zipkin_attrs is deprecated. See DEPRECATIONS.rst"
+        " for details on how to migrate to using Tracer."
+    )
     return get_default_tracer()._context_stack._storage
 
 
@@ -38,8 +40,10 @@ def get_thread_local_span_storage():
     :returns: SpanStore object containing all non-root spans.
     :rtype: py_zipkin.storage.SpanStore
     """
-    log.warning('get_thread_local_span_storage is deprecated. See DEPRECATIONS.rst'
-                ' for details on how to migrate to using Tracer.')
+    log.warning(
+        "get_thread_local_span_storage is deprecated. See DEPRECATIONS.rst"
+        " for details on how to migrate to using Tracer."
+    )
     return get_default_tracer()._span_storage
 
 
@@ -54,8 +58,11 @@ def get_zipkin_attrs():
     :rtype: :class:`zipkin.ZipkinAttrs`
     """
     from py_zipkin.storage import ThreadLocalStack
-    log.warning('get_zipkin_attrs is deprecated. See DEPRECATIONS.rst for'
-                'details on how to migrate to using Tracer.')
+
+    log.warning(
+        "get_zipkin_attrs is deprecated. See DEPRECATIONS.rst for"
+        "details on how to migrate to using Tracer."
+    )
     return ThreadLocalStack().get()
 
 
@@ -70,8 +77,11 @@ def pop_zipkin_attrs():
     :rtype: :class:`zipkin.ZipkinAttrs`
     """
     from py_zipkin.storage import ThreadLocalStack
-    log.warning('pop_zipkin_attrs is deprecated. See DEPRECATIONS.rst for'
-                'details on how to migrate to using Tracer.')
+
+    log.warning(
+        "pop_zipkin_attrs is deprecated. See DEPRECATIONS.rst for"
+        "details on how to migrate to using Tracer."
+    )
     return ThreadLocalStack().pop()
 
 
@@ -86,6 +96,9 @@ def push_zipkin_attrs(zipkin_attr):
     :type zipkin_attr: :class:`zipkin.ZipkinAttrs`
     """
     from py_zipkin.storage import ThreadLocalStack
-    log.warning('push_zipkin_attrs is deprecated. See DEPRECATIONS.rst for'
-                'details on how to migrate to using Tracer.')
+
+    log.warning(
+        "push_zipkin_attrs is deprecated. See DEPRECATIONS.rst for"
+        "details on how to migrate to using Tracer."
+    )
     return ThreadLocalStack().push(zipkin_attr)

--- a/py_zipkin/thrift/__init__.py
+++ b/py_zipkin/thrift/__init__.py
@@ -12,10 +12,10 @@ from thriftpy2.transport import TMemoryBuffer
 from py_zipkin.util import unsigned_hex_to_signed_int
 
 
-thrift_filepath = os.path.join(os.path.dirname(__file__), 'zipkinCore.thrift')
+thrift_filepath = os.path.join(os.path.dirname(__file__), "zipkinCore.thrift")
 zipkin_core = thriftpy2.load(thrift_filepath, module_name="zipkinCore_thrift")
 
-SERVER_ADDR_VAL = '\x01'
+SERVER_ADDR_VAL = "\x01"
 LIST_HEADER_SIZE = 5  # size in bytes of the encoded list header
 
 dummy_endpoint = zipkin_core.Endpoint()
@@ -46,14 +46,11 @@ def create_binary_annotation(key, value, annotation_type, host):
     :returns: zipkin binary annotation object
     """
     return zipkin_core.BinaryAnnotation(
-        key=key,
-        value=value,
-        annotation_type=annotation_type,
-        host=host,
+        key=key, value=value, annotation_type=annotation_type, host=host,
     )
 
 
-def create_endpoint(port=0, service_name='unknown', ipv4=None, ipv6=None):
+def create_endpoint(port=0, service_name="unknown", ipv4=None, ipv6=None):
     """Create a zipkin Endpoint object.
 
     An Endpoint object holds information about the network context of a span.
@@ -69,19 +66,16 @@ def create_endpoint(port=0, service_name='unknown', ipv4=None, ipv6=None):
 
     # Convert ip address to network byte order
     if ipv4:
-        ipv4_int = struct.unpack('!i', socket.inet_pton(socket.AF_INET, ipv4))[0]
+        ipv4_int = struct.unpack("!i", socket.inet_pton(socket.AF_INET, ipv4))[0]
 
     if ipv6:
         ipv6_binary = socket.inet_pton(socket.AF_INET6, ipv6)
 
     # Zipkin passes unsigned values in signed types because Thrift has no
     # unsigned types, so we have to convert the value.
-    port = struct.unpack('h', struct.pack('H', port))[0]
+    port = struct.unpack("h", struct.pack("H", port))[0]
     return zipkin_core.Endpoint(
-        ipv4=ipv4_int,
-        ipv6=ipv6_binary,
-        port=port,
-        service_name=service_name,
+        ipv4=ipv4_int, ipv6=ipv6_binary, port=port, service_name=service_name,
     )
 
 
@@ -94,9 +88,7 @@ def copy_endpoint_with_new_service_name(endpoint, service_name):
     :returns: zipkin Endpoint object
     """
     return zipkin_core.Endpoint(
-        ipv4=endpoint.ipv4,
-        port=endpoint.port,
-        service_name=service_name,
+        ipv4=endpoint.ipv4, port=endpoint.port, service_name=service_name,
     )
 
 
@@ -160,17 +152,17 @@ def create_span(
         trace_id_high = unsigned_hex_to_signed_int(trace_id_high)
 
     span_dict = {
-        'trace_id': unsigned_hex_to_signed_int(trace_id),
-        'name': span_name,
-        'id': unsigned_hex_to_signed_int(span_id),
-        'annotations': annotations,
-        'binary_annotations': binary_annotations,
-        'timestamp': int(timestamp_s * 1000000) if timestamp_s else None,
-        'duration': int(duration_s * 1000000) if duration_s else None,
-        'trace_id_high': trace_id_high,
+        "trace_id": unsigned_hex_to_signed_int(trace_id),
+        "name": span_name,
+        "id": unsigned_hex_to_signed_int(span_id),
+        "annotations": annotations,
+        "binary_annotations": binary_annotations,
+        "timestamp": int(timestamp_s * 1000000) if timestamp_s else None,
+        "duration": int(duration_s * 1000000) if duration_s else None,
+        "trace_id_high": trace_id_high,
     }
     if parent_span_id:
-        span_dict['parent_id'] = unsigned_hex_to_signed_int(parent_span_id)
+        span_dict["parent_id"] = unsigned_hex_to_signed_int(parent_span_id)
     return zipkin_core.Span(**span_dict)
 
 

--- a/py_zipkin/transport.py
+++ b/py_zipkin/transport.py
@@ -7,7 +7,6 @@ from py_zipkin.encoding import Encoding
 
 
 class BaseTransportHandler(object):
-
     def get_max_payload_bytes(self):  # pragma: no cover
         """Returns the maximum payload size for this transport.
 
@@ -21,14 +20,14 @@ class BaseTransportHandler(object):
 
         :returns: max payload size in bytes or None.
         """
-        raise NotImplementedError('get_max_payload_bytes is not implemented')
+        raise NotImplementedError("get_max_payload_bytes is not implemented")
 
     def send(self, payload):  # pragma: no cover
         """Sends the encoded payload over the transport.
 
         :argument payload: encoded list of spans.
         """
-        raise NotImplementedError('send is not implemented')
+        raise NotImplementedError("send is not implemented")
 
     def __call__(self, payload):
         """Internal wrapper around `send`. Do not override.
@@ -43,7 +42,6 @@ class BaseTransportHandler(object):
 
 
 class SimpleHTTPTransport(BaseTransportHandler):
-
     def __init__(self, address, port):
         """A simple HTTP transport for zipkin.
 
@@ -84,19 +82,19 @@ class SimpleHTTPTransport(BaseTransportHandler):
         encoding = detect_span_version_and_encoding(payload)
 
         if encoding == Encoding.V1_JSON:
-            return '/api/v1/spans', 'application/json'
+            return "/api/v1/spans", "application/json"
         elif encoding == Encoding.V1_THRIFT:
-            return '/api/v1/spans', 'application/x-thrift'
+            return "/api/v1/spans", "application/x-thrift"
         elif encoding == Encoding.V2_JSON:
-            return '/api/v2/spans', 'application/json'
+            return "/api/v2/spans", "application/json"
         elif encoding == Encoding.V2_PROTO3:
-            return '/api/v2/spans', 'application/x-protobuf'
+            return "/api/v2/spans", "application/x-protobuf"
 
     def send(self, payload):
         path, content_type = self._get_path_content_type(payload)
-        url = 'http://{}:{}{}'.format(self.address, self.port, path)
+        url = "http://{}:{}{}".format(self.address, self.port, path)
 
-        req = Request(url, payload, {'Content-Type': content_type})
+        req = Request(url, payload, {"Content-Type": content_type})
         response = urlopen(req)
 
         assert response.getcode() == 202

--- a/py_zipkin/util.py
+++ b/py_zipkin/util.py
@@ -11,7 +11,7 @@ def generate_random_64bit_string():
 
     :returns: random 16-character string
     """
-    return '{:016x}'.format(random.getrandbits(64))
+    return "{:016x}".format(random.getrandbits(64))
 
 
 def generate_random_128bit_string():
@@ -26,7 +26,7 @@ def generate_random_128bit_string():
     """
     t = int(time.time())
     lower_96 = random.getrandbits(96)
-    return '{:032x}'.format((t << 96) | lower_96)
+    return "{:032x}".format((t << 96) | lower_96)
 
 
 def unsigned_hex_to_signed_int(hex_string):
@@ -41,7 +41,7 @@ def unsigned_hex_to_signed_int(hex_string):
     :param hex_string: the string representation of a zipkin ID
     :returns: signed int representation
     """
-    return struct.unpack('q', struct.pack('Q', int(hex_string, 16)))[0]
+    return struct.unpack("q", struct.pack("Q", int(hex_string, 16)))[0]
 
 
 def signed_int_to_unsigned_hex(signed_int):
@@ -54,7 +54,7 @@ def signed_int_to_unsigned_hex(signed_int):
     :param signed_int: an int to convert
     :returns: unsigned hex string
     """
-    hex_string = hex(struct.unpack('Q', struct.pack('q', signed_int))[0])[2:]
-    if hex_string.endswith('L'):
+    hex_string = hex(struct.unpack("Q", struct.pack("q", signed_int))[0])[2:]
+    if hex_string.endswith("L"):
         return hex_string[:-1]
     return hex_string

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -28,11 +28,10 @@ Holds the basic attributes needed to log a zipkin trace
 :param is_sampled: pre-computed boolean whether the trace should be logged
 """
 ZipkinAttrs = namedtuple(
-    'ZipkinAttrs',
-    ['trace_id', 'span_id', 'parent_span_id', 'flags', 'is_sampled'],
+    "ZipkinAttrs", ["trace_id", "span_id", "parent_span_id", "flags", "is_sampled"],
 )
 
-ERROR_KEY = 'error'
+ERROR_KEY = "error"
 
 
 class zipkin_span(object):
@@ -95,7 +94,7 @@ class zipkin_span(object):
     def __init__(
         self,
         service_name,
-        span_name='span',
+        span_name="span",
         zipkin_attrs=None,
         transport_handler=None,
         max_span_batch_size=None,
@@ -226,16 +225,16 @@ class zipkin_span(object):
         # same way.
         # This doesn't fit well with v2 spans since those annotations are gone, so
         # we also log a deprecation warning.
-        if 'sr' in self.annotations and 'ss' in self.annotations:
-            self.duration = self.annotations['ss'] - self.annotations['sr']
-            self.timestamp = self.annotations['sr']
+        if "sr" in self.annotations and "ss" in self.annotations:
+            self.duration = self.annotations["ss"] - self.annotations["sr"]
+            self.timestamp = self.annotations["sr"]
             log.warning(
                 "Manually setting 'sr'/'ss' annotations is deprecated. Please "
                 "use the timestamp and duration parameters."
             )
-        if 'cr' in self.annotations and 'cs' in self.annotations:
-            self.duration = self.annotations['cr'] - self.annotations['cs']
-            self.timestamp = self.annotations['cs']
+        if "cr" in self.annotations and "cs" in self.annotations:
+            self.duration = self.annotations["cr"] - self.annotations["cs"]
+            self.timestamp = self.annotations["cs"]
             log.warning(
                 "Manually setting 'cr'/'cs' annotations is deprecated. Please "
                 "use the timestamp and duration parameters."
@@ -246,8 +245,7 @@ class zipkin_span(object):
         if self.zipkin_attrs_override or self.sample_rate is not None:
             # transport_handler is mandatory for root spans
             if self.transport_handler is None:
-                raise ZipkinError(
-                    'Root spans require a transport handler to be given')
+                raise ZipkinError("Root spans require a transport handler to be given")
 
             self._is_local_root_span = True
 
@@ -256,19 +254,21 @@ class zipkin_span(object):
             self._is_local_root_span = True
 
         if self.sample_rate is not None and not (0.0 <= self.sample_rate <= 100.0):
-            raise ZipkinError('Sample rate must be between 0.0 and 100.0')
+            raise ZipkinError("Sample rate must be between 0.0 and 100.0")
 
-        if self._span_storage is not None and \
-                not isinstance(self._span_storage, storage.SpanStorage):
-            raise ZipkinError('span_storage should be an instance '
-                              'of py_zipkin.storage.SpanStorage')
+        if self._span_storage is not None and not isinstance(
+            self._span_storage, storage.SpanStorage
+        ):
+            raise ZipkinError(
+                "span_storage should be an instance of py_zipkin.storage.SpanStorage"
+            )
 
         if self._span_storage is not None:
-            log.warning('span_storage is deprecated. Set local_storage instead.')
+            log.warning("span_storage is deprecated. Set local_storage instead.")
             self.get_tracer()._span_storage = self._span_storage
 
         if self._context_stack is not None:
-            log.warning('context_stack is deprecated. Set local_storage instead.')
+            log.warning("context_stack is deprecated. Set local_storage instead.")
             self.get_tracer()._context_stack = self._context_stack
 
     def __call__(self, f):
@@ -299,6 +299,7 @@ class zipkin_span(object):
                 _tracer=self._tracer,
             ):
                 return f(*args, **kwargs)
+
         return decorated
 
     def get_tracer(self):
@@ -322,12 +323,10 @@ class zipkin_span(object):
                 # than it's a client or server span respectively.
                 # If neither or both are present, then it's a local span
                 # which is represented by kind = None.
-                log.warning(
-                    'The include argument is deprecated. Please use kind.'
-                )
-                if 'client' in include and 'server' not in include:
+                log.warning("The include argument is deprecated. Please use kind.")
+                if "client" in include and "server" not in include:
                     return Kind.CLIENT
-                elif 'client' not in include and 'server' in include:
+                elif "client" not in include and "server" in include:
                     return Kind.SERVER
                 else:
                     return Kind.LOCAL
@@ -359,30 +358,40 @@ class zipkin_span(object):
             if self.sample_rate is not None:
 
                 # If this trace is not sampled, we re-roll the dice.
-                if self.zipkin_attrs_override and \
-                        not self.zipkin_attrs_override.is_sampled:
+                if (
+                    self.zipkin_attrs_override
+                    and not self.zipkin_attrs_override.is_sampled
+                ):
                     # This will be the root span of the trace, so we should
                     # set timestamp and duration.
-                    return True, create_attrs_for_span(
-                        sample_rate=self.sample_rate,
-                        trace_id=self.zipkin_attrs_override.trace_id,
+                    return (
+                        True,
+                        create_attrs_for_span(
+                            sample_rate=self.sample_rate,
+                            trace_id=self.zipkin_attrs_override.trace_id,
+                        ),
                     )
 
                 # If zipkin_attrs_override was not passed in, we simply generate
                 # new zipkin_attrs to start a new trace.
                 elif not self.zipkin_attrs_override:
-                    return True, create_attrs_for_span(
-                        sample_rate=self.sample_rate,
-                        use_128bit_trace_id=self.use_128bit_trace_id,
+                    return (
+                        True,
+                        create_attrs_for_span(
+                            sample_rate=self.sample_rate,
+                            use_128bit_trace_id=self.use_128bit_trace_id,
+                        ),
                     )
 
             if self.firehose_handler and not self.zipkin_attrs_override:
                 # If it has gotten here, the only thing that is
                 # causing a trace is the firehose. So we force a trace
                 # with sample rate of 0
-                return True, create_attrs_for_span(
-                    sample_rate=0.0,
-                    use_128bit_trace_id=self.use_128bit_trace_id,
+                return (
+                    True,
+                    create_attrs_for_span(
+                        sample_rate=0.0, use_128bit_trace_id=self.use_128bit_trace_id,
+                    ),
                 )
 
             # If we arrive here it means the sample_rate was not set while
@@ -395,12 +404,15 @@ class zipkin_span(object):
             # If there's an existing context, let's create new zipkin_attrs
             # with that context as parent.
             if existing_zipkin_attrs:
-                return False, ZipkinAttrs(
-                    trace_id=existing_zipkin_attrs.trace_id,
-                    span_id=generate_random_64bit_string(),
-                    parent_span_id=existing_zipkin_attrs.span_id,
-                    flags=existing_zipkin_attrs.flags,
-                    is_sampled=existing_zipkin_attrs.is_sampled,
+                return (
+                    False,
+                    ZipkinAttrs(
+                        trace_id=existing_zipkin_attrs.trace_id,
+                        span_id=generate_random_64bit_string(),
+                        parent_span_id=existing_zipkin_attrs.span_id,
+                        flags=existing_zipkin_attrs.flags,
+                        is_sampled=existing_zipkin_attrs.is_sampled,
+                    ),
                 )
 
         return False, None
@@ -439,8 +451,10 @@ class zipkin_span(object):
             # cause all previously recorded spans to never be emitted as exiting
             # the inner logging context will reset transport_configured to False.
             if self.get_tracer().is_transport_configured():
-                log.info('Transport was already configured, ignoring override'
-                         'from span {}'.format(self.span_name))
+                log.info(
+                    "Transport was already configured, ignoring override "
+                    "from span {}".format(self.span_name)
+                )
                 return self
             endpoint = create_endpoint(self.port, self.service_name, self.host)
             self.logging_context = ZipkinLoggingContext(
@@ -485,10 +499,8 @@ class zipkin_span(object):
 
         # Add the error annotation if an exception occurred
         if any((_exc_type, _exc_value, _exc_traceback)):
-            error_msg = u'{0}: {1}'.format(_exc_type.__name__, _exc_value)
-            self.update_binary_annotations({
-                ERROR_KEY: error_msg,
-            })
+            error_msg = u"{0}: {1}".format(_exc_type.__name__, _exc_value)
+            self.update_binary_annotations({ERROR_KEY: error_msg})
 
         # Logging context is only initialized for "root" spans of the local
         # process (i.e. this zipkin_span not inside of any other local
@@ -497,9 +509,7 @@ class zipkin_span(object):
             try:
                 self.logging_context.stop()
             except Exception as ex:
-                err_msg = 'Error emitting zipkin trace. {}'.format(
-                    repr(ex),
-                )
+                err_msg = "Error emitting zipkin trace. {}".format(repr(ex))
                 log.error(err_msg)
             finally:
                 self.logging_context = None
@@ -518,19 +528,21 @@ class zipkin_span(object):
             duration = end_timestamp - self.start_timestamp
 
         endpoint = create_endpoint(self.port, self.service_name, self.host)
-        self.get_tracer().add_span(Span(
-            trace_id=self.zipkin_attrs.trace_id,
-            name=self.span_name,
-            parent_id=self.zipkin_attrs.parent_span_id,
-            span_id=self.zipkin_attrs.span_id,
-            kind=self.kind,
-            timestamp=self.timestamp if self.timestamp else self.start_timestamp,
-            duration=duration,
-            annotations=self.annotations,
-            local_endpoint=endpoint,
-            remote_endpoint=self.remote_endpoint,
-            tags=self.binary_annotations,
-        ))
+        self.get_tracer().add_span(
+            Span(
+                trace_id=self.zipkin_attrs.trace_id,
+                name=self.span_name,
+                parent_id=self.zipkin_attrs.parent_span_id,
+                span_id=self.zipkin_attrs.span_id,
+                kind=self.kind,
+                timestamp=self.timestamp if self.timestamp else self.start_timestamp,
+                duration=duration,
+                annotations=self.annotations,
+                local_endpoint=endpoint,
+                remote_endpoint=self.remote_endpoint,
+                tags=self.binary_annotations,
+            )
+        )
 
     def update_binary_annotations(self, extra_annotations):
         """Updates the binary annotations for the current span."""
@@ -564,10 +576,7 @@ class zipkin_span(object):
             self.logging_context.annotations[value] = timestamp
 
     def add_sa_binary_annotation(
-        self,
-        port=0,
-        service_name='unknown',
-        host='127.0.0.1',
+        self, port=0, service_name="unknown", host="127.0.0.1",
     ):
         """Adds a 'sa' binary annotation to the current span.
 
@@ -589,17 +598,15 @@ class zipkin_span(object):
             return
 
         remote_endpoint = create_endpoint(
-            port=port,
-            service_name=service_name,
-            host=host,
+            port=port, service_name=service_name, host=host,
         )
         if not self.logging_context:
             if self.remote_endpoint is not None:
-                raise ValueError('SA annotation already set.')
+                raise ValueError("SA annotation already set.")
             self.remote_endpoint = remote_endpoint
         else:
             if self.logging_context.remote_endpoint is not None:
-                raise ValueError('SA annotation already set.')
+                raise ValueError("SA annotation already set.")
             self.logging_context.remote_endpoint = remote_endpoint
 
     def override_span_name(self, name):
@@ -619,10 +626,10 @@ class zipkin_span(object):
 
 
 def _validate_args(kwargs):
-    if 'kind' in kwargs:
+    if "kind" in kwargs:
         raise ValueError(
             '"kind" is not valid in this context. '
-            'You probably want to use zipkin_span()'
+            "You probably want to use zipkin_span()"
         )
 
 
@@ -639,7 +646,7 @@ class zipkin_client_span(zipkin_span):
         """
         _validate_args(kwargs)
 
-        kwargs['kind'] = Kind.CLIENT
+        kwargs["kind"] = Kind.CLIENT
         super(zipkin_client_span, self).__init__(*args, **kwargs)
 
 
@@ -656,15 +663,12 @@ class zipkin_server_span(zipkin_span):
         """
         _validate_args(kwargs)
 
-        kwargs['kind'] = Kind.SERVER
+        kwargs["kind"] = Kind.SERVER
         super(zipkin_server_span, self).__init__(*args, **kwargs)
 
 
 def create_attrs_for_span(
-    sample_rate=100.0,
-    trace_id=None,
-    span_id=None,
-    use_128bit_trace_id=False,
+    sample_rate=100.0, trace_id=None, span_id=None, use_128bit_trace_id=False,
 ):
     """Creates a set of zipkin attributes for a span.
 
@@ -696,7 +700,7 @@ def create_attrs_for_span(
         trace_id=trace_id,
         span_id=span_id,
         parent_span_id=None,
-        flags='0',
+        flags="0",
         is_sampled=is_sampled,
     )
 
@@ -724,9 +728,9 @@ def create_http_headers_for_new_span(context_stack=None, tracer=None):
         return {}
 
     return {
-        'X-B3-TraceId': zipkin_attrs.trace_id,
-        'X-B3-SpanId': generate_random_64bit_string(),
-        'X-B3-ParentSpanId': zipkin_attrs.span_id,
-        'X-B3-Flags': '0',
-        'X-B3-Sampled': '1' if zipkin_attrs.is_sampled else '0',
+        "X-B3-TraceId": zipkin_attrs.trace_id,
+        "X-B3-SpanId": generate_random_64bit_string(),
+        "X-B3-ParentSpanId": zipkin_attrs.span_id,
+        "X-B3-Flags": "0",
+        "X-B3-Sampled": "1" if zipkin_attrs.is_sampled else "0",
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,10 +6,10 @@ from py_zipkin.zipkin import ZipkinAttrs
 @pytest.fixture
 def zipkin_attributes():
     return {
-        'trace_id': '17133d482ba4f605',
-        'span_id': '27133d482ba4f605',
-        'parent_span_id': '37133d482ba4f605',
-        'flags': '45',
+        "trace_id": "17133d482ba4f605",
+        "span_id": "27133d482ba4f605",
+        "parent_span_id": "37133d482ba4f605",
+        "flags": "45",
     }
 
 

--- a/tests/encoding/__init__test.py
+++ b/tests/encoding/__init__test.py
@@ -8,12 +8,10 @@ from py_zipkin.exception import ZipkinError
 from tests.test_helpers import generate_list_of_spans
 
 
-@pytest.mark.parametrize('encoding', [
-    Encoding.V1_THRIFT,
-    Encoding.V1_JSON,
-    Encoding.V2_JSON,
-    Encoding.V2_PROTO3,
-])
+@pytest.mark.parametrize(
+    "encoding",
+    [Encoding.V1_THRIFT, Encoding.V1_JSON, Encoding.V2_JSON, Encoding.V2_PROTO3],
+)
 def test_detect_span_version_and_encoding(encoding):
     spans, _, _, _ = generate_list_of_spans(encoding)
     old_type = type(spans)
@@ -28,19 +26,20 @@ def test_detect_span_version_and_encoding(encoding):
 
 def test_detect_span_version_and_encoding_incomplete_message():
     with pytest.raises(ZipkinError):
-        detect_span_version_and_encoding('[')
+        detect_span_version_and_encoding("[")
 
 
 def test_detect_span_version_and_encoding_ambiguous_json():
     """JSON spans that don't have any v1 or v2 keyword default to V2"""
-    assert detect_span_version_and_encoding(
-        '[{"traceId": "aaa", "id": "bbb"}]',
-    ) == Encoding.V2_JSON
+    assert (
+        detect_span_version_and_encoding('[{"traceId": "aaa", "id": "bbb"}]')
+        == Encoding.V2_JSON
+    )
 
 
 def test_detect_span_version_and_encoding_unknown_encoding():
     with pytest.raises(ZipkinError):
-        detect_span_version_and_encoding('foobar')
+        detect_span_version_and_encoding("foobar")
 
 
 def test_convert_spans_thrift_to_v2_json():

--- a/tests/encoding/_decoders_test.py
+++ b/tests/encoding/_decoders_test.py
@@ -24,7 +24,7 @@ USEC = 1000 * 1000
 
 @pytest.fixture
 def thrift_endpoint():
-    return thrift.create_endpoint(8888, 'test_service', '10.0.0.1', None)
+    return thrift.create_endpoint(8888, "test_service", "10.0.0.1", None)
 
 
 def test_get_decoder():
@@ -40,15 +40,14 @@ def test_get_decoder():
 def test_idecoder_throws_not_implemented_errors():
     encoder = IDecoder()
     with pytest.raises(NotImplementedError):
-        encoder.decode_spans(b'[]')
+        encoder.decode_spans(b"[]")
 
 
 class TestV1ThriftDecoder(object):
-
     def test_decode_spans_list(self):
         spans, _, _, _ = generate_list_of_spans(Encoding.V1_THRIFT)
         decoder = _V1ThriftDecoder()
-        with mock.patch.object(decoder, '_decode_thrift_span') as mock_decode:
+        with mock.patch.object(decoder, "_decode_thrift_span") as mock_decode:
             decoder.decode_spans(spans)
             assert mock_decode.call_count == 2
 
@@ -62,7 +61,7 @@ class TestV1ThriftDecoder(object):
         """
         span = generate_single_thrift_span()
         decoder = _V1ThriftDecoder()
-        with mock.patch.object(decoder, '_decode_thrift_span') as mock_decode:
+        with mock.patch.object(decoder, "_decode_thrift_span") as mock_decode:
             decoder.decode_spans(span)
             assert mock_decode.call_count == 1
 
@@ -70,30 +69,25 @@ class TestV1ThriftDecoder(object):
         decoder = _V1ThriftDecoder()
 
         ipv4_endpoint = decoder._convert_from_thrift_endpoint(thrift_endpoint)
-        assert ipv4_endpoint == Endpoint('test_service', '10.0.0.1', None, 8888)
+        assert ipv4_endpoint == Endpoint("test_service", "10.0.0.1", None, 8888)
 
-        ipv6_thrift_endpoint = \
-            thrift.create_endpoint(8888, 'test_service', None, '::1')
+        ipv6_thrift_endpoint = thrift.create_endpoint(8888, "test_service", None, "::1")
         ipv6_endpoint = decoder._convert_from_thrift_endpoint(ipv6_thrift_endpoint)
-        assert ipv6_endpoint == Endpoint('test_service', None, '::1', 8888)
+        assert ipv6_endpoint == Endpoint("test_service", None, "::1", 8888)
 
     def test__decode_thrift_annotations(self, thrift_endpoint):
         timestamp = 1.0
         decoder = _V1ThriftDecoder()
         thrift_annotations = thrift.annotation_list_builder(
-            {
-                'cs': timestamp,
-                'cr': timestamp + 10,
-                'my_annotation': timestamp + 15,
-            },
+            {"cs": timestamp, "cr": timestamp + 10, "my_annotation": timestamp + 15},
             thrift_endpoint,
         )
 
         annotations, end, kind, ts, dur = decoder._decode_thrift_annotations(
             thrift_annotations,
         )
-        assert annotations == {'my_annotation': 16.0}
-        assert end == Endpoint('test_service', '10.0.0.1', None, 8888)
+        assert annotations == {"my_annotation": 16.0}
+        assert end == Endpoint("test_service", "10.0.0.1", None, 8888)
         assert kind == Kind.CLIENT
         assert ts == timestamp * USEC
         assert dur == 10 * USEC
@@ -102,18 +96,14 @@ class TestV1ThriftDecoder(object):
         timestamp = 1.0
         decoder = _V1ThriftDecoder()
         thrift_annotations = thrift.annotation_list_builder(
-            {
-                'sr': timestamp,
-                'ss': timestamp + 10,
-            },
-            thrift_endpoint,
+            {"sr": timestamp, "ss": timestamp + 10}, thrift_endpoint,
         )
 
         annotations, end, kind, ts, dur = decoder._decode_thrift_annotations(
             thrift_annotations,
         )
         assert annotations == {}
-        assert end == Endpoint('test_service', '10.0.0.1', None, 8888)
+        assert end == Endpoint("test_service", "10.0.0.1", None, 8888)
         assert kind == Kind.SERVER
         assert ts == timestamp * USEC
         assert dur == 10 * USEC
@@ -123,10 +113,10 @@ class TestV1ThriftDecoder(object):
         decoder = _V1ThriftDecoder()
         thrift_annotations = thrift.annotation_list_builder(
             {
-                'cs': timestamp,
-                'sr': timestamp,
-                'ss': timestamp + 10,
-                'cr': timestamp + 10,
+                "cs": timestamp,
+                "sr": timestamp,
+                "ss": timestamp + 10,
+                "cr": timestamp + 10,
             },
             thrift_endpoint,
         )
@@ -135,7 +125,7 @@ class TestV1ThriftDecoder(object):
             thrift_annotations,
         )
         assert annotations == {}
-        assert end == Endpoint('test_service', '10.0.0.1', None, 8888)
+        assert end == Endpoint("test_service", "10.0.0.1", None, 8888)
         assert kind == Kind.LOCAL
         # ts and dur are not computed for a local span since those always have
         # timestamp and duration set as span arguments.
@@ -144,62 +134,64 @@ class TestV1ThriftDecoder(object):
 
     def test__convert_from_thrift_binary_annotations(self):
         decoder = _V1ThriftDecoder()
-        local_host = thrift.create_endpoint(8888, 'test_service', '10.0.0.1', None)
-        remote_host = thrift.create_endpoint(9999, 'rem_service', '10.0.0.2', None)
+        local_host = thrift.create_endpoint(8888, "test_service", "10.0.0.1", None)
+        remote_host = thrift.create_endpoint(9999, "rem_service", "10.0.0.2", None)
         ann_type = zipkin_core.AnnotationType
         thrift_binary_annotations = [
-            create_binary_annotation('key1', True, ann_type.BOOL, local_host),
-            create_binary_annotation('key2', 'val2', ann_type.STRING, local_host),
-            create_binary_annotation('key3', False, ann_type.BOOL, local_host),
-            create_binary_annotation('key4', b'04', ann_type.I16, local_host),
-            create_binary_annotation('key5', b'0004', ann_type.I32, local_host),
-            create_binary_annotation('sa', True, ann_type.BOOL, remote_host),
+            create_binary_annotation("key1", True, ann_type.BOOL, local_host),
+            create_binary_annotation("key2", "val2", ann_type.STRING, local_host),
+            create_binary_annotation("key3", False, ann_type.BOOL, local_host),
+            create_binary_annotation("key4", b"04", ann_type.I16, local_host),
+            create_binary_annotation("key5", b"0004", ann_type.I32, local_host),
+            create_binary_annotation("sa", True, ann_type.BOOL, remote_host),
         ]
 
-        tags, local_endpoint, remote_endpoint = \
-            decoder._convert_from_thrift_binary_annotations(
-                thrift_binary_annotations,
-            )
+        (
+            tags,
+            local_endpoint,
+            remote_endpoint,
+        ) = decoder._convert_from_thrift_binary_annotations(thrift_binary_annotations)
 
         assert tags == {
-            'key1': 'true',
-            'key2': 'val2',
-            'key3': 'false',
+            "key1": "true",
+            "key2": "val2",
+            "key3": "false",
         }
-        assert local_endpoint == Endpoint('test_service', '10.0.0.1', None, 8888)
-        assert remote_endpoint == Endpoint('rem_service', '10.0.0.2', None, 9999)
+        assert local_endpoint == Endpoint("test_service", "10.0.0.1", None, 8888)
+        assert remote_endpoint == Endpoint("rem_service", "10.0.0.2", None, 9999)
 
     def test__convert_from_thrift_binary_annotations_unicode(self):
         decoder = _V1ThriftDecoder()
-        local_host = thrift.create_endpoint(8888, 'test_service', '10.0.0.1', None)
+        local_host = thrift.create_endpoint(8888, "test_service", "10.0.0.1", None)
         ann_type = zipkin_core.AnnotationType
         thrift_binary_annotations = [
-            create_binary_annotation('key1', u'再见', ann_type.STRING, local_host),
-            create_binary_annotation('key2', 'val2', ann_type.STRING, local_host),
-            create_binary_annotation('key3', '再见', ann_type.STRING, local_host),
+            create_binary_annotation("key1", u"再见", ann_type.STRING, local_host),
+            create_binary_annotation("key2", "val2", ann_type.STRING, local_host),
+            create_binary_annotation("key3", "再见", ann_type.STRING, local_host),
         ]
 
-        tags, local_endpoint, remote_endpoint = \
-            decoder._convert_from_thrift_binary_annotations(
-                thrift_binary_annotations,
-            )
+        (
+            tags,
+            local_endpoint,
+            remote_endpoint,
+        ) = decoder._convert_from_thrift_binary_annotations(thrift_binary_annotations)
 
         assert tags == {
-            'key1': u'再见',
-            'key2': 'val2',
-            'key3': '再见',
+            "key1": u"再见",
+            "key2": "val2",
+            "key3": "再见",
         }
-        assert local_endpoint == Endpoint('test_service', '10.0.0.1', None, 8888)
+        assert local_endpoint == Endpoint("test_service", "10.0.0.1", None, 8888)
 
     def test_seconds_doesnt_crash_with_none(self):
         decoder = _V1ThriftDecoder()
         assert decoder.seconds(6000000) == 6.0
         assert decoder.seconds(None) is None
 
-    @pytest.mark.parametrize('trace_id_generator', [
-        (generate_random_64bit_string),
-        (generate_random_128bit_string),
-    ])
+    @pytest.mark.parametrize(
+        "trace_id_generator",
+        [(generate_random_64bit_string), (generate_random_128bit_string)],
+    )
     def test__convert_trace_id_to_string(self, trace_id_generator):
         decoder = _V1ThriftDecoder()
         trace_id = trace_id_generator()
@@ -207,16 +199,16 @@ class TestV1ThriftDecoder(object):
             generate_random_64bit_string(),
             None,
             trace_id,
-            'test_span',
+            "test_span",
             [],
             [],
             None,
             None,
         )
-        assert decoder._convert_trace_id_to_string(
-            span.trace_id,
-            span.trace_id_high,
-        ) == trace_id
+        assert (
+            decoder._convert_trace_id_to_string(span.trace_id, span.trace_id_high)
+            == trace_id
+        )
 
     def test__convert_unsigned_long_to_lower_hex(self):
         decoder = _V1ThriftDecoder()
@@ -225,7 +217,7 @@ class TestV1ThriftDecoder(object):
             span_id,
             None,
             generate_random_64bit_string(),
-            'test_span',
+            "test_span",
             [],
             [],
             None,

--- a/tests/encoding/_encoders_test.py
+++ b/tests/encoding/_encoders_test.py
@@ -17,83 +17,62 @@ from py_zipkin.encoding._types import Kind
 from py_zipkin.exception import ZipkinError
 
 
-@mock.patch('socket.gethostbyname', autospec=True)
+@mock.patch("socket.gethostbyname", autospec=True)
 def test_create_endpoint_defaults_service_name(gethostbyname):
-    gethostbyname.return_value = '0.0.0.0'
+    gethostbyname.return_value = "0.0.0.0"
     endpoint = create_endpoint(port=8080)
 
-    assert endpoint.service_name == 'unknown'
+    assert endpoint.service_name == "unknown"
     assert endpoint.port == 8080
-    assert endpoint.ipv4 == '0.0.0.0'
+    assert endpoint.ipv4 == "0.0.0.0"
     assert endpoint.ipv6 is None
 
 
-@mock.patch('socket.gethostbyname', autospec=True)
+@mock.patch("socket.gethostbyname", autospec=True)
 def test_create_endpoint_correct_host_ip(gethostbyname):
-    gethostbyname.return_value = '1.2.3.4'
-    endpoint = create_endpoint(host='0.0.0.0')
+    gethostbyname.return_value = "1.2.3.4"
+    endpoint = create_endpoint(host="0.0.0.0")
 
-    assert endpoint.service_name == 'unknown'
+    assert endpoint.service_name == "unknown"
     assert endpoint.port == 0
-    assert endpoint.ipv4 == '0.0.0.0'
+    assert endpoint.ipv4 == "0.0.0.0"
     assert endpoint.ipv6 is None
 
 
-@mock.patch('socket.gethostbyname', autospec=True)
+@mock.patch("socket.gethostbyname", autospec=True)
 def test_create_endpoint_defaults_localhost(gethostbyname):
     gethostbyname.side_effect = socket.gaierror
 
-    endpoint = create_endpoint(
-        port=8080,
-        service_name='foo',
-    )
-    assert endpoint.service_name == 'foo'
+    endpoint = create_endpoint(port=8080, service_name="foo")
+    assert endpoint.service_name == "foo"
     assert endpoint.port == 8080
-    assert endpoint.ipv4 == '127.0.0.1'
+    assert endpoint.ipv4 == "127.0.0.1"
     assert endpoint.ipv6 is None
 
 
 def test_create_endpoint_ipv6():
     endpoint = create_endpoint(
-        port=8080,
-        service_name='foo',
-        host='2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+        port=8080, service_name="foo", host="2001:0db8:85a3:0000:0000:8a2e:0370:7334",
     )
-    assert endpoint.service_name == 'foo'
+    assert endpoint.service_name == "foo"
     assert endpoint.port == 8080
     assert endpoint.ipv4 is None
-    assert endpoint.ipv6 == '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    assert endpoint.ipv6 == "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
 
 
 def test_malformed_host():
-    endpoint = create_endpoint(
-        port=8080,
-        service_name='foo',
-        host='80',
-    )
-    assert endpoint.service_name == 'foo'
+    endpoint = create_endpoint(port=8080, service_name="foo", host="80")
+    assert endpoint.service_name == "foo"
     assert endpoint.port == 8080
     assert endpoint.ipv4 is None
     assert endpoint.ipv6 is None
 
 
 def test_encoder():
-    assert isinstance(
-        get_encoder(Encoding.V1_THRIFT),
-        _V1ThriftEncoder,
-    )
-    assert isinstance(
-        get_encoder(Encoding.V1_JSON),
-        _V1JSONEncoder,
-    )
-    assert isinstance(
-        get_encoder(Encoding.V2_JSON),
-        _V2JSONEncoder,
-    )
-    assert isinstance(
-        get_encoder(Encoding.V2_PROTO3),
-        _V2ProtobufEncoder,
-    )
+    assert isinstance(get_encoder(Encoding.V1_THRIFT), _V1ThriftEncoder)
+    assert isinstance(get_encoder(Encoding.V1_JSON), _V1JSONEncoder)
+    assert isinstance(get_encoder(Encoding.V2_JSON), _V2JSONEncoder)
+    assert isinstance(get_encoder(Encoding.V2_PROTO3), _V2ProtobufEncoder)
     with pytest.raises(ZipkinError):
         get_encoder(None)
 
@@ -124,131 +103,122 @@ class TestBaseJSONEncoder(object):
 
     def test_create_json_endpoint(self, encoder):
         ipv4_endpoint = create_endpoint(
-            port=8888,
-            service_name='test_service',
-            host='127.0.0.1',
+            port=8888, service_name="test_service", host="127.0.0.1",
         )
         assert encoder._create_json_endpoint(ipv4_endpoint, False) == {
-            'serviceName': 'test_service',
-            'port': 8888,
-            'ipv4': '127.0.0.1',
+            "serviceName": "test_service",
+            "port": 8888,
+            "ipv4": "127.0.0.1",
         }
 
         ipv6_endpoint = create_endpoint(
             port=8888,
-            service_name='test_service',
-            host='2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+            service_name="test_service",
+            host="2001:0db8:85a3:0000:0000:8a2e:0370:7334",
         )
         assert encoder._create_json_endpoint(ipv6_endpoint, False) == {
-            'serviceName': 'test_service',
-            'port': 8888,
-            'ipv6': '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+            "serviceName": "test_service",
+            "port": 8888,
+            "ipv6": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
         }
 
         v1_endpoint = create_endpoint(
             port=8888,
             service_name=None,
-            host='2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+            host="2001:0db8:85a3:0000:0000:8a2e:0370:7334",
             use_defaults=False,
         )
         assert encoder._create_json_endpoint(v1_endpoint, True) == {
-            'serviceName': '',
-            'port': 8888,
-            'ipv6': '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+            "serviceName": "",
+            "port": 8888,
+            "ipv6": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
         }
 
         v2_endpoint = create_endpoint(
             port=8888,
             service_name=None,
-            host='2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+            host="2001:0db8:85a3:0000:0000:8a2e:0370:7334",
             use_defaults=False,
         )
         assert encoder._create_json_endpoint(v2_endpoint, False) == {
-            'port': 8888,
-            'ipv6': '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+            "port": 8888,
+            "ipv6": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
         }
 
 
 class TestV1JSONEncoder(object):
     def test_remote_endpoint(self):
         encoder = get_encoder(Encoding.V1_JSON)
-        remote_endpoint = create_endpoint(
-            service_name='test_server',
-            host='127.0.0.1',
-        )
+        remote_endpoint = create_endpoint(service_name="test_server", host="127.0.0.1")
 
         # For server spans, the remote endpoint is encoded as 'ca'
         binary_annotations = []
         encoder.encode_remote_endpoint(
-            remote_endpoint,
-            Kind.SERVER,
-            binary_annotations,
+            remote_endpoint, Kind.SERVER, binary_annotations,
         )
-        assert binary_annotations == [{
-            'endpoint': {'ipv4': '127.0.0.1', 'serviceName': 'test_server'},
-            'key': 'ca',
-            'value': True,
-        }]
+        assert binary_annotations == [
+            {
+                "endpoint": {"ipv4": "127.0.0.1", "serviceName": "test_server"},
+                "key": "ca",
+                "value": True,
+            }
+        ]
 
         # For client spans, the remote endpoint is encoded as 'sa'
         binary_annotations = []
         encoder.encode_remote_endpoint(
-            remote_endpoint,
-            Kind.CLIENT,
-            binary_annotations,
+            remote_endpoint, Kind.CLIENT, binary_annotations,
         )
-        assert binary_annotations == [{
-            'endpoint': {'ipv4': '127.0.0.1', 'serviceName': 'test_server'},
-            'key': 'sa',
-            'value': True,
-        }]
+        assert binary_annotations == [
+            {
+                "endpoint": {"ipv4": "127.0.0.1", "serviceName": "test_server"},
+                "key": "sa",
+                "value": True,
+            }
+        ]
 
 
 class TestV1ThriftEncoder(object):
     def test_remote_endpoint(self):
         encoder = get_encoder(Encoding.V1_THRIFT)
-        remote_endpoint = create_endpoint(
-            service_name='test_server',
-            host='127.0.0.1',
-        )
+        remote_endpoint = create_endpoint(service_name="test_server", host="127.0.0.1")
 
         # For server spans, the remote endpoint is encoded as 'ca'
         binary_annotations = thrift.binary_annotation_list_builder({}, None)
         encoder.encode_remote_endpoint(
-            remote_endpoint,
-            Kind.SERVER,
-            binary_annotations,
+            remote_endpoint, Kind.SERVER, binary_annotations,
         )
-        assert binary_annotations == [thrift.create_binary_annotation(
-            key='ca',
-            value=thrift.SERVER_ADDR_VAL,
-            annotation_type=thrift.zipkin_core.AnnotationType.BOOL,
-            host=thrift.create_endpoint(0, 'test_server', '127.0.0.1', None),
-        )]
+        assert binary_annotations == [
+            thrift.create_binary_annotation(
+                key="ca",
+                value=thrift.SERVER_ADDR_VAL,
+                annotation_type=thrift.zipkin_core.AnnotationType.BOOL,
+                host=thrift.create_endpoint(0, "test_server", "127.0.0.1", None),
+            )
+        ]
 
         # For client spans, the remote endpoint is encoded as 'sa'
         binary_annotations = thrift.binary_annotation_list_builder({}, None)
         encoder.encode_remote_endpoint(
-            remote_endpoint,
-            Kind.CLIENT,
-            binary_annotations,
+            remote_endpoint, Kind.CLIENT, binary_annotations,
         )
-        assert binary_annotations == [thrift.create_binary_annotation(
-            key='sa',
-            value=thrift.SERVER_ADDR_VAL,
-            annotation_type=thrift.zipkin_core.AnnotationType.BOOL,
-            host=thrift.create_endpoint(0, 'test_server', '127.0.0.1', None),
-        )]
+        assert binary_annotations == [
+            thrift.create_binary_annotation(
+                key="sa",
+                value=thrift.SERVER_ADDR_VAL,
+                annotation_type=thrift.zipkin_core.AnnotationType.BOOL,
+                host=thrift.create_endpoint(0, "test_server", "127.0.0.1", None),
+            )
+        ]
 
 
 class TestV2ProtobufEncoder(object):
-
     @pytest.fixture
     def encoder(self):
         return get_encoder(Encoding.V2_PROTO3)
 
     def test_fits(self, encoder):
-        span = Span('1', 'name', '2', '3', Kind.CLIENT, 10, 10)
+        span = Span("1", "name", "2", "3", Kind.CLIENT, 10, 10)
         pb_span = encoder.encode_span(span)
         span_len = len(pb_span)
 
@@ -256,9 +226,9 @@ class TestV2ProtobufEncoder(object):
         assert encoder.fits(None, span_len, span_len * 2, pb_span) is True
         assert encoder.fits(None, span_len + 1, span_len * 2, pb_span) is False
 
-    @mock.patch('py_zipkin.encoding.protobuf.installed', autospec=True)
+    @mock.patch("py_zipkin.encoding.protobuf.installed", autospec=True)
     def test_encode_span(self, mock_installed, encoder):
-        span = Span('1', 'name', '2', '3', Kind.CLIENT, 10, 10)
+        span = Span("1", "name", "2", "3", Kind.CLIENT, 10, 10)
 
         mock_installed.return_value = False
         with pytest.raises(ZipkinError):
@@ -269,7 +239,7 @@ class TestV2ProtobufEncoder(object):
         assert isinstance(pb_span, bytes)
 
     def test_encode_queue(self, encoder):
-        span = Span('1', 'name', '2', '3', Kind.CLIENT, 10, 10)
+        span = Span("1", "name", "2", "3", Kind.CLIENT, 10, 10)
         pb_span = encoder.encode_span(span)
 
         pb_list = encoder.encode_queue([pb_span])

--- a/tests/encoding/_helpers_test.py
+++ b/tests/encoding/_helpers_test.py
@@ -14,110 +14,95 @@ def test_create_span_with_bad_kind():
     with pytest.raises(ZipkinError) as e:
         Span(
             trace_id=generate_random_64bit_string(),
-            name='test span',
+            name="test span",
             parent_id=generate_random_64bit_string(),
             span_id=generate_random_64bit_string(),
-            kind='client',
+            kind="client",
             timestamp=26.0,
             duration=4.0,
         )
 
-    assert (
-        'Invalid kind value client. Must be of type Kind.' in str(e.value)
-    )
+    assert "Invalid kind value client. Must be of type Kind." in str(e.value)
 
 
 def test_create_span_with_bad_local_endpoint():
     with pytest.raises(ZipkinError) as e:
         Span(
             trace_id=generate_random_64bit_string(),
-            name='test span',
+            name="test span",
             parent_id=generate_random_64bit_string(),
             span_id=generate_random_64bit_string(),
             kind=Kind.CLIENT,
             timestamp=26.0,
             duration=4.0,
-            local_endpoint='my_service',
+            local_endpoint="my_service",
         )
 
-    assert (
-        'Invalid local_endpoint value. Must be of type Endpoint.' in str(e.value)
-    )
+    assert "Invalid local_endpoint value. Must be of type Endpoint." in str(e.value)
 
 
 def test_create_span_with_bad_remote_endpoint():
     with pytest.raises(ZipkinError) as e:
         Span(
             trace_id=generate_random_64bit_string(),
-            name='test span',
+            name="test span",
             parent_id=generate_random_64bit_string(),
             span_id=generate_random_64bit_string(),
             kind=Kind.CLIENT,
             timestamp=26.0,
             duration=4.0,
-            remote_endpoint='my_service',
+            remote_endpoint="my_service",
         )
 
-    assert (
-        'Invalid remote_endpoint value. Must be of type Endpoint.' in str(e.value)
-    )
+    assert "Invalid remote_endpoint value. Must be of type Endpoint." in str(e.value)
 
 
-@mock.patch('socket.gethostbyname', autospec=True)
+@mock.patch("socket.gethostbyname", autospec=True)
 def test_create_endpoint_defaults_service_name(gethostbyname):
-    gethostbyname.return_value = '0.0.0.0'
+    gethostbyname.return_value = "0.0.0.0"
     endpoint = create_endpoint(port=8080)
 
-    assert endpoint.service_name == 'unknown'
+    assert endpoint.service_name == "unknown"
     assert endpoint.port == 8080
-    assert endpoint.ipv4 == '0.0.0.0'
+    assert endpoint.ipv4 == "0.0.0.0"
     assert endpoint.ipv6 is None
 
 
-@mock.patch('socket.gethostbyname', autospec=True)
+@mock.patch("socket.gethostbyname", autospec=True)
 def test_create_endpoint_correct_host_ip(gethostbyname):
-    gethostbyname.return_value = '1.2.3.4'
-    endpoint = create_endpoint(host='0.0.0.0')
+    gethostbyname.return_value = "1.2.3.4"
+    endpoint = create_endpoint(host="0.0.0.0")
 
-    assert endpoint.service_name == 'unknown'
+    assert endpoint.service_name == "unknown"
     assert endpoint.port == 0
-    assert endpoint.ipv4 == '0.0.0.0'
+    assert endpoint.ipv4 == "0.0.0.0"
     assert endpoint.ipv6 is None
 
 
-@mock.patch('socket.gethostbyname', autospec=True)
+@mock.patch("socket.gethostbyname", autospec=True)
 def test_create_endpoint_defaults_localhost(gethostbyname):
     gethostbyname.side_effect = socket.gaierror
 
-    endpoint = create_endpoint(
-        port=8080,
-        service_name='foo',
-    )
-    assert endpoint.service_name == 'foo'
+    endpoint = create_endpoint(port=8080, service_name="foo")
+    assert endpoint.service_name == "foo"
     assert endpoint.port == 8080
-    assert endpoint.ipv4 == '127.0.0.1'
+    assert endpoint.ipv4 == "127.0.0.1"
     assert endpoint.ipv6 is None
 
 
 def test_create_endpoint_ipv6():
     endpoint = create_endpoint(
-        port=8080,
-        service_name='foo',
-        host='2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+        port=8080, service_name="foo", host="2001:0db8:85a3:0000:0000:8a2e:0370:7334",
     )
-    assert endpoint.service_name == 'foo'
+    assert endpoint.service_name == "foo"
     assert endpoint.port == 8080
     assert endpoint.ipv4 is None
-    assert endpoint.ipv6 == '2001:0db8:85a3:0000:0000:8a2e:0370:7334'
+    assert endpoint.ipv6 == "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
 
 
 def test_malformed_host():
-    endpoint = create_endpoint(
-        port=8080,
-        service_name='foo',
-        host='80',
-    )
-    assert endpoint.service_name == 'foo'
+    endpoint = create_endpoint(port=8080, service_name="foo", host="80")
+    assert endpoint.service_name == "foo"
     assert endpoint.port == 8080
     assert endpoint.ipv4 is None
     assert endpoint.ipv6 is None

--- a/tests/encoding/_protobuf_test.py
+++ b/tests/encoding/_protobuf_test.py
@@ -8,13 +8,13 @@ from py_zipkin.encoding.protobuf import zipkin_pb2
 
 
 def test_installed():
-    with mock.patch.object(protobuf, 'zipkin_pb2', None):
+    with mock.patch.object(protobuf, "zipkin_pb2", None):
         assert protobuf.installed() is False
 
     assert protobuf.installed() is True
 
 
-@mock.patch('py_zipkin.encoding.protobuf.zipkin_pb2.ListOfSpans')
+@mock.patch("py_zipkin.encoding.protobuf.zipkin_pb2.ListOfSpans")
 def test_encode_pb_list(mock_list):
     protobuf.encode_pb_list([])
 
@@ -25,53 +25,50 @@ def test_encode_pb_list(mock_list):
 
 def test_create_protobuf_span():
     span = Span(
-        trace_id='1',
-        name='name',
-        parent_id='2',
-        span_id='3',
+        trace_id="1",
+        name="name",
+        parent_id="2",
+        span_id="3",
         kind=Kind.CLIENT,
         timestamp=10,
         duration=10,
-        local_endpoint=create_endpoint(
-            service_name='service1',
-            use_defaults=False,
-        ),
-        remote_endpoint=create_endpoint(
-            service_name='service2',
-            use_defaults=False,
-        ),
+        local_endpoint=create_endpoint(service_name="service1", use_defaults=False),
+        remote_endpoint=create_endpoint(service_name="service2", use_defaults=False),
         debug=True,
         shared=True,
-        annotations={'foo': 1},
-        tags={'key': 'value'},
+        annotations={"foo": 1},
+        tags={"key": "value"},
     )
 
     pb_span = protobuf.create_protobuf_span(span)
 
     assert pb_span == zipkin_pb2.Span(
-        trace_id=b'\000\000\000\000\000\000\000\001',
-        parent_id=b'\000\000\000\000\000\000\000\002',
-        id=b'\000\000\000\000\000\000\000\003',
+        trace_id=b"\000\000\000\000\000\000\000\001",
+        parent_id=b"\000\000\000\000\000\000\000\002",
+        id=b"\000\000\000\000\000\000\000\003",
         kind=zipkin_pb2.Span.CLIENT,
-        name='name',
+        name="name",
         timestamp=10000000,
         duration=10000000,
-        local_endpoint=zipkin_pb2.Endpoint(service_name='service1'),
-        remote_endpoint=zipkin_pb2.Endpoint(service_name='service2'),
+        local_endpoint=zipkin_pb2.Endpoint(service_name="service1"),
+        remote_endpoint=zipkin_pb2.Endpoint(service_name="service2"),
         debug=True,
         shared=True,
-        annotations=[zipkin_pb2.Annotation(timestamp=1000000, value='foo')],
-        tags={'key': 'value'},
+        annotations=[zipkin_pb2.Annotation(timestamp=1000000, value="foo")],
+        tags={"key": "value"},
     )
 
 
 def test_hex_to_bytes():
-    assert protobuf._hex_to_bytes('6e611a263bd498a') == \
-        b'\x06\xe6\x11\xa2c\xbdI\x8a'
-    assert protobuf._hex_to_bytes('5c72e322656b5346e611a263bd498a') == \
-        b'\x00\\r\xe3"ekSF\xe6\x11\xa2c\xbdI\x8a'
-    assert protobuf._hex_to_bytes('325c72e322656b5346e611a263bd498a') == \
-        b'2\\r\xe3"ekSF\xe6\x11\xa2c\xbdI\x8a'
+    assert protobuf._hex_to_bytes("6e611a263bd498a") == b"\x06\xe6\x11\xa2c\xbdI\x8a"
+    assert (
+        protobuf._hex_to_bytes("5c72e322656b5346e611a263bd498a")
+        == b'\x00\\r\xe3"ekSF\xe6\x11\xa2c\xbdI\x8a'
+    )
+    assert (
+        protobuf._hex_to_bytes("325c72e322656b5346e611a263bd498a")
+        == b'2\\r\xe3"ekSF\xe6\x11\xa2c\xbdI\x8a'
+    )
 
 
 def test_get_protobuf_kind():
@@ -83,27 +80,24 @@ def test_get_protobuf_kind():
 
 
 def test_convert_endpoint():
-    endpoint = create_endpoint(8888, 'service1', '127.0.0.1')
+    endpoint = create_endpoint(8888, "service1", "127.0.0.1")
     assert protobuf._convert_endpoint(endpoint) == zipkin_pb2.Endpoint(
-        service_name='service1',
-        port=8888,
-        ipv4=b'\177\000\000\001',
-        ipv6=None,
+        service_name="service1", port=8888, ipv4=b"\177\000\000\001", ipv6=None,
     )
 
-    ipv6_endpoint = create_endpoint(0, 'service1', 'fe80::1ff:fe23:4567:890')
+    ipv6_endpoint = create_endpoint(0, "service1", "fe80::1ff:fe23:4567:890")
     assert protobuf._convert_endpoint(ipv6_endpoint) == zipkin_pb2.Endpoint(
-        service_name='service1',
+        service_name="service1",
         ipv4=None,
-        ipv6=b'\376\200\000\000\000\000\000\000\001\377\376#Eg\010\220',
+        ipv6=b"\376\200\000\000\000\000\000\000\001\377\376#Eg\010\220",
     )
 
 
 def test_convert_annotations():
-    annotations = protobuf._convert_annotations({'foo': 123.456, 'bar': 456.789})
+    annotations = protobuf._convert_annotations({"foo": 123.456, "bar": 456.789})
     # The annotations dict is unordered in python < 3.6 so we need to sort the
     # output list to avoid making this test flaky.
     assert sorted(annotations, key=lambda a: a.timestamp) == [
-        zipkin_pb2.Annotation(timestamp=123456000, value='foo'),
-        zipkin_pb2.Annotation(timestamp=456789000, value='bar'),
+        zipkin_pb2.Annotation(timestamp=123456000, value="foo"),
+        zipkin_pb2.Annotation(timestamp=456789000, value="bar"),
     ]

--- a/tests/integration/decoding_test.py
+++ b/tests/integration/decoding_test.py
@@ -13,45 +13,46 @@ def us(seconds):
 
 
 def test_encoding():
-    thrift_spans, zipkin_attrs, inner_span_id, ts = \
-        generate_list_of_spans(Encoding.V1_THRIFT)
+    thrift_spans, zipkin_attrs, inner_span_id, ts = generate_list_of_spans(
+        Encoding.V1_THRIFT
+    )
 
     json_spans = convert_spans(thrift_spans, Encoding.V2_JSON)
 
     inner_span, root_span = json.loads(json_spans)
 
     assert root_span == {
-        'traceId': zipkin_attrs.trace_id,
-        'name': 'test_span_name',
-        'parentId': zipkin_attrs.parent_span_id,
-        'id': zipkin_attrs.span_id,
-        'timestamp': us(ts),
-        'duration': us(10),
-        'kind': 'CLIENT',
-        'localEndpoint': {
-            'ipv4': '10.0.0.0',
-            'port': 8080,
-            'serviceName': 'test_service_name',
+        "traceId": zipkin_attrs.trace_id,
+        "name": "test_span_name",
+        "parentId": zipkin_attrs.parent_span_id,
+        "id": zipkin_attrs.span_id,
+        "timestamp": us(ts),
+        "duration": us(10),
+        "kind": "CLIENT",
+        "localEndpoint": {
+            "ipv4": "10.0.0.0",
+            "port": 8080,
+            "serviceName": "test_service_name",
         },
-        'remoteEndpoint': {
-            'ipv6': '2001:db8:85a3::8a2e:370:7334',
-            'port': 8888,
-            'serviceName': 'sa_service',
+        "remoteEndpoint": {
+            "ipv6": "2001:db8:85a3::8a2e:370:7334",
+            "port": 8888,
+            "serviceName": "sa_service",
         },
-        'tags': {'some_key': 'some_value'},
+        "tags": {"some_key": "some_value"},
     }
 
     assert inner_span == {
-        'traceId': zipkin_attrs.trace_id,
-        'name': 'inner_span',
-        'parentId': zipkin_attrs.span_id,
-        'id': inner_span_id,
-        'timestamp': us(ts),
-        'duration': us(5),
-        'localEndpoint': {
-            'ipv4': '10.0.0.0',
-            'port': 8080,
-            'serviceName': 'test_service_name',
+        "traceId": zipkin_attrs.trace_id,
+        "name": "inner_span",
+        "parentId": zipkin_attrs.span_id,
+        "id": inner_span_id,
+        "timestamp": us(ts),
+        "duration": us(5),
+        "localEndpoint": {
+            "ipv4": "10.0.0.0",
+            "port": 8080,
+            "serviceName": "test_service_name",
         },
-        'annotations': [{'timestamp': us(ts), 'value': 'ws'}],
+        "annotations": [{"timestamp": us(ts), "value": "ws"}],
     }

--- a/tests/integration/encoding_test.py
+++ b/tests/integration/encoding_test.py
@@ -39,79 +39,47 @@ def check_v1_json(obj, zipkin_attrs, inner_span_id, ts):
     inner_span, root_span = json.loads(obj)
 
     endpoint = {
-        'ipv4': '10.0.0.0',
-        'port': 8080,
-        'serviceName': 'test_service_name',
+        "ipv4": "10.0.0.0",
+        "port": 8080,
+        "serviceName": "test_service_name",
     }
     assert root_span == {
-        'traceId': zipkin_attrs.trace_id,
-        'parentId': zipkin_attrs.parent_span_id,
-        'name': 'test_span_name',
-        'id': zipkin_attrs.span_id,
-        'binaryAnnotations': [
+        "traceId": zipkin_attrs.trace_id,
+        "parentId": zipkin_attrs.parent_span_id,
+        "name": "test_span_name",
+        "id": zipkin_attrs.span_id,
+        "binaryAnnotations": [
+            {"endpoint": endpoint, "key": "some_key", "value": "some_value"},
             {
-                'endpoint': endpoint,
-                'key': 'some_key',
-                'value': 'some_value',
-            },
-            {
-                'endpoint': {
-                    'ipv6': '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-                    'port': 8888,
-                    'serviceName': 'sa_service',
+                "endpoint": {
+                    "ipv6": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                    "port": 8888,
+                    "serviceName": "sa_service",
                 },
-                'key': 'sa',
-                'value': True,
+                "key": "sa",
+                "value": True,
             },
         ],
-        'annotations': [
-            {
-                'endpoint': endpoint,
-                'timestamp': us(ts),
-                'value': 'cs',
-            },
-            {
-                'endpoint': endpoint,
-                'timestamp': us(ts + 10),
-                'value': 'cr',
-            },
+        "annotations": [
+            {"endpoint": endpoint, "timestamp": us(ts), "value": "cs"},
+            {"endpoint": endpoint, "timestamp": us(ts + 10), "value": "cr"},
         ],
     }
 
     assert inner_span == {
-        'traceId': zipkin_attrs.trace_id,
-        'parentId': zipkin_attrs.span_id,
-        'name': 'inner_span',
-        'id': inner_span_id,
-        'timestamp': us(ts),
-        'duration': us(5),
-        'binaryAnnotations': [],
-        'annotations': [
-            {
-                'endpoint': endpoint,
-                'timestamp': us(ts),
-                'value': 'cs',
-            },
-            {
-                'endpoint': endpoint,
-                'timestamp': us(ts),
-                'value': 'sr',
-            },
-            {
-                'endpoint': endpoint,
-                'timestamp': us(ts + 5),
-                'value': 'ss',
-            },
-            {
-                'endpoint': endpoint,
-                'timestamp': us(ts + 5),
-                'value': 'cr',
-            },
-            {
-                'endpoint': endpoint,
-                'timestamp': us(ts),
-                'value': 'ws',
-            },
+        "traceId": zipkin_attrs.trace_id,
+        "parentId": zipkin_attrs.span_id,
+        "name": "inner_span",
+        "id": inner_span_id,
+        "timestamp": us(ts),
+        "duration": us(5),
+        "binaryAnnotations": [],
+        "annotations": [
+            {"endpoint": endpoint, "timestamp": us(ts), "value": "cs"},
+            {"endpoint": endpoint, "timestamp": us(ts), "value": "sr"},
+            {"endpoint": endpoint, "timestamp": us(ts + 5), "value": "ss"},
+            {"endpoint": endpoint, "timestamp": us(ts + 5), "value": "cr"},
+            {"endpoint": endpoint, "timestamp": us(ts), "value": "ws"},
         ],
     }
 
@@ -120,33 +88,31 @@ def check_v1_thrift(obj, zipkin_attrs, inner_span_id, ts):
     inner_span, root_span = _decode_binary_thrift_objs(obj)
 
     endpoint = thrift.create_endpoint(
-        port=8080,
-        service_name='test_service_name',
-        ipv4='10.0.0.0',
+        port=8080, service_name="test_service_name", ipv4="10.0.0.0",
     )
     binary_annotations = thrift.binary_annotation_list_builder(
-        {'some_key': 'some_value'},
-        endpoint,
+        {"some_key": "some_value"}, endpoint,
     )
-    binary_annotations.append(thrift.create_binary_annotation(
-        'sa',
-        '\x01',
-        zipkin_core.AnnotationType.BOOL,
-        thrift.create_endpoint(
-            port=8888,
-            service_name='sa_service',
-            ipv6='2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-        ),
-    ))
+    binary_annotations.append(
+        thrift.create_binary_annotation(
+            "sa",
+            "\x01",
+            zipkin_core.AnnotationType.BOOL,
+            thrift.create_endpoint(
+                port=8888,
+                service_name="sa_service",
+                ipv6="2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+            ),
+        )
+    )
 
     expected_root = thrift.create_span(
         span_id=zipkin_attrs.span_id,
         parent_span_id=zipkin_attrs.parent_span_id,
         trace_id=zipkin_attrs.trace_id,
-        span_name='test_span_name',
+        span_name="test_span_name",
         annotations=thrift.annotation_list_builder(
-            OrderedDict([('cs', ts), ('cr', ts + 10)]),
-            endpoint,
+            OrderedDict([("cs", ts), ("cr", ts + 10)]), endpoint,
         ),
         binary_annotations=binary_annotations,
         timestamp_s=None,
@@ -163,10 +129,11 @@ def check_v1_thrift(obj, zipkin_attrs, inner_span_id, ts):
         span_id=inner_span_id,
         parent_span_id=zipkin_attrs.span_id,
         trace_id=zipkin_attrs.trace_id,
-        span_name='inner_span',
+        span_name="inner_span",
         annotations=thrift.annotation_list_builder(
-            OrderedDict([('cs', ts), ('sr', ts), ('ss', ts + 5),
-                         ('cr', ts + 5), ('ws', ts)]),
+            OrderedDict(
+                [("cs", ts), ("sr", ts), ("ss", ts + 5), ("cr", ts + 5), ("ws", ts)]
+            ),
             endpoint,
         ),
         binary_annotations=[],
@@ -185,48 +152,51 @@ def check_v2_json(obj, zipkin_attrs, inner_span_id, ts):
     inner_span, root_span = json.loads(obj)
 
     assert root_span == {
-        'traceId': zipkin_attrs.trace_id,
-        'name': 'test_span_name',
-        'parentId': zipkin_attrs.parent_span_id,
-        'id': zipkin_attrs.span_id,
-        'kind': 'CLIENT',
-        'timestamp': us(ts),
-        'duration': us(10),
-        'shared': True,
-        'localEndpoint': {
-            'ipv4': '10.0.0.0',
-            'port': 8080,
-            'serviceName': 'test_service_name',
+        "traceId": zipkin_attrs.trace_id,
+        "name": "test_span_name",
+        "parentId": zipkin_attrs.parent_span_id,
+        "id": zipkin_attrs.span_id,
+        "kind": "CLIENT",
+        "timestamp": us(ts),
+        "duration": us(10),
+        "shared": True,
+        "localEndpoint": {
+            "ipv4": "10.0.0.0",
+            "port": 8080,
+            "serviceName": "test_service_name",
         },
-        'remoteEndpoint': {
-            'ipv6': '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-            'port': 8888,
-            'serviceName': 'sa_service',
+        "remoteEndpoint": {
+            "ipv6": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+            "port": 8888,
+            "serviceName": "sa_service",
         },
-        'tags': {'some_key': 'some_value'},
+        "tags": {"some_key": "some_value"},
     }
 
     assert inner_span == {
-        'traceId': zipkin_attrs.trace_id,
-        'name': 'inner_span',
-        'parentId': zipkin_attrs.span_id,
-        'id': inner_span_id,
-        'timestamp': us(ts),
-        'duration': us(5),
-        'localEndpoint': {
-            'ipv4': '10.0.0.0',
-            'port': 8080,
-            'serviceName': 'test_service_name',
+        "traceId": zipkin_attrs.trace_id,
+        "name": "inner_span",
+        "parentId": zipkin_attrs.span_id,
+        "id": inner_span_id,
+        "timestamp": us(ts),
+        "duration": us(5),
+        "localEndpoint": {
+            "ipv4": "10.0.0.0",
+            "port": 8080,
+            "serviceName": "test_service_name",
         },
-        'annotations': [{'timestamp': us(ts), 'value': 'ws'}],
+        "annotations": [{"timestamp": us(ts), "value": "ws"}],
     }
 
 
-@pytest.mark.parametrize('encoding,validate_fn', [
-    (Encoding.V1_THRIFT, check_v1_thrift),
-    (Encoding.V1_JSON, check_v1_json),
-    (Encoding.V2_JSON, check_v2_json),
-])
+@pytest.mark.parametrize(
+    "encoding,validate_fn",
+    [
+        (Encoding.V1_THRIFT, check_v1_thrift),
+        (Encoding.V1_JSON, check_v1_json),
+        (Encoding.V2_JSON, check_v2_json),
+    ],
+)
 def test_encoding(encoding, validate_fn):
     zipkin_attrs = ZipkinAttrs(
         trace_id=generate_random_64bit_string(),
@@ -243,38 +213,34 @@ def test_encoding(encoding, validate_fn):
     # sometimes returns N and sometimes N+1. This ts value doesn't have that
     # issue afaict, probably since it ends in zeros.
     ts = 1538544126.115900
-    with mock.patch('time.time', autospec=True) as mock_time:
+    with mock.patch("time.time", autospec=True) as mock_time:
         # zipkin.py start, logging_helper.start, 3 x logging_helper.stop
         # I don't understand why logging_helper.stop would run 3 times, but
         # that's what I'm seeing in the test
         mock_time.side_effect = iter([ts, ts, ts + 10, ts + 10, ts + 10])
         with zipkin.zipkin_span(
-            service_name='test_service_name',
-            span_name='test_span_name',
+            service_name="test_service_name",
+            span_name="test_span_name",
             transport_handler=mock_transport_handler,
-            binary_annotations={'some_key': 'some_value'},
+            binary_annotations={"some_key": "some_value"},
             encoding=encoding,
             zipkin_attrs=zipkin_attrs,
-            host='10.0.0.0',
+            host="10.0.0.0",
             port=8080,
             kind=Kind.CLIENT,
         ) as span:
             with mock.patch.object(
-                zipkin,
-                'generate_random_64bit_string',
-                return_value=inner_span_id,
+                zipkin, "generate_random_64bit_string", return_value=inner_span_id,
             ):
                 with zipkin.zipkin_span(
-                    service_name='test_service_name',
-                    span_name='inner_span',
+                    service_name="test_service_name",
+                    span_name="inner_span",
                     timestamp=ts,
                     duration=5,
-                    annotations={'ws': ts},
+                    annotations={"ws": ts},
                 ):
                     span.add_sa_binary_annotation(
-                        8888,
-                        'sa_service',
-                        '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+                        8888, "sa_service", "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
                     )
 
     output = mock_transport_handler.get_payloads()[0]

--- a/tests/integration/multithreading_test.py
+++ b/tests/integration/multithreading_test.py
@@ -10,9 +10,9 @@ from tests.test_helpers import MockTransportHandler
 tracer = get_default_tracer()
 
 
-@zipkin_span(service_name='service1', span_name='service1_do_stuff')
+@zipkin_span(service_name="service1", span_name="service1_do_stuff")
 def do_stuff():
-    return 'OK'
+    return "OK"
 
 
 def run_inside_another_thread(transport):
@@ -24,8 +24,8 @@ def run_inside_another_thread(transport):
     :type transport: MockTransportHandler
     """
     with get_default_tracer().zipkin_span(
-        service_name='webapp',
-        span_name='index',
+        service_name="webapp",
+        span_name="index",
         transport_handler=transport,
         sample_rate=100.0,
         encoding=Encoding.V2_JSON,
@@ -48,5 +48,5 @@ def test_decorator_works_in_a_new_thread():
 
     spans = json.loads(output[0])
     assert len(spans) == 2
-    assert spans[0]['name'] == 'service1_do_stuff'
-    assert spans[1]['name'] == 'index'
+    assert spans[0]["name"] == "service1_do_stuff"
+    assert spans[1]["name"] == "index"

--- a/tests/integration/zipkin_integration_test.py
+++ b/tests/integration/zipkin_integration_test.py
@@ -33,11 +33,11 @@ def test_starting_zipkin_trace_with_sampling_rate():
     mock_transport_handler, mock_logs = mock_logger()
     mock_firehose_handler, mock_firehose_logs = mock_logger()
     with zipkin.zipkin_span(
-        service_name='test_service_name',
-        span_name='test_span_name',
+        service_name="test_service_name",
+        span_name="test_span_name",
         transport_handler=mock_transport_handler,
         sample_rate=100.0,
-        binary_annotations={'some_key': 'some_value'},
+        binary_annotations={"some_key": "some_value"},
         add_logging_annotation=True,
         firehose_handler=mock_firehose_handler,
         encoding=Encoding.V2_JSON,
@@ -45,15 +45,16 @@ def test_starting_zipkin_trace_with_sampling_rate():
         pass
 
     def check_span(span):
-        assert span['name'] == 'test_span_name'
-        assert span['localEndpoint']['serviceName'] == 'test_service_name'
-        assert 'parentId' not in span
+        assert span["name"] == "test_span_name"
+        assert span["localEndpoint"]["serviceName"] == "test_service_name"
+        assert "parentId" not in span
         # timestamp and duration are microsecond conversions of time.time()
-        assert span['timestamp'] is not None
-        assert span['duration'] is not None
-        assert span['tags']['some_key'] == 'some_value'
-        assert sorted([ann['value'] for ann in span['annotations']]) == [
-            LOGGING_END_KEY]
+        assert span["timestamp"] is not None
+        assert span["duration"] is not None
+        assert span["tags"]["some_key"] == "some_value"
+        assert sorted([ann["value"] for ann in span["annotations"]]) == [
+            LOGGING_END_KEY
+        ]
 
     check_span(json.loads(mock_logs[0])[0])
     check_span(json.loads(mock_firehose_logs[0])[0])
@@ -63,11 +64,11 @@ def test_starting_zipkin_trace_with_128bit_trace_id():
     mock_transport_handler, mock_logs = mock_logger()
     mock_firehose_handler, mock_firehose_logs = mock_logger()
     with zipkin.zipkin_span(
-        service_name='test_service_name',
-        span_name='test_span_name',
+        service_name="test_service_name",
+        span_name="test_span_name",
         transport_handler=mock_transport_handler,
         sample_rate=100.0,
-        binary_annotations={'some_key': 'some_value'},
+        binary_annotations={"some_key": "some_value"},
         add_logging_annotation=True,
         use_128bit_trace_id=True,
         firehose_handler=mock_firehose_handler,
@@ -76,8 +77,8 @@ def test_starting_zipkin_trace_with_128bit_trace_id():
         pass
 
     def check_span(span):
-        assert 'traceId' in span
-        assert len(span['traceId']) == 32
+        assert "traceId" in span
+        assert len(span["traceId"]) == 32
 
     check_span(json.loads(mock_logs[0])[0])
     check_span(json.loads(mock_firehose_logs[0])[0])
@@ -87,18 +88,18 @@ def test_span_inside_trace():
     """This tests that nested spans work correctly"""
     mock_transport_handler, mock_logs = mock_logger()
     with zipkin.zipkin_span(
-        service_name='test_service_name',
-        span_name='test_span_name',
+        service_name="test_service_name",
+        span_name="test_span_name",
         transport_handler=mock_transport_handler,
         sample_rate=100.0,
-        binary_annotations={'some_key': 'some_value'},
+        binary_annotations={"some_key": "some_value"},
         encoding=Encoding.V2_JSON,
     ):
         with zipkin.zipkin_span(
-            service_name='nested_service',
-            span_name='nested_span',
-            annotations={'nested_annotation': 43},
-            binary_annotations={'nested_key': 'nested_value'},
+            service_name="nested_service",
+            span_name="nested_span",
+            annotations={"nested_annotation": 43},
+            binary_annotations={"nested_key": "nested_value"},
         ):
             pass
 
@@ -108,20 +109,21 @@ def test_span_inside_trace():
     nested_span = spans[0]
     root_span = spans[1]
 
-    assert nested_span['name'] == 'nested_span'
-    assert nested_span['localEndpoint']['serviceName'] == 'nested_service'
-    assert nested_span['parentId'] == root_span['id']
-    assert nested_span['tags']['nested_key'] == 'nested_value'
+    assert nested_span["name"] == "nested_span"
+    assert nested_span["localEndpoint"]["serviceName"] == "nested_service"
+    assert nested_span["parentId"] == root_span["id"]
+    assert nested_span["tags"]["nested_key"] == "nested_value"
     # Local nested spans report timestamp and duration
-    assert nested_span['timestamp'] is not None
-    assert nested_span['duration'] is not None
-    assert len(nested_span['annotations']) == 1
-    assert 'kind' not in nested_span
-    assert sorted([ann['value'] for ann in nested_span['annotations']]) == sorted([
-        'nested_annotation'])
-    for ann in nested_span['annotations']:
-        if ann['value'] == 'nested_annotation':
-            assert ann['timestamp'] == 43 * USECS
+    assert nested_span["timestamp"] is not None
+    assert nested_span["duration"] is not None
+    assert len(nested_span["annotations"]) == 1
+    assert "kind" not in nested_span
+    assert sorted([ann["value"] for ann in nested_span["annotations"]]) == sorted(
+        ["nested_annotation"]
+    )
+    for ann in nested_span["annotations"]:
+        if ann["value"] == "nested_annotation":
+            assert ann["timestamp"] == 43 * USECS
 
 
 def test_annotation_override():
@@ -131,68 +133,70 @@ def test_annotation_override():
     mock_transport_handler, mock_logs = mock_logger()
     mock_firehose_handler, mock_firehose_logs = mock_logger()
     with zipkin.zipkin_span(
-        service_name='test_service_name',
-        span_name='test_span_name',
+        service_name="test_service_name",
+        span_name="test_span_name",
         transport_handler=mock_transport_handler,
         sample_rate=100.0,
-        binary_annotations={'some_key': 'some_value'},
+        binary_annotations={"some_key": "some_value"},
         firehose_handler=mock_firehose_handler,
         encoding=Encoding.V1_JSON,
     ):
         with zipkin.zipkin_span(
-            service_name='nested_service',
-            span_name='nested_span',
-            annotations={'nested_annotation': 43, 'cs': 100, 'cr': 300},
-            binary_annotations={'nested_key': 'nested_value'},
+            service_name="nested_service",
+            span_name="nested_span",
+            annotations={"nested_annotation": 43, "cs": 100, "cr": 300},
+            binary_annotations={"nested_key": "nested_value"},
         ):
             pass
 
     def check_spans(spans):
         nested_span = spans[0]
         root_span = spans[1]
-        assert nested_span['name'] == 'nested_span'
-        assert nested_span['annotations'][0]['endpoint']['serviceName'] == \
-            'nested_service'
-        assert nested_span['parentId'] == root_span['id']
-        assert nested_span['binaryAnnotations'][0]['key'] == 'nested_key'
-        assert nested_span['binaryAnnotations'][0]['value'] == 'nested_value'
+        assert nested_span["name"] == "nested_span"
+        assert (
+            nested_span["annotations"][0]["endpoint"]["serviceName"] == "nested_service"
+        )
+        assert nested_span["parentId"] == root_span["id"]
+        assert nested_span["binaryAnnotations"][0]["key"] == "nested_key"
+        assert nested_span["binaryAnnotations"][0]["value"] == "nested_value"
         # Local nested spans report timestamp and duration
-        assert nested_span['timestamp'] is not None
-        assert nested_span['duration'] is not None
-        assert len(nested_span['annotations']) == 5
-        assert sorted([ann['value'] for ann in nested_span['annotations']]) == \
-            sorted(['ss', 'sr', 'cs', 'cr', 'nested_annotation'])
-        for ann in nested_span['annotations']:
-            if ann['value'] == 'nested_annotation':
-                assert ann['timestamp'] == 43 * USECS
-            elif ann['value'] == 'cs':
-                assert ann['timestamp'] == 100 * USECS
-            elif ann['value'] == 'cr':
-                assert ann['timestamp'] == 300 * USECS
+        assert nested_span["timestamp"] is not None
+        assert nested_span["duration"] is not None
+        assert len(nested_span["annotations"]) == 5
+        assert sorted([ann["value"] for ann in nested_span["annotations"]]) == sorted(
+            ["ss", "sr", "cs", "cr", "nested_annotation"]
+        )
+        for ann in nested_span["annotations"]:
+            if ann["value"] == "nested_annotation":
+                assert ann["timestamp"] == 43 * USECS
+            elif ann["value"] == "cs":
+                assert ann["timestamp"] == 100 * USECS
+            elif ann["value"] == "cr":
+                assert ann["timestamp"] == 300 * USECS
 
     check_spans(json.loads(mock_logs[0]))
     check_spans(json.loads(mock_firehose_logs[0]))
 
 
-@pytest.mark.parametrize('encoding', [Encoding.V1_JSON, Encoding.V2_JSON])
+@pytest.mark.parametrize("encoding", [Encoding.V1_JSON, Encoding.V2_JSON])
 def test_sr_ss_annotation_override(encoding):
     """Here we override ss and sr and expect the output span to contain the
     values we're passing in.
     """
     mock_transport_handler, mock_logs = mock_logger()
     with zipkin.zipkin_span(
-        service_name='test_service_name',
-        span_name='test_span_name',
+        service_name="test_service_name",
+        span_name="test_span_name",
         transport_handler=mock_transport_handler,
         sample_rate=100.0,
-        binary_annotations={'some_key': 'some_value'},
+        binary_annotations={"some_key": "some_value"},
         encoding=encoding,
     ):
         with zipkin.zipkin_span(
-            service_name='nested_service',
-            span_name='nested_span',
-            annotations={'nested_annotation': 43, 'sr': 100, 'ss': 300},
-            binary_annotations={'nested_key': 'nested_value'},
+            service_name="nested_service",
+            span_name="nested_span",
+            annotations={"nested_annotation": 43, "sr": 100, "ss": 300},
+            binary_annotations={"nested_key": "nested_value"},
             kind=Kind.SERVER,
         ):
             pass
@@ -202,36 +206,32 @@ def test_sr_ss_annotation_override(encoding):
     nested_span = spans[0]
     root_span = spans[1]
 
-    assert nested_span['parentId'] == root_span['id']
-    assert nested_span['timestamp'] == 100 * USECS
-    assert nested_span['duration'] == 200 * USECS
+    assert nested_span["parentId"] == root_span["id"]
+    assert nested_span["timestamp"] == 100 * USECS
+    assert nested_span["duration"] == 200 * USECS
 
     # In V1, we also add sr and ss to the list of annotations
     if encoding == Encoding.V1_JSON:
-        assert len(nested_span['annotations']) == 3
-        for ann in nested_span['annotations']:
-            if ann['value'] == 'nested_annotation':
-                assert ann['timestamp'] == 43 * USECS
-            elif ann['value'] == 'sr':
-                assert ann['timestamp'] == 100 * USECS
-            elif ann['value'] == 'ss':
-                assert ann['timestamp'] == 300 * USECS
+        assert len(nested_span["annotations"]) == 3
+        for ann in nested_span["annotations"]:
+            if ann["value"] == "nested_annotation":
+                assert ann["timestamp"] == 43 * USECS
+            elif ann["value"] == "sr":
+                assert ann["timestamp"] == 100 * USECS
+            elif ann["value"] == "ss":
+                assert ann["timestamp"] == 300 * USECS
 
 
-@pytest.mark.parametrize('encoding', [Encoding.V1_JSON, Encoding.V2_JSON])
+@pytest.mark.parametrize("encoding", [Encoding.V1_JSON, Encoding.V2_JSON])
 def test_service_span(encoding):
     """Tests that zipkin_attrs can be passed in"""
     mock_transport_handler, mock_logs = mock_logger()
     zipkin_attrs = ZipkinAttrs(
-        trace_id='0',
-        span_id='1',
-        parent_span_id='2',
-        flags='0',
-        is_sampled=True,
+        trace_id="0", span_id="1", parent_span_id="2", flags="0", is_sampled=True,
     )
     with zipkin.zipkin_span(
-        service_name='test_service_name',
-        span_name='service_span',
+        service_name="test_service_name",
+        span_name="service_span",
         zipkin_attrs=zipkin_attrs,
         transport_handler=mock_transport_handler,
         encoding=encoding,
@@ -239,21 +239,21 @@ def test_service_span(encoding):
         pass
 
     span = json.loads(mock_logs[0])[0]
-    assert span['name'] == 'service_span'
-    assert span['traceId'] == '0'
-    assert span['id'] == '1'
-    assert span['parentId'] == '2'
+    assert span["name"] == "service_span"
+    assert span["traceId"] == "0"
+    assert span["id"] == "1"
+    assert span["parentId"] == "2"
 
     if encoding == Encoding.V1_JSON:
         # Spans continued on the server don't log timestamp/duration, as it's
         # assumed the client part of the pair will log them.
-        assert 'timestamp' not in span
-        assert 'duration' not in span
+        assert "timestamp" not in span
+        assert "duration" not in span
     elif encoding == Encoding.V2_JSON:
-        assert span['shared'] is True
+        assert span["shared"] is True
 
 
-@mock.patch.object(log, 'error', autospec=True)
+@mock.patch.object(log, "error", autospec=True)
 def test_service_exits_on_erroneous_span(log_mock):
     """Tests that for invalid zipkin_attrs exceptions are not thrown
        Services may not be handling them. Instead log an error
@@ -262,15 +262,15 @@ def test_service_exits_on_erroneous_span(log_mock):
     tracer = MockTracer()
     try:
         zipkin_attrs = ZipkinAttrs(
-            trace_id='0',
-            span_id='1, 1',  # invalid span id
-            parent_span_id='2',
-            flags='0',
+            trace_id="0",
+            span_id="1, 1",  # invalid span id
+            parent_span_id="2",
+            flags="0",
             is_sampled=True,
         )
         with tracer.zipkin_span(
-            service_name='test_service_name',
-            span_name='service_span',
+            service_name="test_service_name",
+            span_name="service_span",
             zipkin_attrs=zipkin_attrs,
             transport_handler=mock_transport_handler,
             encoding=Encoding.V1_THRIFT,
@@ -278,7 +278,7 @@ def test_service_exits_on_erroneous_span(log_mock):
             pass
 
     except Exception:
-        pytest.fail('Exception not expected to be thrown!')
+        pytest.fail("Exception not expected to be thrown!")
 
     finally:
         assert log_mock.call_count == 1
@@ -292,15 +292,11 @@ def test_service_span_report_timestamp_override():
     # We need to pass in zipkin_attrs so that py_zipkin doesn't think this is the
     # root span (ts and duration are always set for the root span)
     zipkin_attrs = ZipkinAttrs(
-        trace_id='0',
-        span_id='1',
-        parent_span_id='2',
-        flags='0',
-        is_sampled=True,
+        trace_id="0", span_id="1", parent_span_id="2", flags="0", is_sampled=True,
     )
     with zipkin.zipkin_span(
-        service_name='test_service_name',
-        span_name='service_span',
+        service_name="test_service_name",
+        span_name="service_span",
         zipkin_attrs=zipkin_attrs,
         transport_handler=mock_transport_handler,
         report_root_timestamp=True,
@@ -309,11 +305,11 @@ def test_service_span_report_timestamp_override():
         pass
 
     span = json.loads(mock_logs[0])[0]
-    assert 'timestamp' in span
-    assert 'duration' in span
+    assert "timestamp" in span
+    assert "duration" in span
 
 
-@pytest.mark.parametrize('encoding', [Encoding.V1_JSON, Encoding.V2_JSON])
+@pytest.mark.parametrize("encoding", [Encoding.V1_JSON, Encoding.V2_JSON])
 def test_service_span_that_is_independently_sampled(encoding):
     """Tests that sample_rate has can turn on sampling for a trace.
 
@@ -323,15 +319,11 @@ def test_service_span_that_is_independently_sampled(encoding):
     mock_transport_handler, mock_logs = mock_logger()
     mock_firehose_handler, mock_firehose_logs = mock_logger()
     zipkin_attrs = ZipkinAttrs(
-        trace_id='0',
-        span_id='1',
-        parent_span_id='2',
-        flags='0',
-        is_sampled=False,
+        trace_id="0", span_id="1", parent_span_id="2", flags="0", is_sampled=False,
     )
     with zipkin.zipkin_span(
-        service_name='test_service_name',
-        span_name='service_span',
+        service_name="test_service_name",
+        span_name="service_span",
         zipkin_attrs=zipkin_attrs,
         transport_handler=mock_transport_handler,
         port=45,
@@ -342,19 +334,19 @@ def test_service_span_that_is_independently_sampled(encoding):
         pass
 
     def check_span(span):
-        assert span['traceId'] == '0'
-        assert span['name'] == 'service_span'
-        assert 'parentId' not in span
+        assert span["traceId"] == "0"
+        assert span["name"] == "service_span"
+        assert "parentId" not in span
         # Spans that are part of an unsampled trace which start their own sampling
         # should report timestamp/duration, as they're acting as root spans.
-        assert 'timestamp' in span
-        assert 'duration' in span
+        assert "timestamp" in span
+        assert "duration" in span
         if encoding == Encoding.V2_JSON:
             # BUG: this should fail in the firehose trace since there was already
             # an ongoing trace and we have a parent. However we emit the exact
             # same span for both the normal transport and firehose, so this is not
             # something we can handle right now.
-            assert 'shared' not in span
+            assert "shared" not in span
 
     check_span(json.loads(mock_logs[0])[0])
     check_span(json.loads(mock_firehose_logs[0])[0])
@@ -363,8 +355,8 @@ def test_service_span_that_is_independently_sampled(encoding):
 def test_zipkin_trace_with_no_sampling_no_firehose():
     mock_transport_handler, mock_logs = mock_logger()
     with zipkin.zipkin_span(
-        service_name='test_service_name',
-        span_name='test_span_name',
+        service_name="test_service_name",
+        span_name="test_span_name",
         transport_handler=mock_transport_handler,
         sample_rate=None,
     ):
@@ -378,8 +370,8 @@ def test_zipkin_trace_with_no_sampling_with_firehose():
     mock_transport_handler, mock_logs = mock_logger()
     mock_firehose_handler, mock_firehose_logs = mock_logger()
     with zipkin.zipkin_span(
-        service_name='test_service_name',
-        span_name='test_span_name',
+        service_name="test_service_name",
+        span_name="test_span_name",
         transport_handler=mock_transport_handler,
         sample_rate=None,
         firehose_handler=mock_firehose_handler,
@@ -391,8 +383,8 @@ def test_zipkin_trace_with_no_sampling_with_firehose():
     assert len(mock_firehose_logs) == 1
     firehose_span = json.loads(mock_firehose_logs[0])[0]
 
-    assert firehose_span['name'] == 'test_span_name'
-    assert firehose_span['localEndpoint']['serviceName'] == 'test_service_name'
+    assert firehose_span["name"] == "test_span_name"
+    assert firehose_span["localEndpoint"]["serviceName"] == "test_service_name"
 
 
 def test_no_sampling_with_inner_span():
@@ -400,16 +392,15 @@ def test_no_sampling_with_inner_span():
     mock_transport_handler, mock_logs = mock_logger()
     mock_firehose_handler, mock_firehose_logs = mock_logger()
     with zipkin.zipkin_span(
-        service_name='test_service_name',
-        span_name='test_span_name',
+        service_name="test_service_name",
+        span_name="test_span_name",
         transport_handler=mock_transport_handler,
         sample_rate=None,
         firehose_handler=mock_firehose_handler,
         encoding=Encoding.V2_JSON,
     ):
         with zipkin.zipkin_span(
-            service_name='nested_service',
-            span_name='nested_span',
+            service_name="nested_service", span_name="nested_span",
         ):
             pass
 
@@ -422,18 +413,18 @@ def test_no_sampling_with_inner_span():
 
     nested_span = firehose_spans[0]
     root_span = firehose_spans[1]
-    assert nested_span['name'] == 'nested_span'
-    assert nested_span['localEndpoint']['serviceName'] == 'nested_service'
-    assert nested_span['parentId'] == root_span['id']
+    assert nested_span["name"] == "nested_span"
+    assert nested_span["localEndpoint"]["serviceName"] == "nested_service"
+    assert nested_span["parentId"] == root_span["id"]
 
 
-@pytest.mark.parametrize('encoding', [Encoding.V1_JSON, Encoding.V2_JSON])
+@pytest.mark.parametrize("encoding", [Encoding.V1_JSON, Encoding.V2_JSON])
 def test_client_span(encoding):
     """Tests the zipkin_client_span helper."""
     mock_transport_handler, mock_logs = mock_logger()
     with zipkin.zipkin_client_span(
-        service_name='test_service_name',
-        span_name='test_span_name',
+        service_name="test_service_name",
+        span_name="test_span_name",
         transport_handler=mock_transport_handler,
         sample_rate=100.0,
         encoding=encoding,
@@ -443,27 +434,25 @@ def test_client_span(encoding):
     assert len(mock_logs) == 1
     span = json.loads(mock_logs[0])[0]
 
-    assert span['name'] == 'test_span_name'
+    assert span["name"] == "test_span_name"
     if encoding == Encoding.V1_JSON:
-        assert sorted([ann['value'] for ann in span['annotations']]) == \
-            ['cr', 'cs']
+        assert sorted([ann["value"] for ann in span["annotations"]]) == ["cr", "cs"]
     elif encoding == Encoding.V2_JSON:
-        assert span['kind'] == 'CLIENT'
+        assert span["kind"] == "CLIENT"
 
 
-@pytest.mark.parametrize('encoding', [Encoding.V1_JSON, Encoding.V2_JSON])
+@pytest.mark.parametrize("encoding", [Encoding.V1_JSON, Encoding.V2_JSON])
 def test_server_span(encoding):
     mock_transport_handler, mock_logs = mock_logger()
     with zipkin.zipkin_server_span(
-        service_name='test_service_name',
-        span_name='test_span_name',
+        service_name="test_service_name",
+        span_name="test_span_name",
         transport_handler=mock_transport_handler,
         sample_rate=100.0,
         encoding=encoding,
     ):
         with zipkin.zipkin_client_span(
-            service_name='nested_service',
-            span_name='nested_span',
+            service_name="nested_service", span_name="nested_span",
         ):
             pass
 
@@ -474,55 +463,55 @@ def test_server_span(encoding):
     client_span = spans[0]
     server_span = spans[1]
 
-    assert server_span['name'] == 'test_span_name'
+    assert server_span["name"] == "test_span_name"
     # Local nested spans report timestamp and duration
-    assert 'timestamp' in server_span
-    assert 'duration' in server_span
+    assert "timestamp" in server_span
+    assert "duration" in server_span
     if encoding == Encoding.V1_JSON:
-        assert len(server_span['annotations']) == 2
-        assert sorted([ann['value'] for ann in server_span['annotations']]) == [
-            'sr', 'ss']
+        assert len(server_span["annotations"]) == 2
+        assert sorted([ann["value"] for ann in server_span["annotations"]]) == [
+            "sr",
+            "ss",
+        ]
     elif encoding == Encoding.V2_JSON:
-        assert server_span['kind'] == 'SERVER'
+        assert server_span["kind"] == "SERVER"
 
-    assert client_span['name'] == 'nested_span'
+    assert client_span["name"] == "nested_span"
     # Local nested spans report timestamp and duration
-    assert 'timestamp' in client_span
-    assert 'duration' in client_span
+    assert "timestamp" in client_span
+    assert "duration" in client_span
     if encoding == Encoding.V1_JSON:
-        assert len(client_span['annotations']) == 2
-        assert sorted([ann['value'] for ann in client_span['annotations']]) == [
-            'cr', 'cs']
+        assert len(client_span["annotations"]) == 2
+        assert sorted([ann["value"] for ann in client_span["annotations"]]) == [
+            "cr",
+            "cs",
+        ]
     elif encoding == Encoding.V2_JSON:
-        assert client_span['kind'] == 'CLIENT'
+        assert client_span["kind"] == "CLIENT"
 
 
-@pytest.mark.parametrize('encoding', [Encoding.V1_JSON, Encoding.V2_JSON])
+@pytest.mark.parametrize("encoding", [Encoding.V1_JSON, Encoding.V2_JSON])
 def test_include_still_works(encoding):
     mock_transport_handler, mock_logs = mock_logger()
     with zipkin.zipkin_span(
-        service_name='test_service_name',
-        span_name='test_span_name',
+        service_name="test_service_name",
+        span_name="test_span_name",
         transport_handler=mock_transport_handler,
         sample_rate=100.0,
         encoding=encoding,
     ):
         with zipkin.zipkin_span(
-            service_name='nested_service',
-            span_name='nested_span',
-            include={'client'},
+            service_name="nested_service", span_name="nested_span", include={"client"},
         ):
             pass
         with zipkin.zipkin_span(
-            service_name='nested_service',
-            span_name='nested_span',
-            include={'server'},
+            service_name="nested_service", span_name="nested_span", include={"server"},
         ):
             pass
         with zipkin.zipkin_span(
-            service_name='nested_service',
-            span_name='nested_span',
-            include={'client', 'server'},
+            service_name="nested_service",
+            span_name="nested_span",
+            include={"client", "server"},
         ):
             pass
         pass
@@ -534,51 +523,57 @@ def test_include_still_works(encoding):
     server_span = spans[1]
     local_span = spans[2]
     if encoding == Encoding.V1_JSON:
-        assert len(client_span['annotations']) == 2
-        assert sorted([ann['value'] for ann in client_span['annotations']]) == [
-            'cr', 'cs']
-        assert len(server_span['annotations']) == 2
-        assert sorted([ann['value'] for ann in server_span['annotations']]) == [
-            'sr', 'ss']
-        assert len(local_span['annotations']) == 4
-        assert sorted([ann['value'] for ann in local_span['annotations']]) == [
-            'cr', 'cs', 'sr', 'ss']
+        assert len(client_span["annotations"]) == 2
+        assert sorted([ann["value"] for ann in client_span["annotations"]]) == [
+            "cr",
+            "cs",
+        ]
+        assert len(server_span["annotations"]) == 2
+        assert sorted([ann["value"] for ann in server_span["annotations"]]) == [
+            "sr",
+            "ss",
+        ]
+        assert len(local_span["annotations"]) == 4
+        assert sorted([ann["value"] for ann in local_span["annotations"]]) == [
+            "cr",
+            "cs",
+            "sr",
+            "ss",
+        ]
     elif encoding == Encoding.V2_JSON:
-        assert client_span['kind'] == 'CLIENT'
-        assert server_span['kind'] == 'SERVER'
-        assert 'kind' not in local_span
+        assert client_span["kind"] == "CLIENT"
+        assert server_span["kind"] == "SERVER"
+        assert "kind" not in local_span
 
 
-@pytest.mark.parametrize('encoding', [Encoding.V1_JSON, Encoding.V2_JSON])
+@pytest.mark.parametrize("encoding", [Encoding.V1_JSON, Encoding.V2_JSON])
 def test_can_set_sa_annotation(encoding):
     mock_transport_handler, mock_logs = mock_logger()
     with zipkin.zipkin_client_span(
-        service_name='test_service_name',
-        span_name='test_span_name',
+        service_name="test_service_name",
+        span_name="test_span_name",
         transport_handler=mock_transport_handler,
         sample_rate=100.0,
         encoding=encoding,
     ) as span:
         span.add_sa_binary_annotation(
-            port=8888,
-            service_name='sa_service',
-            host='10.0.0.0',
+            port=8888, service_name="sa_service", host="10.0.0.0",
         )
 
     assert len(mock_logs) == 1
     client_span = json.loads(mock_logs[0])[0]
 
     if encoding == Encoding.V1_JSON:
-        assert client_span['binaryAnnotations'][0]['key'] == 'sa'
-        assert client_span['binaryAnnotations'][0]['value'] is True
-        host = client_span['binaryAnnotations'][0]['endpoint']
+        assert client_span["binaryAnnotations"][0]["key"] == "sa"
+        assert client_span["binaryAnnotations"][0]["value"] is True
+        host = client_span["binaryAnnotations"][0]["endpoint"]
     elif encoding == Encoding.V2_JSON:
-        host = client_span['remoteEndpoint']
+        host = client_span["remoteEndpoint"]
 
-    assert host['serviceName'] == u'sa_service'
-    assert host['ipv4'] == '10.0.0.0'
-    assert 'ipv6' not in host
-    assert host['port'] == 8888
+    assert host["serviceName"] == u"sa_service"
+    assert host["ipv4"] == "10.0.0.0"
+    assert "ipv6" not in host
+    assert host["port"] == 8888
 
 
 def test_memory_leak():
@@ -588,15 +583,14 @@ def test_memory_leak():
     assert len(get_default_tracer().get_spans()) == 0
     for _ in range(10):
         with zipkin.zipkin_client_span(
-            service_name='test_service_name',
-            span_name='test_span_name',
+            service_name="test_service_name",
+            span_name="test_span_name",
             transport_handler=mock_transport_handler,
             sample_rate=0.0,
             encoding=Encoding.V2_JSON,
         ):
             with zipkin.zipkin_span(
-                service_name='inner_service_name',
-                span_name='inner_span_name',
+                service_name="inner_service_name", span_name="inner_span_name",
             ):
                 pass
 

--- a/tests/logging_helper_test.py
+++ b/tests/logging_helper_test.py
@@ -17,15 +17,10 @@ from tests.test_helpers import MockTransportHandler
 
 @pytest.fixture
 def fake_endpoint():
-    return Endpoint(
-        service_name='test_server',
-        ipv4='127.0.0.1',
-        ipv6=None,
-        port=80,
-    )
+    return Endpoint(service_name="test_server", ipv4="127.0.0.1", ipv6=None, port=80)
 
 
-@mock.patch('py_zipkin.logging_helper.time.time', autospec=True)
+@mock.patch("py_zipkin.logging_helper.time.time", autospec=True)
 def test_zipkin_logging_context(time_mock):
     # Tests the context manager aspects of the ZipkinLoggingContext
     time_mock.return_value = 42
@@ -33,16 +28,16 @@ def test_zipkin_logging_context(time_mock):
     tracer = MockTracer()
     context = logging_helper.ZipkinLoggingContext(
         zipkin_attrs=attr,
-        endpoint=create_endpoint(80, 'test_server', '127.0.0.1'),
-        span_name='span_name',
+        endpoint=create_endpoint(80, "test_server", "127.0.0.1"),
+        span_name="span_name",
         transport_handler=MockTransportHandler(),
         report_root_timestamp=False,
         get_tracer=lambda: tracer,
-        service_name='test_server',
+        service_name="test_server",
         encoding=Encoding.V1_JSON,
     )
     # Ignore the actual logging part
-    with mock.patch.object(context, 'emit_spans'):
+    with mock.patch.object(context, "emit_spans"):
         context.start()
         assert context.start_timestamp == 42
         context.stop()
@@ -50,21 +45,19 @@ def test_zipkin_logging_context(time_mock):
         assert context.emit_spans.call_count == 1
 
 
-@mock.patch('py_zipkin.logging_helper.time.time', autospec=True)
-@mock.patch('py_zipkin.logging_helper.ZipkinBatchSender.flush',
-            autospec=True)
-@mock.patch('py_zipkin.logging_helper.ZipkinBatchSender.add_span',
-            autospec=True)
+@mock.patch("py_zipkin.logging_helper.time.time", autospec=True)
+@mock.patch("py_zipkin.logging_helper.ZipkinBatchSender.flush", autospec=True)
+@mock.patch("py_zipkin.logging_helper.ZipkinBatchSender.add_span", autospec=True)
 def test_zipkin_logging_server_context_emit_spans(
     add_span_mock, flush_mock, time_mock, fake_endpoint
 ):
     # This lengthy function tests that the logging context properly
     # logs both client and server spans.
-    trace_id = '000000000000000f'
-    parent_span_id = '0000000000000001'
-    server_span_id = '0000000000000002'
-    client_span_id = '0000000000000003'
-    client_span_name = 'breadcrumbs'
+    trace_id = "000000000000000f"
+    parent_span_id = "0000000000000001"
+    server_span_id = "0000000000000002"
+    client_span_id = "0000000000000003"
+    client_span_name = "breadcrumbs"
     attr = ZipkinAttrs(
         trace_id=trace_id,
         span_id=server_span_id,
@@ -82,11 +75,9 @@ def test_zipkin_logging_server_context_emit_spans(
         kind=Kind.CLIENT,
         timestamp=26.0,
         duration=4.0,
-        local_endpoint=create_endpoint(
-            service_name='test_server',
-        ),
-        annotations={'ann2': 2, 'cs': 26, 'cr': 30},
-        tags={'bann2': 'yiss'},
+        local_endpoint=create_endpoint(service_name="test_server"),
+        annotations={"ann2": 2, "cs": 26, "cr": 30},
+        tags={"bann2": "yiss"},
     )
     tracer.get_spans().append(client_span)
 
@@ -95,54 +86,55 @@ def test_zipkin_logging_server_context_emit_spans(
     context = logging_helper.ZipkinLoggingContext(
         zipkin_attrs=attr,
         endpoint=fake_endpoint,
-        span_name='GET /foo',
+        span_name="GET /foo",
         transport_handler=transport_handler,
         report_root_timestamp=True,
         get_tracer=lambda: tracer,
-        service_name='test_server',
+        service_name="test_server",
         encoding=Encoding.V1_JSON,
     )
 
     context.start_timestamp = 24
     context.response_status_code = 200
 
-    context.tags = {'k': 'v'}
+    context.tags = {"k": "v"}
     time_mock.return_value = 42
 
     context.emit_spans()
     client_log_call, server_log_call = add_span_mock.call_args_list
-    assert server_log_call[0][1].build_v1_span() == Span(
-        trace_id=trace_id,
-        name='GET /foo',
-        parent_id=parent_span_id,
-        span_id=server_span_id,
-        kind=Kind.SERVER,
-        timestamp=24.0,
-        duration=18.0,
-        local_endpoint=fake_endpoint,
-        annotations={'sr': 24, 'ss': 42},
-        tags={'k': 'v'},
-    ).build_v1_span()
+    assert (
+        server_log_call[0][1].build_v1_span()
+        == Span(
+            trace_id=trace_id,
+            name="GET /foo",
+            parent_id=parent_span_id,
+            span_id=server_span_id,
+            kind=Kind.SERVER,
+            timestamp=24.0,
+            duration=18.0,
+            local_endpoint=fake_endpoint,
+            annotations={"sr": 24, "ss": 42},
+            tags={"k": "v"},
+        ).build_v1_span()
+    )
     assert client_log_call[0][1] == client_span
     assert flush_mock.call_count == 1
 
 
-@mock.patch('py_zipkin.logging_helper.time.time', autospec=True)
-@mock.patch('py_zipkin.logging_helper.ZipkinBatchSender.flush',
-            autospec=True)
-@mock.patch('py_zipkin.logging_helper.ZipkinBatchSender.add_span',
-            autospec=True)
+@mock.patch("py_zipkin.logging_helper.time.time", autospec=True)
+@mock.patch("py_zipkin.logging_helper.ZipkinBatchSender.flush", autospec=True)
+@mock.patch("py_zipkin.logging_helper.ZipkinBatchSender.add_span", autospec=True)
 def test_zipkin_logging_server_context_emit_spans_with_firehose(
     add_span_mock, flush_mock, time_mock, fake_endpoint
 ):
     # This lengthy function tests that the logging context properly
     # logs both client and server spans.
-    trace_id = '000000000000000f'
-    parent_span_id = '0000000000000001'
-    server_span_id = '0000000000000002'
-    client_span_id = '0000000000000003'
-    client_span_name = 'breadcrumbs'
-    client_svc_name = 'svc'
+    trace_id = "000000000000000f"
+    parent_span_id = "0000000000000001"
+    server_span_id = "0000000000000002"
+    client_span_id = "0000000000000003"
+    client_span_name = "breadcrumbs"
+    client_svc_name = "svc"
     attr = ZipkinAttrs(
         trace_id=trace_id,
         span_id=server_span_id,
@@ -162,8 +154,8 @@ def test_zipkin_logging_server_context_emit_spans_with_firehose(
         timestamp=26.0,
         duration=4.0,
         local_endpoint=create_endpoint(service_name=client_svc_name),
-        annotations={'ann2': 2, 'cs': 26, 'cr': 30},
-        tags={'bann2': 'yiss'},
+        annotations={"ann2": 2, "cs": 26, "cr": 30},
+        tags={"bann2": "yiss"},
     )
     tracer.get_spans().append(client_span)
 
@@ -173,55 +165,58 @@ def test_zipkin_logging_server_context_emit_spans_with_firehose(
     context = logging_helper.ZipkinLoggingContext(
         zipkin_attrs=attr,
         endpoint=fake_endpoint,
-        span_name='GET /foo',
+        span_name="GET /foo",
         transport_handler=transport_handler,
         report_root_timestamp=True,
         get_tracer=lambda: tracer,
         firehose_handler=firehose_handler,
-        service_name='test_server',
+        service_name="test_server",
         encoding=Encoding.V1_JSON,
     )
 
     context.start_timestamp = 24
     context.response_status_code = 200
 
-    context.tags = {'k': 'v'}
+    context.tags = {"k": "v"}
     time_mock.return_value = 42
 
     context.emit_spans()
     call_args = add_span_mock.call_args_list
     firehose_client_log_call, client_log_call = call_args[0], call_args[2]
     firehose_server_log_call, server_log_call = call_args[1], call_args[3]
-    assert server_log_call[0][1].build_v1_span() == \
-        firehose_server_log_call[0][1].build_v1_span()
-    assert server_log_call[0][1].build_v1_span() == Span(
-        trace_id=trace_id,
-        name='GET /foo',
-        parent_id=parent_span_id,
-        span_id=server_span_id,
-        kind=Kind.SERVER,
-        timestamp=24.0,
-        duration=18.0,
-        local_endpoint=fake_endpoint,
-        annotations={'sr': 24, 'ss': 42},
-        tags={'k': 'v'},
-    ).build_v1_span()
+    assert (
+        server_log_call[0][1].build_v1_span()
+        == firehose_server_log_call[0][1].build_v1_span()
+    )
+    assert (
+        server_log_call[0][1].build_v1_span()
+        == Span(
+            trace_id=trace_id,
+            name="GET /foo",
+            parent_id=parent_span_id,
+            span_id=server_span_id,
+            kind=Kind.SERVER,
+            timestamp=24.0,
+            duration=18.0,
+            local_endpoint=fake_endpoint,
+            annotations={"sr": 24, "ss": 42},
+            tags={"k": "v"},
+        ).build_v1_span()
+    )
     assert client_log_call[0][1] == firehose_client_log_call[0][1] == client_span
     assert flush_mock.call_count == 2
 
 
-@mock.patch('py_zipkin.logging_helper.time.time', autospec=True)
-@mock.patch('py_zipkin.logging_helper.ZipkinBatchSender.flush',
-            autospec=True)
-@mock.patch('py_zipkin.logging_helper.ZipkinBatchSender.add_span',
-            autospec=True)
+@mock.patch("py_zipkin.logging_helper.time.time", autospec=True)
+@mock.patch("py_zipkin.logging_helper.ZipkinBatchSender.flush", autospec=True)
+@mock.patch("py_zipkin.logging_helper.ZipkinBatchSender.add_span", autospec=True)
 def test_zipkin_logging_client_context_emit_spans(
     add_span_mock, flush_mock, time_mock, fake_endpoint
 ):
     # This lengthy function tests that the logging context properly
     # logs root client span
-    trace_id = '000000000000000f'
-    client_span_id = '0000000000000003'
+    trace_id = "000000000000000f"
+    client_span_id = "0000000000000003"
     attr = ZipkinAttrs(
         trace_id=trace_id,
         span_id=client_span_id,
@@ -236,47 +231,47 @@ def test_zipkin_logging_client_context_emit_spans(
     context = logging_helper.ZipkinLoggingContext(
         zipkin_attrs=attr,
         endpoint=fake_endpoint,
-        span_name='GET /foo',
+        span_name="GET /foo",
         transport_handler=transport_handler,
         report_root_timestamp=True,
         get_tracer=lambda: tracer,
         client_context=True,
-        service_name='test_server',
+        service_name="test_server",
         encoding=Encoding.V1_JSON,
     )
 
     context.start_timestamp = 24
     context.response_status_code = 200
 
-    context.tags = {'k': 'v'}
+    context.tags = {"k": "v"}
     time_mock.return_value = 42
 
     context.emit_spans()
     log_call = add_span_mock.call_args_list[0]
-    assert log_call[0][1].build_v1_span() == Span(
-        trace_id=trace_id,
-        name='GET /foo',
-        parent_id=None,
-        span_id=client_span_id,
-        kind=Kind.CLIENT,
-        timestamp=24.0,
-        duration=18.0,
-        local_endpoint=fake_endpoint,
-        annotations={'cs': 24, 'cr': 42},
-        tags={'k': 'v'},
-    ).build_v1_span()
+    assert (
+        log_call[0][1].build_v1_span()
+        == Span(
+            trace_id=trace_id,
+            name="GET /foo",
+            parent_id=None,
+            span_id=client_span_id,
+            kind=Kind.CLIENT,
+            timestamp=24.0,
+            duration=18.0,
+            local_endpoint=fake_endpoint,
+            annotations={"cs": 24, "cr": 42},
+            tags={"k": "v"},
+        ).build_v1_span()
+    )
     assert flush_mock.call_count == 1
 
 
-@mock.patch('py_zipkin.logging_helper.ZipkinBatchSender.flush',
-            autospec=True)
-@mock.patch('py_zipkin.logging_helper.ZipkinBatchSender.add_span',
-            autospec=True)
-def test_batch_sender_add_span_not_called_if_not_sampled(add_span_mock,
-                                                         flush_mock):
+@mock.patch("py_zipkin.logging_helper.ZipkinBatchSender.flush", autospec=True)
+@mock.patch("py_zipkin.logging_helper.ZipkinBatchSender.add_span", autospec=True)
+def test_batch_sender_add_span_not_called_if_not_sampled(add_span_mock, flush_mock):
     attr = ZipkinAttrs(
-        trace_id='0000000000000001',
-        span_id='0000000000000002',
+        trace_id="0000000000000001",
+        span_id="0000000000000002",
         parent_span_id=None,
         flags=None,
         is_sampled=False,
@@ -286,12 +281,12 @@ def test_batch_sender_add_span_not_called_if_not_sampled(add_span_mock,
 
     context = logging_helper.ZipkinLoggingContext(
         zipkin_attrs=attr,
-        endpoint=create_endpoint(80, 'test_server', '127.0.0.1'),
-        span_name='span_name',
+        endpoint=create_endpoint(80, "test_server", "127.0.0.1"),
+        span_name="span_name",
         transport_handler=transport_handler,
         report_root_timestamp=False,
         get_tracer=lambda: tracer,
-        service_name='test_server',
+        service_name="test_server",
         encoding=Encoding.V1_JSON,
     )
     context.emit_spans()
@@ -299,17 +294,15 @@ def test_batch_sender_add_span_not_called_if_not_sampled(add_span_mock,
     assert flush_mock.call_count == 0
 
 
-@mock.patch('py_zipkin.logging_helper.time.time', autospec=True)
-@mock.patch('py_zipkin.logging_helper.ZipkinBatchSender.flush',
-            autospec=True)
-@mock.patch('py_zipkin.logging_helper.ZipkinBatchSender.add_span',
-            autospec=True)
-def test_batch_sender_add_span_not_sampled_with_firehose(add_span_mock,
-                                                         flush_mock,
-                                                         time_mock):
+@mock.patch("py_zipkin.logging_helper.time.time", autospec=True)
+@mock.patch("py_zipkin.logging_helper.ZipkinBatchSender.flush", autospec=True)
+@mock.patch("py_zipkin.logging_helper.ZipkinBatchSender.add_span", autospec=True)
+def test_batch_sender_add_span_not_sampled_with_firehose(
+    add_span_mock, flush_mock, time_mock
+):
     attr = ZipkinAttrs(
-        trace_id='0000000000000001',
-        span_id='0000000000000002',
+        trace_id="0000000000000001",
+        span_id="0000000000000002",
         parent_span_id=None,
         flags=None,
         is_sampled=False,
@@ -320,19 +313,19 @@ def test_batch_sender_add_span_not_sampled_with_firehose(add_span_mock,
 
     context = logging_helper.ZipkinLoggingContext(
         zipkin_attrs=attr,
-        endpoint=create_endpoint(80, 'test_server', '127.0.0.1'),
-        span_name='span_name',
+        endpoint=create_endpoint(80, "test_server", "127.0.0.1"),
+        span_name="span_name",
         transport_handler=transport_handler,
         report_root_timestamp=False,
         get_tracer=lambda: tracer,
         firehose_handler=firehose_handler,
-        service_name='test_server',
+        service_name="test_server",
         encoding=Encoding.V1_JSON,
     )
     context.start_timestamp = 24
     context.response_status_code = 200
 
-    context.tags = {'k': 'v'}
+    context.tags = {"k": "v"}
     time_mock.return_value = 42
 
     context.emit_spans()
@@ -344,37 +337,37 @@ def test_batch_sender_add_span(fake_endpoint):
     # This test verifies it's possible to add 1 span without throwing errors.
     # It also checks that exiting the ZipkinBatchSender context manager
     # triggers a flush of all the already added spans.
-    encoder = MockEncoder(encoded_queue='foobar')
+    encoder = MockEncoder(encoded_queue="foobar")
     sender = logging_helper.ZipkinBatchSender(
         transport_handler=MockTransportHandler(),
         max_portion_size=None,
         encoder=encoder,
     )
     with sender:
-        sender.add_span(Span(
-            trace_id='000000000000000f',
-            name='span',
-            parent_id='0000000000000001',
-            span_id='0000000000000002',
-            kind=Kind.CLIENT,
-            timestamp=26.0,
-            duration=4.0,
-            local_endpoint=fake_endpoint,
-            annotations={},
-            tags={},
-        ))
+        sender.add_span(
+            Span(
+                trace_id="000000000000000f",
+                name="span",
+                parent_id="0000000000000001",
+                span_id="0000000000000002",
+                kind=Kind.CLIENT,
+                timestamp=26.0,
+                duration=4.0,
+                local_endpoint=fake_endpoint,
+                annotations={},
+                tags={},
+            )
+        )
     assert encoder.encode_queue.call_count == 1
 
 
 def test_batch_sender_with_error_on_exit():
     sender = logging_helper.ZipkinBatchSender(
-        MockTransportHandler(),
-        None,
-        MockEncoder(),
+        MockTransportHandler(), None, MockEncoder(),
     )
     with pytest.raises(ZipkinError):
         with sender:
-            raise Exception('Error!')
+            raise Exception("Error!")
 
 
 def test_batch_sender_add_span_many_times(fake_endpoint):
@@ -389,18 +382,20 @@ def test_batch_sender_add_span_many_times(fake_endpoint):
     max_portion_size = logging_helper.ZipkinBatchSender.MAX_PORTION_SIZE
     with sender:
         for _ in range(max_portion_size * 2 + 1):
-            sender.add_span(Span(
-                trace_id='000000000000000f',
-                name='span',
-                parent_id='0000000000000001',
-                span_id='0000000000000002',
-                kind=Kind.CLIENT,
-                timestamp=26.0,
-                duration=4.0,
-                local_endpoint=fake_endpoint,
-                annotations={},
-                tags={},
-            ))
+            sender.add_span(
+                Span(
+                    trace_id="000000000000000f",
+                    name="span",
+                    parent_id="0000000000000001",
+                    span_id="0000000000000002",
+                    kind=Kind.CLIENT,
+                    timestamp=26.0,
+                    duration=4.0,
+                    local_endpoint=fake_endpoint,
+                    annotations={},
+                    tags={},
+                )
+            )
 
     assert encoder.encode_queue.call_count == 3
     assert len(encoder.encode_queue.call_args_list[0][0][0]) == max_portion_size
@@ -414,24 +409,24 @@ def test_batch_sender_add_span_too_big(fake_endpoint):
     mock_transport_handler = mock.Mock(spec=MockTransportHandler)
     mock_transport_handler.get_max_payload_bytes = lambda: 1000
     sender = logging_helper.ZipkinBatchSender(
-        mock_transport_handler,
-        100,
-        get_encoder(Encoding.V1_THRIFT),
+        mock_transport_handler, 100, get_encoder(Encoding.V1_THRIFT),
     )
     with sender:
         for _ in range(201):
-            sender.add_span(Span(
-                trace_id='000000000000000f',
-                name='span',
-                parent_id='0000000000000001',
-                span_id='0000000000000002',
-                kind=Kind.CLIENT,
-                timestamp=26.0,
-                duration=4.0,
-                local_endpoint=fake_endpoint,
-                annotations={},
-                tags={},
-            ))
+            sender.add_span(
+                Span(
+                    trace_id="000000000000000f",
+                    name="span",
+                    parent_id="0000000000000001",
+                    span_id="0000000000000002",
+                    kind=Kind.CLIENT,
+                    timestamp=26.0,
+                    duration=4.0,
+                    local_endpoint=fake_endpoint,
+                    annotations={},
+                    tags={},
+                )
+            )
 
     # 5 spans per batch, means we need 201 / 4 = 41 batches to send them all.
     assert mock_transport_handler.call_count == 41
@@ -444,33 +439,31 @@ def test_batch_sender_add_span_too_big(fake_endpoint):
     assert len(mock_transport_handler.call_args_list[40][0][0]) == 202
 
 
-def test_batch_sender_flush_calls_transport_handler_with_correct_params(
-    fake_endpoint,
-):
+def test_batch_sender_flush_calls_transport_handler_with_correct_params(fake_endpoint):
     # Tests that the transport handler is called with the value returned
     # by encoder.encode_queue.
     transport_handler = mock.Mock()
     transport_handler.get_max_payload_bytes = lambda: None
-    encoder = MockEncoder(encoded_queue='foobar')
+    encoder = MockEncoder(encoded_queue="foobar")
     sender = logging_helper.ZipkinBatchSender(
-        transport_handler=transport_handler,
-        max_portion_size=None,
-        encoder=encoder,
+        transport_handler=transport_handler, max_portion_size=None, encoder=encoder,
     )
     with sender:
-        sender.add_span(Span(
-            trace_id='000000000000000f',
-            name='span',
-            parent_id='0000000000000001',
-            span_id='0000000000000002',
-            kind=Kind.CLIENT,
-            timestamp=26.0,
-            duration=4.0,
-            local_endpoint=fake_endpoint,
-            annotations={},
-            tags={},
-        ))
-    transport_handler.assert_called_once_with('foobar')
+        sender.add_span(
+            Span(
+                trace_id="000000000000000f",
+                name="span",
+                parent_id="0000000000000001",
+                span_id="0000000000000002",
+                kind=Kind.CLIENT,
+                timestamp=26.0,
+                duration=4.0,
+                local_endpoint=fake_endpoint,
+                annotations={},
+                tags={},
+            )
+        )
+    transport_handler.assert_called_once_with("foobar")
 
 
 def test_batch_sender_defensive_about_transport_handler(fake_endpoint):
@@ -478,22 +471,22 @@ def test_batch_sender_defensive_about_transport_handler(fake_endpoint):
     None."""
     encoder = MockEncoder()
     sender = logging_helper.ZipkinBatchSender(
-        transport_handler=None,
-        max_portion_size=None,
-        encoder=encoder,
+        transport_handler=None, max_portion_size=None, encoder=encoder,
     )
     with sender:
-        sender.add_span(Span(
-            trace_id='000000000000000f',
-            name='span',
-            parent_id='0000000000000001',
-            span_id='0000000000000002',
-            kind=Kind.CLIENT,
-            timestamp=26.0,
-            duration=4.0,
-            local_endpoint=fake_endpoint,
-            annotations={},
-            tags={},
-        ))
+        sender.add_span(
+            Span(
+                trace_id="000000000000000f",
+                name="span",
+                parent_id="0000000000000001",
+                span_id="0000000000000002",
+                kind=Kind.CLIENT,
+                timestamp=26.0,
+                duration=4.0,
+                local_endpoint=fake_endpoint,
+                annotations={},
+                tags={},
+            )
+        )
     assert encoder.encode_span.call_count == 1
     assert encoder.encode_queue.call_count == 0

--- a/tests/stack_test.py
+++ b/tests/stack_test.py
@@ -4,7 +4,7 @@ import pytest
 import py_zipkin.storage
 
 
-@pytest.fixture(autouse=True, scope='module')
+@pytest.fixture(autouse=True, scope="module")
 def create_zipkin_attrs():
     # The following tests all expect _thread_local.zipkin_attrs to exist: if it
     # doesn't, mock.patch will fail.
@@ -13,13 +13,13 @@ def create_zipkin_attrs():
 
 def test_get_zipkin_attrs_returns_none_if_no_zipkin_attrs():
     tracer = py_zipkin.storage.get_default_tracer()
-    with mock.patch.object(tracer._context_stack, '_storage', []):
+    with mock.patch.object(tracer._context_stack, "_storage", []):
         assert not py_zipkin.storage.ThreadLocalStack().get()
         assert not py_zipkin.storage.ThreadLocalStack().get()
 
 
 def test_get_zipkin_attrs_with_context_returns_none_if_no_zipkin_attrs():
-    with mock.patch.object(py_zipkin.storage.log, 'warning', autospec=True) as log:
+    with mock.patch.object(py_zipkin.storage.log, "warning", autospec=True) as log:
         assert not py_zipkin.storage.Stack([]).get()
         assert log.call_count == 1
 
@@ -31,17 +31,17 @@ def test_storage_stack_still_works_if_you_dont_pass_in_storage():
 
 def test_get_zipkin_attrs_returns_the_last_of_the_list():
     tracer = py_zipkin.storage.get_default_tracer()
-    with mock.patch.object(tracer._context_stack, '_storage', ['foo']):
-        assert 'foo' == py_zipkin.storage.ThreadLocalStack().get()
+    with mock.patch.object(tracer._context_stack, "_storage", ["foo"]):
+        assert "foo" == py_zipkin.storage.ThreadLocalStack().get()
 
 
 def test_get_zipkin_attrs_with_context_returns_the_last_of_the_list():
-    assert 'foo' == py_zipkin.storage.Stack(['bar', 'foo']).get()
+    assert "foo" == py_zipkin.storage.Stack(["bar", "foo"]).get()
 
 
 def test_pop_zipkin_attrs_does_nothing_if_no_requests():
     tracer = py_zipkin.storage.get_default_tracer()
-    with mock.patch.object(tracer._context_stack, '_storage', []):
+    with mock.patch.object(tracer._context_stack, "_storage", []):
         assert not py_zipkin.storage.ThreadLocalStack().pop()
 
 
@@ -51,27 +51,27 @@ def test_pop_zipkin_attrs_with_context_does_nothing_if_no_requests():
 
 def test_pop_zipkin_attrs_removes_the_last_zipkin_attrs():
     tracer = py_zipkin.storage.get_default_tracer()
-    with mock.patch.object(tracer._context_stack, '_storage', ['foo', 'bar']):
-        assert 'bar' == py_zipkin.storage.ThreadLocalStack().pop()
-        assert 'foo' == py_zipkin.storage.ThreadLocalStack().get()
+    with mock.patch.object(tracer._context_stack, "_storage", ["foo", "bar"]):
+        assert "bar" == py_zipkin.storage.ThreadLocalStack().pop()
+        assert "foo" == py_zipkin.storage.ThreadLocalStack().get()
 
 
 def test_pop_zipkin_attrs_with_context_removes_the_last_zipkin_attrs():
-    context_stack = py_zipkin.storage.Stack(['foo', 'bar'])
-    assert 'bar' == context_stack.pop()
-    assert 'foo' == context_stack.get()
+    context_stack = py_zipkin.storage.Stack(["foo", "bar"])
+    assert "bar" == context_stack.pop()
+    assert "foo" == context_stack.get()
 
 
 def test_push_zipkin_attrs_adds_new_zipkin_attrs_to_list():
     tracer = py_zipkin.storage.get_default_tracer()
-    with mock.patch.object(tracer._context_stack, '_storage', ['foo']):
-        assert 'foo' == py_zipkin.storage.ThreadLocalStack().get()
-        py_zipkin.storage.ThreadLocalStack().push('bar')
-        assert 'bar' == py_zipkin.storage.ThreadLocalStack().get()
+    with mock.patch.object(tracer._context_stack, "_storage", ["foo"]):
+        assert "foo" == py_zipkin.storage.ThreadLocalStack().get()
+        py_zipkin.storage.ThreadLocalStack().push("bar")
+        assert "bar" == py_zipkin.storage.ThreadLocalStack().get()
 
 
 def test_push_zipkin_attrs_with_context_adds_new_zipkin_attrs_to_list():
-    stack = py_zipkin.storage.Stack(['foo'])
-    assert 'foo' == stack.get()
-    stack.push('bar')
-    assert 'bar' == stack.get()
+    stack = py_zipkin.storage.Stack(["foo"])
+    assert "foo" == stack.get()
+    stack.push("bar")
+    assert "bar" == stack.get()

--- a/tests/storage_test.py
+++ b/tests/storage_test.py
@@ -4,8 +4,8 @@ from py_zipkin import storage
 from tests.test_helpers import MockTracer
 
 
-@mock.patch.object(storage, '_thread_local_tracer')
-@mock.patch.object(storage, 'Tracer')
+@mock.patch.object(storage, "_thread_local_tracer")
+@mock.patch.object(storage, "Tracer")
 def test_get_thread_local_tracer_no_tracer(mock_tracer, mock_tl):
     del mock_tl.tracer
     tracer = storage._get_thread_local_tracer()
@@ -14,7 +14,7 @@ def test_get_thread_local_tracer_no_tracer(mock_tracer, mock_tl):
     assert tracer == mock_tracer.return_value
 
 
-@mock.patch.object(storage, '_thread_local_tracer')
+@mock.patch.object(storage, "_thread_local_tracer")
 def test_set_thread_local_tracer(mock_tl):
     tracer = MockTracer()
     storage._set_thread_local_tracer(tracer)
@@ -22,8 +22,8 @@ def test_set_thread_local_tracer(mock_tl):
     assert storage._get_thread_local_tracer() == tracer
 
 
-@mock.patch.object(storage, '_thread_local_tracer')
-@mock.patch.object(storage, 'Tracer')
+@mock.patch.object(storage, "_thread_local_tracer")
+@mock.patch.object(storage, "Tracer")
 def test_get_thread_local_tracer_existing_tracer(mock_tracer, mock_tl):
     tracer = storage._get_thread_local_tracer()
 
@@ -32,12 +32,12 @@ def test_get_thread_local_tracer_existing_tracer(mock_tracer, mock_tl):
 
 
 def test_default_span_storage_warns():
-    with mock.patch.object(storage.log, 'warning') as mock_log:
+    with mock.patch.object(storage.log, "warning") as mock_log:
         storage.default_span_storage()
         assert mock_log.call_count == 1
 
 
-@mock.patch.object(storage, '_contextvars_tracer')
+@mock.patch.object(storage, "_contextvars_tracer")
 def test_get_default_tracer(mock_contextvar):
     # We're in python 3.7+
     assert storage.get_default_tracer() == storage._contextvars_tracer.get()
@@ -45,11 +45,10 @@ def test_get_default_tracer(mock_contextvar):
     storage._contextvars_tracer = None
 
     # We're in python 2.7 to 3.6
-    assert storage.get_default_tracer() == \
-        storage._thread_local_tracer.tracer
+    assert storage.get_default_tracer() == storage._thread_local_tracer.tracer
 
 
-@mock.patch.object(storage, '_contextvars_tracer')
+@mock.patch.object(storage, "_contextvars_tracer")
 def test_set_default_tracer(mock_contextvar):
     tracer = MockTracer()
     # We're in python 3.7+

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -17,12 +17,9 @@ from py_zipkin.zipkin import ZipkinAttrs
 
 
 class MockEncoder(IEncoder):
-
-    def __init__(self, fits=True, encoded_span='', encoded_queue=''):
+    def __init__(self, fits=True, encoded_span="", encoded_queue=""):
         self.fits_bool = fits
-        self.encode_span = mock.Mock(
-            return_value=(encoded_span, len(encoded_span)),
-        )
+        self.encode_span = mock.Mock(return_value=(encoded_span, len(encoded_span)))
         self.encode_queue = mock.Mock(return_value=encoded_queue)
 
     def fits(self, current_count, current_size, max_size, new_span):
@@ -55,38 +52,34 @@ def generate_list_of_spans(encoding):
     # sometimes returns N and sometimes N+1. This ts value doesn't have that
     # issue afaict, probably since it ends in zeros.
     ts = 1538544126.115900
-    with mock.patch('time.time', autospec=True) as mock_time:
+    with mock.patch("time.time", autospec=True) as mock_time:
         # zipkin.py start, logging_helper.start, 3 x logging_helper.stop
         # I don't understand why logging_helper.stop would run 3 times, but
         # that's what I'm seeing in the test
         mock_time.side_effect = iter([ts, ts, ts + 10, ts + 10, ts + 10])
         with zipkin.zipkin_span(
-                service_name='test_service_name',
-                span_name='test_span_name',
-                transport_handler=transport_handler,
-                binary_annotations={'some_key': 'some_value'},
-                encoding=encoding,
-                zipkin_attrs=zipkin_attrs,
-                host='10.0.0.0',
-                port=8080,
-                kind=Kind.CLIENT,
+            service_name="test_service_name",
+            span_name="test_span_name",
+            transport_handler=transport_handler,
+            binary_annotations={"some_key": "some_value"},
+            encoding=encoding,
+            zipkin_attrs=zipkin_attrs,
+            host="10.0.0.0",
+            port=8080,
+            kind=Kind.CLIENT,
         ) as span:
             with mock.patch.object(
-                    zipkin,
-                    'generate_random_64bit_string',
-                    return_value=inner_span_id,
+                zipkin, "generate_random_64bit_string", return_value=inner_span_id,
             ):
                 with zipkin.zipkin_span(
-                        service_name='test_service_name',
-                        span_name='inner_span',
-                        timestamp=ts,
-                        duration=5,
-                        annotations={'ws': ts},
+                    service_name="test_service_name",
+                    span_name="inner_span",
+                    timestamp=ts,
+                    duration=5,
+                    annotations={"ws": ts},
                 ):
                     span.add_sa_binary_annotation(
-                        8888,
-                        'sa_service',
-                        '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+                        8888, "sa_service", "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
                     )
 
     return transport_handler.get_payloads()[0], zipkin_attrs, inner_span_id, ts
@@ -97,22 +90,17 @@ def generate_single_thrift_span():
     span_id = generate_random_64bit_string()
     timestamp_s = round(time.time(), 3)
     duration_s = 2.0
-    host = thrift.create_endpoint(port=8000, service_name='host')
+    host = thrift.create_endpoint(port=8000, service_name="host")
     host.ipv4 = 2130706433
     span = thrift.create_span(
         span_id=span_id,
         parent_span_id=None,
         trace_id=trace_id,
-        span_name='foo',
-        annotations=[
-            thrift.create_annotation(1472470996199000, "cs", host),
-        ],
+        span_name="foo",
+        annotations=[thrift.create_annotation(1472470996199000, "cs", host)],
         binary_annotations=[
             thrift.create_binary_annotation(
-                "key",
-                "value",
-                zipkin_core.AnnotationType.STRING,
-                host,
+                "key", "value", zipkin_core.AnnotationType.STRING, host,
             ),
         ],
         timestamp_s=timestamp_s,

--- a/tests/thread_local_test.py
+++ b/tests/thread_local_test.py
@@ -7,32 +7,32 @@ from py_zipkin.storage import SpanStorage
 
 def test_get_thread_local_zipkin_attrs_returns_back_zipkin_attrs_if_present():
     tracer = storage.get_default_tracer()
-    with mock.patch.object(tracer._context_stack, '_storage', ['foo']):
-        assert thread_local.get_thread_local_zipkin_attrs() == ['foo']
+    with mock.patch.object(tracer._context_stack, "_storage", ["foo"]):
+        assert thread_local.get_thread_local_zipkin_attrs() == ["foo"]
 
 
 def test_get_thread_local_span_storage_present():
     tracer = storage.get_default_tracer()
-    with mock.patch.object(tracer, '_span_storage', SpanStorage(['foo'])):
-        assert thread_local.get_thread_local_span_storage() == SpanStorage(['foo'])
+    with mock.patch.object(tracer, "_span_storage", SpanStorage(["foo"])):
+        assert thread_local.get_thread_local_span_storage() == SpanStorage(["foo"])
 
 
 def test_get_zipkin_attrs_returns_the_last_of_the_list():
     tracer = storage.get_default_tracer()
-    with mock.patch.object(tracer._context_stack, '_storage', ['foo']):
-        assert 'foo' == thread_local.get_zipkin_attrs()
+    with mock.patch.object(tracer._context_stack, "_storage", ["foo"]):
+        assert "foo" == thread_local.get_zipkin_attrs()
 
 
 def test_pop_zipkin_attrs_removes_the_last_zipkin_attrs():
     tracer = storage.get_default_tracer()
-    with mock.patch.object(tracer._context_stack, '_storage', ['foo', 'bar']):
-        assert 'bar' == thread_local.pop_zipkin_attrs()
-        assert 'foo' == thread_local.get_zipkin_attrs()
+    with mock.patch.object(tracer._context_stack, "_storage", ["foo", "bar"]):
+        assert "bar" == thread_local.pop_zipkin_attrs()
+        assert "foo" == thread_local.get_zipkin_attrs()
 
 
 def test_push_zipkin_attrs_adds_new_zipkin_attrs_to_list():
     tracer = storage.get_default_tracer()
-    with mock.patch.object(tracer._context_stack, '_storage', ['foo']):
-        assert 'foo' == thread_local.get_zipkin_attrs()
-        thread_local.push_zipkin_attrs('bar')
-        assert 'bar' == thread_local.get_zipkin_attrs()
+    with mock.patch.object(tracer._context_stack, "_storage", ["foo"]):
+        assert "foo" == thread_local.get_zipkin_attrs()
+        thread_local.push_zipkin_attrs("bar")
+        assert "bar" == thread_local.get_zipkin_attrs()

--- a/tests/thrift/thrift_test.py
+++ b/tests/thrift/thrift_test.py
@@ -9,21 +9,21 @@ def test_create_span():
     # Not much logic here so this is just a smoke test. The only
     # substantive thing is that hex IDs get converted to ints.
     span = thrift.create_span(
-        span_id='0000000000000001',
-        parent_span_id='0000000000000002',
-        trace_id='000000000000000f',
-        span_name='foo',
-        annotations='ann',
-        binary_annotations='binary_ann',
+        span_id="0000000000000001",
+        parent_span_id="0000000000000002",
+        trace_id="000000000000000f",
+        span_name="foo",
+        annotations="ann",
+        binary_annotations="binary_ann",
         timestamp_s=1485920381.2,
         duration_s=2.0,
     )
     assert span.id == 1
     assert span.parent_id == 2
     assert span.trace_id == 15
-    assert span.name == 'foo'
-    assert span.annotations == 'ann'
-    assert span.binary_annotations == 'binary_ann'
+    assert span.name == "foo"
+    assert span.annotations == "ann"
+    assert span.binary_annotations == "binary_ann"
     assert span.timestamp == 1485920381.2 * 1000000
     assert span.duration == 2.0 * 1000000
     assert span.trace_id_high is None
@@ -31,12 +31,12 @@ def test_create_span():
 
 def test_create_span_with_128_bit_trace_ids():
     span = thrift.create_span(
-        span_id='0000000000000001',
-        parent_span_id='0000000000000002',
-        trace_id='000000000000000f000000000000000e',
-        span_name='foo',
-        annotations='ann',
-        binary_annotations='binary_ann',
+        span_id="0000000000000001",
+        parent_span_id="0000000000000002",
+        trace_id="000000000000000f000000000000000e",
+        span_name="foo",
+        annotations="ann",
+        binary_annotations="binary_ann",
         timestamp_s=1485920381.2,
         duration_s=2.0,
     )
@@ -47,106 +47,99 @@ def test_create_span_with_128_bit_trace_ids():
 def test_create_span_fails_with_wrong_128_bit_trace_id_length():
     with pytest.raises(AssertionError):
         thrift.create_span(
-            span_id='0000000000000001',
-            parent_span_id='0000000000000002',
-            trace_id='000000000000000f000000000000000',
-            span_name='foo',
-            annotations='ann',
-            binary_annotations='binary_ann',
+            span_id="0000000000000001",
+            parent_span_id="0000000000000002",
+            trace_id="000000000000000f000000000000000",
+            span_name="foo",
+            annotations="ann",
+            binary_annotations="binary_ann",
             timestamp_s=1485920381.2,
             duration_s=2.0,
         )
 
     with pytest.raises(AssertionError):
         thrift.create_span(
-            span_id='0000000000000001',
-            parent_span_id='0000000000000002',
-            trace_id='000000000000000f000000000000000f0',
-            span_name='foo',
-            annotations='ann',
-            binary_annotations='binary_ann',
+            span_id="0000000000000001",
+            parent_span_id="0000000000000002",
+            trace_id="000000000000000f000000000000000f0",
+            span_name="foo",
+            annotations="ann",
+            binary_annotations="binary_ann",
             timestamp_s=1485920381.2,
             duration_s=2.0,
         )
 
 
-@mock.patch('socket.gethostbyname', autospec=True)
+@mock.patch("socket.gethostbyname", autospec=True)
 def test_create_endpoint_creates_correct_endpoint(gethostbyname):
-    gethostbyname.return_value = '0.0.0.0'
-    endpoint = thrift.create_endpoint(
-        port=8080,
-        service_name='foo',
-    )
-    assert endpoint.service_name == 'foo'
+    gethostbyname.return_value = "0.0.0.0"
+    endpoint = thrift.create_endpoint(port=8080, service_name="foo")
+    assert endpoint.service_name == "foo"
     assert endpoint.port == 8080
     # An IP address of 0.0.0.0 unpacks to just 0
     assert endpoint.ipv4 == 0
 
 
 def test_create_endpoint_ipv6():
-    endpoint = thrift.create_endpoint(
-        port=8080,
-        service_name='foo',
-        ipv6='::1'
-    )
-    assert endpoint.service_name == 'foo'
+    endpoint = thrift.create_endpoint(port=8080, service_name="foo", ipv6="::1")
+    assert endpoint.service_name == "foo"
     assert endpoint.port == 8080
     assert endpoint.ipv4 == 0
-    assert endpoint.ipv6 == \
-        b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01'
-
-
-@mock.patch('socket.gethostbyname', autospec=True)
-def test_copy_endpoint_with_new_service_name(gethostbyname):
-    gethostbyname.return_value = '0.0.0.0'
-    endpoint = thrift.create_endpoint(
-        port=8080,
-        service_name='foo',
+    assert (
+        endpoint.ipv6
+        == b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01"
     )
-    new_endpoint = thrift.copy_endpoint_with_new_service_name(
-        endpoint, 'blargh')
+
+
+@mock.patch("socket.gethostbyname", autospec=True)
+def test_copy_endpoint_with_new_service_name(gethostbyname):
+    gethostbyname.return_value = "0.0.0.0"
+    endpoint = thrift.create_endpoint(port=8080, service_name="foo")
+    new_endpoint = thrift.copy_endpoint_with_new_service_name(endpoint, "blargh")
     assert new_endpoint.port == 8080
-    assert new_endpoint.service_name == 'blargh'
+    assert new_endpoint.service_name == "blargh"
     # An IP address of 0.0.0.0 unpacks to just 0
     assert endpoint.ipv4 == 0
 
 
 def test_create_annotation():
-    ann = thrift.create_annotation('foo', 'bar', 'baz')
-    assert ('foo', 'bar', 'baz') == (ann.timestamp, ann.value, ann.host)
+    ann = thrift.create_annotation("foo", "bar", "baz")
+    assert ("foo", "bar", "baz") == (ann.timestamp, ann.value, ann.host)
 
 
-@mock.patch('py_zipkin.thrift.create_annotation', autospec=True)
+@mock.patch("py_zipkin.thrift.create_annotation", autospec=True)
 def test_annotation_list_builder(ann_mock):
-    ann_list = {'foo': 1, 'bar': 2}
-    thrift.annotation_list_builder(ann_list, 'host')
-    ann_mock.assert_any_call(1000000, 'foo', 'host')
-    ann_mock.assert_any_call(2000000, 'bar', 'host')
+    ann_list = {"foo": 1, "bar": 2}
+    thrift.annotation_list_builder(ann_list, "host")
+    ann_mock.assert_any_call(1000000, "foo", "host")
+    ann_mock.assert_any_call(2000000, "bar", "host")
     assert ann_mock.call_count == 2
 
 
 @pytest.mark.parametrize(
-    'value',
-    [(b'binary', u'unicøde')],
+    "value", [(b"binary", u"unicøde")],
 )
 def test_create_binary_annotation(value):
-    bann = thrift.create_binary_annotation(
-        'foo', value, 'baz', 'bla')
-    assert ('foo', value, 'baz', 'bla') == (
-        bann.key, bann.value, bann.annotation_type, bann.host)
+    bann = thrift.create_binary_annotation("foo", value, "baz", "bla")
+    assert ("foo", value, "baz", "bla") == (
+        bann.key,
+        bann.value,
+        bann.annotation_type,
+        bann.host,
+    )
 
 
-@mock.patch('py_zipkin.thrift.create_binary_annotation', autospec=True)
+@mock.patch("py_zipkin.thrift.create_binary_annotation", autospec=True)
 def test_binary_annotation_list_builder(bann_mock):
-    bann_list = {'key1': 'val1', 'key2': 'val2'}
-    thrift.binary_annotation_list_builder(bann_list, 'host')
-    bann_mock.assert_any_call('key1', 'val1', 6, 'host')
-    bann_mock.assert_any_call('key2', 'val2', 6, 'host')
+    bann_list = {"key1": "val1", "key2": "val2"}
+    thrift.binary_annotation_list_builder(bann_list, "host")
+    bann_mock.assert_any_call("key1", "val1", 6, "host")
+    bann_mock.assert_any_call("key2", "val2", 6, "host")
     assert bann_mock.call_count == 2
 
 
 def test_binary_annotation_list_builder_with_nonstring_values():
-    bann_list = {'test key': 5}
-    banns = thrift.binary_annotation_list_builder(bann_list, 'host')
-    assert banns[0].key == 'test key'
-    assert banns[0].value == '5'
+    bann_list = {"test key": 5}
+    banns = thrift.binary_annotation_list_builder(bann_list, "host")
+    assert banns[0].key == "test key"
+    assert banns[0].value == "5"

--- a/tests/transport_test.py
+++ b/tests/transport_test.py
@@ -10,7 +10,7 @@ from tests.test_helpers import MockTransportHandler
 
 class TestBaseTransportHandler(object):
     def test_call_calls_send(self):
-        with mock.patch.object(MockTransportHandler, 'send', autospec=True):
+        with mock.patch.object(MockTransportHandler, "send", autospec=True):
             transport = MockTransportHandler()
             transport("foobar")
 
@@ -20,20 +20,23 @@ class TestBaseTransportHandler(object):
 
 class TestSimpleHTTPTransport(object):
     def test_get_max_payload_bytes(self):
-        transport = SimpleHTTPTransport('localhost', 9411)
+        transport = SimpleHTTPTransport("localhost", 9411)
         assert transport.get_max_payload_bytes() is None
 
-    @pytest.mark.parametrize('encoding,path,content_type', [
-        (Encoding.V1_THRIFT, '/api/v1/spans', 'application/x-thrift'),
-        (Encoding.V1_JSON, '/api/v1/spans', 'application/json'),
-        (Encoding.V2_JSON, '/api/v2/spans', 'application/json'),
-        (Encoding.V2_PROTO3, '/api/v2/spans', 'application/x-protobuf'),
-    ])
+    @pytest.mark.parametrize(
+        "encoding,path,content_type",
+        [
+            (Encoding.V1_THRIFT, "/api/v1/spans", "application/x-thrift"),
+            (Encoding.V1_JSON, "/api/v1/spans", "application/json"),
+            (Encoding.V2_JSON, "/api/v2/spans", "application/json"),
+            (Encoding.V2_PROTO3, "/api/v2/spans", "application/x-protobuf"),
+        ],
+    )
     def test__get_path_content_type(self, encoding, path, content_type):
         transport = MockTransportHandler()
         with zipkin_span(
-            service_name='my_service',
-            span_name='home',
+            service_name="my_service",
+            span_name="home",
             sample_rate=100,
             transport_handler=transport,
             encoding=encoding,
@@ -41,15 +44,15 @@ class TestSimpleHTTPTransport(object):
             pass
 
         spans = transport.get_payloads()[0]
-        http_transport = SimpleHTTPTransport('localhost', 9411)
+        http_transport = SimpleHTTPTransport("localhost", 9411)
         assert http_transport._get_path_content_type(spans) == (path, content_type)
 
-    @mock.patch('py_zipkin.transport.urlopen', autospec=True)
+    @mock.patch("py_zipkin.transport.urlopen", autospec=True)
     def test_send(self, mock_urlopen):
-        transport = SimpleHTTPTransport('localhost', 9411)
+        transport = SimpleHTTPTransport("localhost", 9411)
         with zipkin_span(
-            service_name='my_service',
-            span_name='home',
+            service_name="my_service",
+            span_name="home",
             sample_rate=100,
             transport_handler=transport,
             encoding=Encoding.V2_JSON,
@@ -58,7 +61,7 @@ class TestSimpleHTTPTransport(object):
 
         assert mock_urlopen.call_count == 1
         request = mock_urlopen.call_args[0][0]
-        assert request.get_full_url() == 'http://localhost:9411/api/v2/spans'
+        assert request.get_full_url() == "http://localhost:9411/api/v2/spans"
         # I don't understand why, but Type gets lowercased to type by urllib
         # Header keys are case insensitive anyway, so it's not a big deal
-        assert request.get_header('Content-type') == 'application/json'
+        assert request.get_header("Content-type") == "application/json"

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -5,23 +5,23 @@ import mock
 from py_zipkin import util
 
 
-@mock.patch('py_zipkin.util.random.getrandbits', autospec=True)
+@mock.patch("py_zipkin.util.random.getrandbits", autospec=True)
 def test_generate_random_64bit_string(rand):
-    rand.return_value = 0x17133d482ba4f605
+    rand.return_value = 0x17133D482BA4F605
     random_string = util.generate_random_64bit_string()
-    assert random_string == '17133d482ba4f605'
+    assert random_string == "17133d482ba4f605"
     # This acts as a contract test of sorts. This should return a str
     # in both py2 and py3. IOW, no unicode objects.
     assert isinstance(random_string, str)
 
 
-@mock.patch('py_zipkin.util.time.time', autospec=True)
-@mock.patch('py_zipkin.util.random.getrandbits', autospec=True)
+@mock.patch("py_zipkin.util.time.time", autospec=True)
+@mock.patch("py_zipkin.util.random.getrandbits", autospec=True)
 def test_generate_random_128bit_string(rand, mock_time):
-    rand.return_value = 0x2ba4f60517133d482ba4f605
-    mock_time.return_value = float(0x17133d48)
+    rand.return_value = 0x2BA4F60517133D482BA4F605
+    mock_time.return_value = float(0x17133D48)
     random_string = util.generate_random_128bit_string()
-    assert random_string == '17133d482ba4f60517133d482ba4f605'
+    assert random_string == "17133d482ba4f60517133d482ba4f605"
     rand.assert_called_once_with(96)  # 96 bits
     # This acts as a contract test of sorts. This should return a str
     # in both py2 and py3. IOW, no unicode objects.
@@ -29,20 +29,18 @@ def test_generate_random_128bit_string(rand, mock_time):
 
 
 def test_unsigned_hex_to_signed_int():
-    assert util.unsigned_hex_to_signed_int('17133d482ba4f605') == \
-        1662740067609015813
-    assert util.unsigned_hex_to_signed_int('b6dbb1c2b362bf51') == \
-        -5270423489115668655
+    assert util.unsigned_hex_to_signed_int("17133d482ba4f605") == 1662740067609015813
+    assert util.unsigned_hex_to_signed_int("b6dbb1c2b362bf51") == -5270423489115668655
 
 
 def test_signed_int_to_unsigned_hex():
-    assert util.signed_int_to_unsigned_hex(1662740067609015813) == \
-        '17133d482ba4f605'
-    assert util.signed_int_to_unsigned_hex(-5270423489115668655) == \
-        'b6dbb1c2b362bf51'
+    assert util.signed_int_to_unsigned_hex(1662740067609015813) == "17133d482ba4f605"
+    assert util.signed_int_to_unsigned_hex(-5270423489115668655) == "b6dbb1c2b362bf51"
 
     if sys.version_info > (3,):
-        with mock.patch('builtins.hex') as mock_hex:
-            mock_hex.return_value = '0xb6dbb1c2b362bf51L'
-            assert util.signed_int_to_unsigned_hex(-5270423489115668655) == \
-                'b6dbb1c2b362bf51'
+        with mock.patch("builtins.hex") as mock_hex:
+            mock_hex.return_value = "0xb6dbb1c2b362bf51L"
+            assert (
+                util.signed_int_to_unsigned_hex(-5270423489115668655)
+                == "b6dbb1c2b362bf51"
+            )

--- a/tests/zipkin_test.py
+++ b/tests/zipkin_test.py
@@ -39,8 +39,7 @@ def clean_thread_local():
 
 
 class TestZipkinSpan(object):
-
-    @mock.patch.object(zipkin.zipkin_span, '_generate_kind', autospec=True)
+    @mock.patch.object(zipkin.zipkin_span, "_generate_kind", autospec=True)
     def test_init(self, mock_generate_kind):
         # Test that all arguments are correctly saved
         zipkin_attrs = ZipkinAttrs(None, None, None, None, None)
@@ -51,20 +50,20 @@ class TestZipkinSpan(object):
         tracer = MockTracer()
 
         context = tracer.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             zipkin_attrs=zipkin_attrs,
             transport_handler=transport,
             max_span_batch_size=10,
-            annotations={'test_annotation': 1},
-            binary_annotations={'status': '200'},
+            annotations={"test_annotation": 1},
+            binary_annotations={"status": "200"},
             port=80,
             sample_rate=100.0,
-            include=('cs', 'cr'),
+            include=("cs", "cr"),
             add_logging_annotation=True,
             report_root_timestamp=True,
             use_128bit_trace_id=True,
-            host='127.0.0.255',
+            host="127.0.0.255",
             context_stack=stack,
             span_storage=span_storage,
             firehose_handler=firehose,
@@ -74,27 +73,25 @@ class TestZipkinSpan(object):
             encoding=Encoding.V2_JSON,
         )
 
-        assert context.service_name == 'test_service'
-        assert context.span_name == 'test_span'
+        assert context.service_name == "test_service"
+        assert context.span_name == "test_span"
         assert context.zipkin_attrs_override == zipkin_attrs
         assert context.transport_handler == transport
         assert context.max_span_batch_size == 10
-        assert context.annotations == {'test_annotation': 1}
-        assert context.binary_annotations == {'status': '200'}
+        assert context.annotations == {"test_annotation": 1}
+        assert context.binary_annotations == {"status": "200"}
         assert context.port == 80
         assert context.sample_rate == 100.0
         assert context.add_logging_annotation is True
         assert context.report_root_timestamp_override is True
         assert context.use_128bit_trace_id is True
-        assert context.host == '127.0.0.255'
+        assert context.host == "127.0.0.255"
         assert context._context_stack == stack
         assert context._span_storage == span_storage
         assert context.firehose_handler == firehose
         assert mock_generate_kind.call_count == 1
         assert mock_generate_kind.call_args == mock.call(
-            context,
-            Kind.CLIENT,
-            ('cs', 'cr'),
+            context, Kind.CLIENT, ("cs", "cr"),
         )
         assert context.timestamp == 1234
         assert context.duration == 10
@@ -104,44 +101,39 @@ class TestZipkinSpan(object):
         assert tracer.get_spans() == span_storage
         assert tracer.get_context() == stack
 
-    @mock.patch.object(zipkin.storage, 'default_span_storage', autospec=True)
-    @mock.patch.object(zipkin.zipkin_span, '_generate_kind', autospec=True)
+    @mock.patch.object(zipkin.storage, "default_span_storage", autospec=True)
+    @mock.patch.object(zipkin.zipkin_span, "_generate_kind", autospec=True)
     def test_init_defaults(self, mock_generate_kind, mock_storage):
         # Test that special arguments are properly defaulted
         mock_storage.return_value = SpanStorage()
         context = zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service", span_name="test_span",
         )
 
-        assert context.service_name == 'test_service'
-        assert context.span_name == 'test_span'
+        assert context.service_name == "test_service"
+        assert context.span_name == "test_span"
         assert context.annotations == {}
         assert context.binary_annotations == {}
-        assert mock_generate_kind.call_args == mock.call(
-            context,
-            None,
-            None,
-        )
+        assert mock_generate_kind.call_args == mock.call(context, None, None)
 
-    @mock.patch.object(zipkin.log, 'warning', autospec=True)
+    @mock.patch.object(zipkin.log, "warning", autospec=True)
     def test_init_override_timestamp_by_sr_ss(self, mock_log):
         context = zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
-            annotations={'sr': 100, 'ss': 500},
+            service_name="test_service",
+            span_name="test_span",
+            annotations={"sr": 100, "ss": 500},
         )
 
         assert context.timestamp == 100
         assert context.duration == 400
         assert mock_log.call_count == 1
 
-    @mock.patch.object(zipkin.log, 'warning', autospec=True)
+    @mock.patch.object(zipkin.log, "warning", autospec=True)
     def test_init_override_timestamp_by_cr_cs(self, mock_log):
         context = zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
-            annotations={'cs': 100, 'cr': 500},
+            service_name="test_service",
+            span_name="test_span",
+            annotations={"cs": 100, "cr": 500},
         )
 
         assert context.timestamp == 100
@@ -152,8 +144,7 @@ class TestZipkinSpan(object):
         # Normal spans are not marked as local root since they're not responsible
         # to log the resulting spans
         context = zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service", span_name="test_span",
         )
 
         assert context._is_local_root_span is False
@@ -161,8 +152,8 @@ class TestZipkinSpan(object):
     def test_init_local_root_transport_sample_rate(self):
         # If transport_handler and sample_rate are set, then this is a local root
         context = zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             transport_handler=MockTransportHandler(),
             sample_rate=100.0,
         )
@@ -172,8 +163,8 @@ class TestZipkinSpan(object):
     def test_init_local_root_transport_zipkin_attrs(self):
         # If transport_handler and zipkin_attrs are set, then this is a local root
         context = zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             transport_handler=MockTransportHandler(),
             zipkin_attrs=zipkin.create_attrs_for_span(),
         )
@@ -184,10 +175,10 @@ class TestZipkinSpan(object):
         # Missing transport_handler
         with pytest.raises(ZipkinError):
             with zipkin.zipkin_span(
-                    service_name='some_service_name',
-                    span_name='span_name',
-                    port=5,
-                    sample_rate=100.0,
+                service_name="some_service_name",
+                span_name="span_name",
+                port=5,
+                sample_rate=100.0,
             ):
                 pass
 
@@ -195,8 +186,8 @@ class TestZipkinSpan(object):
         # If firehose_handler is set, then this is a local root even if there's
         # no sample_rate or zipkin_attrs
         context = zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             firehose_handler=MockTransportHandler(),
         )
 
@@ -206,31 +197,31 @@ class TestZipkinSpan(object):
         # Missing transport_handler
         with pytest.raises(ZipkinError):
             with zipkin.zipkin_span(
-                    service_name='some_service_name',
-                    span_name='span_name',
-                    transport_handler=MockTransportHandler(),
-                    port=5,
-                    sample_rate=100.0,
-                    span_storage=[],
+                service_name="some_service_name",
+                span_name="span_name",
+                transport_handler=MockTransportHandler(),
+                port=5,
+                sample_rate=100.0,
+                span_storage=[],
             ):
                 pass
 
     def test_initinvalid_sample_rate(self):
         with pytest.raises(ZipkinError):
             with zipkin.zipkin_span(
-                    service_name='some_service_name',
-                    span_name='span_name',
-                    transport_handler=MockTransportHandler(),
-                    sample_rate=101.0,
+                service_name="some_service_name",
+                span_name="span_name",
+                transport_handler=MockTransportHandler(),
+                sample_rate=101.0,
             ):
                 pass
 
         with pytest.raises(ZipkinError):
             with zipkin.zipkin_span(
-                    service_name='some_service_name',
-                    span_name='span_name',
-                    transport_handler=MockTransportHandler(),
-                    sample_rate=-0.1,
+                service_name="some_service_name",
+                span_name="span_name",
+                transport_handler=MockTransportHandler(),
+                sample_rate=-0.1,
             ):
                 pass
 
@@ -244,39 +235,37 @@ class TestZipkinSpan(object):
         else:
             signature = inspect.getfullargspec(zipkin.zipkin_span).args
 
-        @zipkin.zipkin_span('test_service', 'test_span')
+        @zipkin.zipkin_span("test_service", "test_span")
         def fn():
             pass
 
-        with mock.patch.object(zipkin, 'zipkin_span') as mock_ctx:
+        with mock.patch.object(zipkin, "zipkin_span") as mock_ctx:
             fn()
 
             # call_args[1] returns the kwargs and we only check that the
             # list of keys is exactly the same as the signature.
             # We skip the first element of the signature since that's self.
-            assert list(mock_ctx.call_args[1].keys()).sort() == \
-                signature[1:].sort()
+            assert list(mock_ctx.call_args[1].keys()).sort() == signature[1:].sort()
 
     def test_enter(self):
         # Test that __enter__ calls self.start
-        context = zipkin.zipkin_span('test_service', 'test_span')
-        with mock.patch.object(context, 'start', autospec=True) as mock_start:
+        context = zipkin.zipkin_span("test_service", "test_span")
+        with mock.patch.object(context, "start", autospec=True) as mock_start:
             context.__enter__()
             assert mock_start.call_count == 1
 
     def test_generate_kind(self):
-        context = zipkin.zipkin_span('test_service', 'test_span')
+        context = zipkin.zipkin_span("test_service", "test_span")
 
-        assert context._generate_kind(Kind.SERVER, ('client',)) == Kind.SERVER
-        assert context._generate_kind(None, ('client',)) == Kind.CLIENT
-        assert context._generate_kind(None, ('server',)) == Kind.SERVER
-        assert context._generate_kind(None, ('client', 'server')) == Kind.LOCAL
+        assert context._generate_kind(Kind.SERVER, ("client",)) == Kind.SERVER
+        assert context._generate_kind(None, ("client",)) == Kind.CLIENT
+        assert context._generate_kind(None, ("server",)) == Kind.SERVER
+        assert context._generate_kind(None, ("client", "server")) == Kind.LOCAL
         assert context._generate_kind(None, None) == Kind.LOCAL
 
-    @mock.patch.object(zipkin, 'create_attrs_for_span', autospec=True)
+    @mock.patch.object(zipkin, "create_attrs_for_span", autospec=True)
     def test_get_current_context_root_sample_rate_override_not_sampled(
-        self,
-        mock_create_attr,
+        self, mock_create_attr,
     ):
         # Root span, with custom zipkin_attrs, not sampled and sample_rate
         zipkin_attrs = ZipkinAttrs(
@@ -287,8 +276,8 @@ class TestZipkinSpan(object):
             is_sampled=False,
         )
         context = zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             transport_handler=MockTransportHandler(),
             zipkin_attrs=zipkin_attrs,
             sample_rate=100.0,
@@ -297,16 +286,14 @@ class TestZipkinSpan(object):
         report_root, _ = context._get_current_context()
 
         assert mock_create_attr.call_args == mock.call(
-            sample_rate=100.0,
-            trace_id=zipkin_attrs.trace_id,
+            sample_rate=100.0, trace_id=zipkin_attrs.trace_id,
         )
         # It wasn't sampled before and now it is, so this is the trace root
         assert report_root is True
 
-    @mock.patch.object(zipkin, 'create_attrs_for_span', autospec=True)
+    @mock.patch.object(zipkin, "create_attrs_for_span", autospec=True)
     def test_get_current_context_root_sample_rate_override_sampled(
-            self,
-            mock_create_attr,
+        self, mock_create_attr,
     ):
         # Root span, with custom zipkin_attrs, sampled
         # Just return the custom zipkin_attrs.
@@ -318,8 +305,8 @@ class TestZipkinSpan(object):
             is_sampled=True,
         )
         context = zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             transport_handler=MockTransportHandler(),
             zipkin_attrs=zipkin_attrs,
             sample_rate=100.0,
@@ -333,16 +320,15 @@ class TestZipkinSpan(object):
         # not the trace root.
         assert report_root is False
 
-    @mock.patch.object(zipkin, 'create_attrs_for_span', autospec=True)
+    @mock.patch.object(zipkin, "create_attrs_for_span", autospec=True)
     def test_get_current_context_root_sample_rate_no_override(
-            self,
-            mock_create_attr,
+        self, mock_create_attr,
     ):
         # Root span, with sample_rate, no override
         # Just generate new zipkin_attrs
         context = zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             transport_handler=MockTransportHandler(),
             sample_rate=100.0,
         )
@@ -350,38 +336,34 @@ class TestZipkinSpan(object):
         report_root, _ = context._get_current_context()
 
         assert mock_create_attr.call_args == mock.call(
-            sample_rate=100.0,
-            use_128bit_trace_id=False,
+            sample_rate=100.0, use_128bit_trace_id=False,
         )
         # No override, which means this is for sure the trace root
         assert report_root is True
 
-    @mock.patch.object(zipkin, 'create_attrs_for_span', autospec=True)
+    @mock.patch.object(zipkin, "create_attrs_for_span", autospec=True)
     def test_get_current_context_root_no_sample_rate_no_override_firehose(
-            self,
-            mock_create_attr,
+        self, mock_create_attr,
     ):
         # Root span, no sample_rate, no override, firehose set
         # Just generate new zipkin_attrs with sample_rate 0
         context = zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             firehose_handler=MockTransportHandler(),
         )
 
         report_root, _ = context._get_current_context()
 
         assert mock_create_attr.call_args == mock.call(
-            sample_rate=0.0,
-            use_128bit_trace_id=False,
+            sample_rate=0.0, use_128bit_trace_id=False,
         )
         # No override, which means this is for sure the trace root
         assert report_root is True
 
-    @mock.patch.object(zipkin, 'create_attrs_for_span', autospec=True)
+    @mock.patch.object(zipkin, "create_attrs_for_span", autospec=True)
     def test_get_current_context_non_root_existing(
-            self,
-            mock_create_attr,
+        self, mock_create_attr,
     ):
         # Non root, zipkin_attrs in context stack.
         # Return existing zipkin_attrs with the current one as parent
@@ -394,8 +376,7 @@ class TestZipkinSpan(object):
         )
         tracer = MockTracer()
         context = tracer.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service", span_name="test_span",
         )
         tracer._context_stack.push(zipkin_attrs)
 
@@ -410,15 +391,13 @@ class TestZipkinSpan(object):
             is_sampled=zipkin_attrs.is_sampled,
         )
 
-    @mock.patch.object(zipkin, 'create_attrs_for_span', autospec=True)
+    @mock.patch.object(zipkin, "create_attrs_for_span", autospec=True)
     def test_get_current_context_non_root_non_existing(
-            self,
-            mock_create_attr,
+        self, mock_create_attr,
     ):
         # Non root, nothing in the stack
         context = zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service", span_name="test_span",
         )
 
         _, current_attrs = context._get_current_context()
@@ -428,23 +407,24 @@ class TestZipkinSpan(object):
 
     def test_start_no_current_context(self):
         # No current context in the stack, let's exit immediately
-        context = zipkin.zipkin_span('test_service', 'test_span')
+        context = zipkin.zipkin_span("test_service", "test_span")
 
-        with mock.patch.object(context.get_tracer()._context_stack, 'push') \
-                as mock_push:
+        with mock.patch.object(
+            context.get_tracer()._context_stack, "push"
+        ) as mock_push:
             context.start()
             assert mock_push.call_count == 0
 
-    @mock.patch.object(zipkin, 'ZipkinLoggingContext', autospec=True)
-    @mock.patch('time.time', autospec=True, return_value=123)
+    @mock.patch.object(zipkin, "ZipkinLoggingContext", autospec=True)
+    @mock.patch("time.time", autospec=True, return_value=123)
     def test_start_root_span(self, mock_time, mock_log_ctx):
         transport = MockTransportHandler()
         firehose = MockTransportHandler()
         tracer = MockTracer()
 
         context = tracer.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             transport_handler=transport,
             firehose_handler=firehose,
             sample_rate=100.0,
@@ -459,11 +439,11 @@ class TestZipkinSpan(object):
         assert mock_log_ctx.call_args == mock.call(
             context.zipkin_attrs,
             mock.ANY,
-            'test_span',
+            "test_span",
             transport,
             True,
             context.get_tracer,
-            'test_service',
+            "test_service",
             binary_annotations={},
             add_logging_annotation=False,
             client_context=False,
@@ -475,13 +455,13 @@ class TestZipkinSpan(object):
         assert mock_log_ctx.return_value.start.call_count == 1
         assert tracer.is_transport_configured() is True
 
-    @mock.patch.object(zipkin, 'ZipkinLoggingContext', autospec=True)
+    @mock.patch.object(zipkin, "ZipkinLoggingContext", autospec=True)
     def test_start_root_span_not_sampled(self, mock_log_ctx):
         transport = MockTransportHandler()
         tracer = MockTracer()
         context = tracer.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             transport_handler=transport,
             sample_rate=0.0,
         )
@@ -492,7 +472,7 @@ class TestZipkinSpan(object):
         assert mock_log_ctx.call_count == 0
         assert tracer.is_transport_configured() is False
 
-    @mock.patch.object(zipkin, 'ZipkinLoggingContext', autospec=True)
+    @mock.patch.object(zipkin, "ZipkinLoggingContext", autospec=True)
     def test_start_root_span_not_sampled_firehose(self, mock_log_ctx):
         # This request is not sampled, but firehose is setup. So we need to
         # setup the transport anyway.
@@ -500,8 +480,8 @@ class TestZipkinSpan(object):
         firehose = MockTransportHandler()
         tracer = MockTracer()
         context = tracer.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             transport_handler=transport,
             firehose_handler=firehose,
             sample_rate=0.0,
@@ -514,16 +494,16 @@ class TestZipkinSpan(object):
         assert mock_log_ctx.return_value.start.call_count == 1
         assert tracer.is_transport_configured() is True
 
-    @mock.patch.object(zipkin, 'ZipkinLoggingContext', autospec=True)
-    @mock.patch.object(zipkin.log, 'info', autospec=True)
+    @mock.patch.object(zipkin, "ZipkinLoggingContext", autospec=True)
+    @mock.patch.object(zipkin.log, "info", autospec=True)
     def test_start_root_span_redef_transport(self, mock_log, mock_log_ctx):
         # Transport is already setup, so we should not override it
         # and log a message to inform the user.
         transport = MockTransportHandler()
         tracer = MockTracer()
         context = tracer.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             transport_handler=transport,
             sample_rate=100.0,
         )
@@ -538,22 +518,22 @@ class TestZipkinSpan(object):
         assert mock_log.call_count == 1
 
     def test_exit(self):
-        context = zipkin.zipkin_span('test_service', 'test_span')
+        context = zipkin.zipkin_span("test_service", "test_span")
 
-        with mock.patch.object(context, 'stop', autospec=True) as mock_stop:
-            context.__exit__(ValueError, 'error', None)
-            assert mock_stop.call_args == mock.call(ValueError, 'error', None)
+        with mock.patch.object(context, "stop", autospec=True) as mock_stop:
+            context.__exit__(ValueError, "error", None)
+            assert mock_stop.call_args == mock.call(ValueError, "error", None)
 
     def test_stop_no_transport(self):
         # Transport is not setup, exit immediately
         span_storage = SpanStorage()
         context = zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             span_storage=span_storage,
         )
 
-        with mock.patch.object(context, 'logging_context') as mock_log_ctx:
+        with mock.patch.object(context, "logging_context") as mock_log_ctx:
             context.start()
             context.stop()
             assert mock_log_ctx.stop.call_count == 0
@@ -564,42 +544,42 @@ class TestZipkinSpan(object):
         transport = MockTransportHandler()
         span_storage = SpanStorage()
         context = zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             transport_handler=transport,
             sample_rate=100.0,
             span_storage=span_storage,
         )
 
-        with mock.patch.object(context, 'update_binary_annotations') as mock_upd:
+        with mock.patch.object(context, "update_binary_annotations") as mock_upd:
             context.start()
-            context.stop(ValueError, 'bad error')
-            assert mock_upd.call_args == mock.call({
-                zipkin.ERROR_KEY: 'ValueError: bad error'
-            })
+            context.stop(ValueError, "bad error")
+            assert mock_upd.call_args == mock.call(
+                {zipkin.ERROR_KEY: "ValueError: bad error"}
+            )
             assert len(span_storage) == 0
 
     def test_error_stopping_log_context(self):
-        '''Tests if exception is raised while emitting traces that
+        """Tests if exception is raised while emitting traces that
            1. tracer is cleared
            2. excpetion is not passed up
-        '''
+        """
         transport = MockTransportHandler()
         tracer = MockTracer()
         context = tracer.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             transport_handler=transport,
             sample_rate=100.0,
         )
         context.start()
 
-        with mock.patch.object(context, 'logging_context') as mock_log_ctx:
+        with mock.patch.object(context, "logging_context") as mock_log_ctx:
             mock_log_ctx.stop.side_effect = Exception
             try:
                 context.stop()
             except Exception:
-                pytest.fail('Exception not expected to be thrown!')
+                pytest.fail("Exception not expected to be thrown!")
 
             assert mock_log_ctx.stop.call_count == 1
             assert len(tracer.get_spans()) == 0
@@ -608,14 +588,14 @@ class TestZipkinSpan(object):
         transport = MockTransportHandler()
         tracer = MockTracer()
         context = tracer.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             transport_handler=transport,
             sample_rate=100.0,
         )
         context.start()
 
-        with mock.patch.object(context, 'logging_context') as mock_log_ctx:
+        with mock.patch.object(context, "logging_context") as mock_log_ctx:
             context.stop()
             assert mock_log_ctx.stop.call_count == 1
             # Test that we reset everything after calling stop()
@@ -623,23 +603,22 @@ class TestZipkinSpan(object):
             assert tracer.is_transport_configured() is False
             assert len(tracer.get_spans()) == 0
 
-    @mock.patch('time.time', autospec=True, return_value=123)
+    @mock.patch("time.time", autospec=True, return_value=123)
     def test_stop_non_root(self, mock_time):
         tracer = MockTracer()
         tracer.set_transport_configured(configured=True)
         tracer.get_context().push(zipkin.create_attrs_for_span())
         context = tracer.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service", span_name="test_span",
         )
         context.start()
 
         context.stop()
         assert len(tracer.get_spans()) == 1
-        endpoint = create_endpoint(service_name='test_service')
+        endpoint = create_endpoint(service_name="test_service")
         assert tracer.get_spans()[0] == Span(
             trace_id=context.zipkin_attrs.trace_id,
-            name='test_span',
+            name="test_span",
             parent_id=context.zipkin_attrs.parent_span_id,
             span_id=context.zipkin_attrs.span_id,
             kind=Kind.LOCAL,
@@ -659,8 +638,8 @@ class TestZipkinSpan(object):
         tracer.get_context().push(zipkin.create_attrs_for_span())
         ts = time.time()
         context = tracer.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             timestamp=ts,
             duration=25,
         )
@@ -668,10 +647,10 @@ class TestZipkinSpan(object):
 
         context.stop()
         assert len(tracer.get_spans()) == 1
-        endpoint = create_endpoint(service_name='test_service')
+        endpoint = create_endpoint(service_name="test_service")
         assert tracer.get_spans()[0] == Span(
             trace_id=context.zipkin_attrs.trace_id,
-            name='test_span',
+            name="test_span",
             parent_id=context.zipkin_attrs.parent_span_id,
             span_id=context.zipkin_attrs.span_id,
             kind=Kind.LOCAL,
@@ -687,265 +666,257 @@ class TestZipkinSpan(object):
 
     def test_update_binary_annotations_root(self):
         with zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             transport_handler=MockTransportHandler(),
             sample_rate=100.0,
-            binary_annotations={'region': 'uswest-1'},
+            binary_annotations={"region": "uswest-1"},
             add_logging_annotation=True,
         ) as span:
-            span.update_binary_annotations({'status': '200'})
+            span.update_binary_annotations({"status": "200"})
 
             assert span.logging_context.tags == {
-                'region': 'uswest-1',
-                'status': '200',
+                "region": "uswest-1",
+                "status": "200",
             }
 
     def test_update_binary_annotations_non_root(self):
         context = zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
-            binary_annotations={'region': 'uswest-1'}
+            service_name="test_service",
+            span_name="test_span",
+            binary_annotations={"region": "uswest-1"},
         )
         context.get_tracer()._context_stack.push(zipkin.create_attrs_for_span())
         with context as span:
-            span.update_binary_annotations({'status': '200'})
+            span.update_binary_annotations({"status": "200"})
 
             assert span.binary_annotations == {
-                'region': 'uswest-1',
-                'status': '200',
+                "region": "uswest-1",
+                "status": "200",
             }
 
     def test_update_binary_annotations_non_root_not_traced(self):
         # nothing happens if the request is not traced
         with zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
-            binary_annotations={'region': 'uswest-1'}
+            service_name="test_service",
+            span_name="test_span",
+            binary_annotations={"region": "uswest-1"},
         ) as span:
-            span.update_binary_annotations({'status': '200'})
+            span.update_binary_annotations({"status": "200"})
 
             assert span.binary_annotations == {
-                'region': 'uswest-1',
-                'status': '200',
+                "region": "uswest-1",
+                "status": "200",
             }
 
     def test_add_annotation_root(self):
         with zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             transport_handler=MockTransportHandler(),
             sample_rate=100.0,
-            annotations={'abc': 123},
+            annotations={"abc": 123},
             add_logging_annotation=True,
         ) as span:
-            span.add_annotation('def', 345)
-            span.add_annotation('ghi', timestamp=678)
-            with mock.patch('py_zipkin.zipkin.time.time') as mock_time:
+            span.add_annotation("def", 345)
+            span.add_annotation("ghi", timestamp=678)
+            with mock.patch("py_zipkin.zipkin.time.time") as mock_time:
                 mock_time.return_value = 91011
-                span.add_annotation('jkl')
+                span.add_annotation("jkl")
 
             assert span.logging_context.annotations == {
-                'abc': 123,
-                'def': 345,
-                'ghi': 678,
-                'jkl': 91011,
+                "abc": 123,
+                "def": 345,
+                "ghi": 678,
+                "jkl": 91011,
             }
 
     def test_add_annotation_non_root(self):
         context = zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
-            annotations={'abc': 123},
+            service_name="test_service",
+            span_name="test_span",
+            annotations={"abc": 123},
         )
         context.get_tracer()._context_stack.push(zipkin.create_attrs_for_span())
         with context as span:
-            span.add_annotation('def', 345)
-            span.add_annotation('ghi', timestamp=678)
-            with mock.patch('py_zipkin.zipkin.time.time') as mock_time:
+            span.add_annotation("def", 345)
+            span.add_annotation("ghi", timestamp=678)
+            with mock.patch("py_zipkin.zipkin.time.time") as mock_time:
                 mock_time.return_value = 91011
-                span.add_annotation('jkl')
+                span.add_annotation("jkl")
 
             assert span.annotations == {
-                'abc': 123,
-                'def': 345,
-                'ghi': 678,
-                'jkl': 91011,
+                "abc": 123,
+                "def": 345,
+                "ghi": 678,
+                "jkl": 91011,
             }
 
     def test_add_annotation_non_root_not_traced(self):
         # nothing happens if the request is not traced
         with zipkin.zipkin_span(
-            service_name='test_service',
-            span_name='test_span',
-            annotations={'abc': 123},
+            service_name="test_service",
+            span_name="test_span",
+            annotations={"abc": 123},
         ) as span:
-            span.add_annotation('def', 345)
-            span.add_annotation('ghi', timestamp=678)
-            with mock.patch('py_zipkin.zipkin.time.time') as mock_time:
+            span.add_annotation("def", 345)
+            span.add_annotation("ghi", timestamp=678)
+            with mock.patch("py_zipkin.zipkin.time.time") as mock_time:
                 mock_time.return_value = 91011
-                span.add_annotation('jkl')
+                span.add_annotation("jkl")
 
             assert span.annotations == {
-                'abc': 123,
-                'def': 345,
-                'ghi': 678,
-                'jkl': 91011,
+                "abc": 123,
+                "def": 345,
+                "ghi": 678,
+                "jkl": 91011,
             }
 
     def test_add_sa_binary_annotation_non_client(self):
         # Nothing happens if this is not a client span
-        context = zipkin.zipkin_span('test_service', 'test_span')
+        context = zipkin.zipkin_span("test_service", "test_span")
 
-        context.add_sa_binary_annotation(80, 'remote_service', '10.1.2.3')
+        context.add_sa_binary_annotation(80, "remote_service", "10.1.2.3")
 
         assert context.remote_endpoint is None
 
     def test_add_sa_binary_annotation_non_root(self):
         # Nothing happens if this is not a client span
-        with zipkin.zipkin_client_span('test_service', 'test_span') as span:
+        with zipkin.zipkin_client_span("test_service", "test_span") as span:
 
-            span.add_sa_binary_annotation(80, 'remote_service', '10.1.2.3')
+            span.add_sa_binary_annotation(80, "remote_service", "10.1.2.3")
 
-            expected_endpoint = create_endpoint(80, 'remote_service', '10.1.2.3')
+            expected_endpoint = create_endpoint(80, "remote_service", "10.1.2.3")
             assert span.remote_endpoint == expected_endpoint
 
             # setting it again throws an error
             with pytest.raises(ValueError):
-                span.add_sa_binary_annotation(80, 'remote_service', '10.1.2.3')
+                span.add_sa_binary_annotation(80, "remote_service", "10.1.2.3")
 
     def test_add_sa_binary_annotation_root(self):
         # Nothing happens if this is not a client span
         with zipkin.zipkin_client_span(
-            service_name='test_service',
-            span_name='test_span',
+            service_name="test_service",
+            span_name="test_span",
             transport_handler=MockTransportHandler(),
             sample_rate=100.0,
         ) as span:
 
-            span.add_sa_binary_annotation(80, 'remote_service', '10.1.2.3')
+            span.add_sa_binary_annotation(80, "remote_service", "10.1.2.3")
 
-            expected_endpoint = create_endpoint(80, 'remote_service', '10.1.2.3')
+            expected_endpoint = create_endpoint(80, "remote_service", "10.1.2.3")
             assert span.logging_context.remote_endpoint == expected_endpoint
 
             # setting it again throws an error
             with pytest.raises(ValueError):
-                span.add_sa_binary_annotation(80, 'remote_service', '10.1.2.3')
+                span.add_sa_binary_annotation(80, "remote_service", "10.1.2.3")
 
     def test_override_span_name(self):
         with zipkin.zipkin_client_span(
-                service_name='test_service',
-                span_name='test_span',
-                transport_handler=MockTransportHandler(),
-                sample_rate=100.0,
+            service_name="test_service",
+            span_name="test_span",
+            transport_handler=MockTransportHandler(),
+            sample_rate=100.0,
         ) as span:
-            span.override_span_name('new_name')
+            span.override_span_name("new_name")
 
-            assert span.span_name == 'new_name'
-            assert span.logging_context.span_name == 'new_name'
+            assert span.span_name == "new_name"
+            assert span.logging_context.span_name == "new_name"
 
 
 def test_zipkin_client_span():
-    context = zipkin.zipkin_client_span('test_service', 'test_span')
+    context = zipkin.zipkin_client_span("test_service", "test_span")
 
     assert context.kind == Kind.CLIENT
 
     with pytest.raises(ValueError):
-        zipkin.zipkin_client_span('test_service', 'test_span', kind=Kind.LOCAL)
+        zipkin.zipkin_client_span("test_service", "test_span", kind=Kind.LOCAL)
 
 
 def test_zipkin_server_span():
-    context = zipkin.zipkin_server_span('test_service', 'test_span')
+    context = zipkin.zipkin_server_span("test_service", "test_span")
 
     assert context.kind == Kind.SERVER
 
     with pytest.raises(ValueError):
-        zipkin.zipkin_server_span('test_service', 'test_span', kind=Kind.LOCAL)
+        zipkin.zipkin_server_span("test_service", "test_span", kind=Kind.LOCAL)
 
 
-@mock.patch('py_zipkin.zipkin.generate_random_128bit_string', autospec=True)
-@mock.patch('py_zipkin.zipkin.generate_random_64bit_string', autospec=True)
+@mock.patch("py_zipkin.zipkin.generate_random_128bit_string", autospec=True)
+@mock.patch("py_zipkin.zipkin.generate_random_64bit_string", autospec=True)
 def test_create_attrs_for_span(random_64bit_mock, random_128bit_mock):
-    random_64bit_mock.return_value = '0000000000000042'
+    random_64bit_mock.return_value = "0000000000000042"
     expected_attrs = ZipkinAttrs(
-        trace_id='0000000000000042',
-        span_id='0000000000000042',
+        trace_id="0000000000000042",
+        span_id="0000000000000042",
         parent_span_id=None,
-        flags='0',
+        flags="0",
         is_sampled=True,
     )
     assert expected_attrs == zipkin.create_attrs_for_span()
 
     # Test overrides
     expected_attrs = ZipkinAttrs(
-        trace_id='0000000000000045',
-        span_id='0000000000000046',
+        trace_id="0000000000000045",
+        span_id="0000000000000046",
         parent_span_id=None,
-        flags='0',
+        flags="0",
         is_sampled=False,
     )
     assert expected_attrs == zipkin.create_attrs_for_span(
-        sample_rate=0.0,
-        trace_id='0000000000000045',
-        span_id='0000000000000046',
+        sample_rate=0.0, trace_id="0000000000000045", span_id="0000000000000046",
     )
 
-    random_128bit_mock.return_value = '00000000000000420000000000000042'
+    random_128bit_mock.return_value = "00000000000000420000000000000042"
     expected_attrs = ZipkinAttrs(
-        trace_id='00000000000000420000000000000042',
-        span_id='0000000000000042',
+        trace_id="00000000000000420000000000000042",
+        span_id="0000000000000042",
         parent_span_id=None,
-        flags='0',
+        flags="0",
         is_sampled=True,
     )
-    assert expected_attrs == zipkin.create_attrs_for_span(
-        use_128bit_trace_id=True,
-    )
+    assert expected_attrs == zipkin.create_attrs_for_span(use_128bit_trace_id=True)
 
 
 def test_create_headers_for_new_span_empty_if_no_active_request():
-    with mock.patch.object(get_default_tracer(), 'get_zipkin_attrs') as mock_ctx:
+    with mock.patch.object(get_default_tracer(), "get_zipkin_attrs") as mock_ctx:
         mock_ctx.return_value = None
         assert {} == zipkin.create_http_headers_for_new_span()
 
 
-@mock.patch('py_zipkin.zipkin.generate_random_64bit_string', autospec=True)
+@mock.patch("py_zipkin.zipkin.generate_random_64bit_string", autospec=True)
 def test_create_headers_for_new_span_returns_header_if_active_request(gen_mock):
     mock_context_stack = mock.Mock()
     mock_context_stack.get.return_value = mock.Mock(
-        trace_id='27133d482ba4f605',
-        span_id='37133d482ba4f605',
-        is_sampled=True,
+        trace_id="27133d482ba4f605", span_id="37133d482ba4f605", is_sampled=True,
     )
-    gen_mock.return_value = '17133d482ba4f605'
+    gen_mock.return_value = "17133d482ba4f605"
     expected = {
-        'X-B3-TraceId': '27133d482ba4f605',
-        'X-B3-SpanId': '17133d482ba4f605',
-        'X-B3-ParentSpanId': '37133d482ba4f605',
-        'X-B3-Flags': '0',
-        'X-B3-Sampled': '1',
+        "X-B3-TraceId": "27133d482ba4f605",
+        "X-B3-SpanId": "17133d482ba4f605",
+        "X-B3-ParentSpanId": "37133d482ba4f605",
+        "X-B3-Flags": "0",
+        "X-B3-Sampled": "1",
     }
     assert expected == zipkin.create_http_headers_for_new_span(
         context_stack=mock_context_stack,
     )
 
 
-@mock.patch('py_zipkin.zipkin.generate_random_64bit_string', autospec=True)
+@mock.patch("py_zipkin.zipkin.generate_random_64bit_string", autospec=True)
 def test_create_headers_for_new_span_custom_tracer(gen_mock):
     tracer = MockTracer()
-    tracer.push_zipkin_attrs(mock.Mock(
-        trace_id='27133d482ba4f605',
-        span_id='37133d482ba4f605',
-        is_sampled=True,
-    ))
-    gen_mock.return_value = '17133d482ba4f605'
-    expected = {
-        'X-B3-TraceId': '27133d482ba4f605',
-        'X-B3-SpanId': '17133d482ba4f605',
-        'X-B3-ParentSpanId': '37133d482ba4f605',
-        'X-B3-Flags': '0',
-        'X-B3-Sampled': '1',
-    }
-    assert expected == zipkin.create_http_headers_for_new_span(
-        tracer=tracer,
+    tracer.push_zipkin_attrs(
+        mock.Mock(
+            trace_id="27133d482ba4f605", span_id="37133d482ba4f605", is_sampled=True,
+        )
     )
+    gen_mock.return_value = "17133d482ba4f605"
+    expected = {
+        "X-B3-TraceId": "27133d482ba4f605",
+        "X-B3-SpanId": "17133d482ba4f605",
+        "X-B3-ParentSpanId": "37133d482ba4f605",
+        "X-B3-Flags": "0",
+        "X-B3-Sampled": "1",
+    }
+    assert expected == zipkin.create_http_headers_for_new_span(tracer=tracer)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pre-commit, py27, py35, py36, py37, pypy, flake8
+envlist = pre-commit, py27, py35, py36, py37, pypy, black, flake8
 
 [testenv]
 deps = -rrequirements-dev.txt
@@ -33,8 +33,14 @@ commands =
     flake8 py_zipkin tests
 
 [flake8]
-exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,docs,py_zipkin/encoding/protobuf/zipkin_pb2.py
-max_line_length = 83
+exclude = .git,__pycache__,.tox,docs,py_zipkin/encoding/protobuf/zipkin_pb2.py
+max_line_length = 88
+
+[testenv:black]
+basepython = python3.7
+deps = black
+commands =
+    black --target-version py27 --exclude setup.py
 
 [coverage:report]
 omit = py_zipkin/encoding/protobuf/zipkin_pb2.py


### PR DESCRIPTION
Similar to what we're doing in other repos, let's use black to format the code to ensure a consistent style