### PR TITLE
Run flake8 after black; make tox's black ignore .tox dir

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
     -   id: debug-statements
     -   id: name-tests-test
         exclude: tests/test_helpers.py
-    -   id: flake8
     -   id: requirements-txt-fixer
 -   repo: https://github.com/asottile/reorder_python_imports.git
     rev: v1.9.0
@@ -25,3 +24,7 @@ repos:
         language_version: python3.7
         exclude: setup.py
         args: [--target-version, py27]
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+    -   id: flake8

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ max_line_length = 88
 basepython = python3.7
 deps = black
 commands =
-    black . --target-version py27 --exclude setup.py
+    black . --target-version py27 --exclude (\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|\.svn|_build|buck-out|build|dist)/|/setup.py
 
 [coverage:report]
 omit = py_zipkin/encoding/protobuf/zipkin_pb2.py


### PR DESCRIPTION
For some reason, I guess the exclusion of setup.py for black when run by
tox caused the default excludes to not take effect.  It's possible tox
expanded paths out fully, so black never saw _just_ ".tox" and the
default exclude failed to match.

In any case, to test this patch, you can run this in your working tree,
before and after this patch:

Before:

rm -rf .tox
tox -eblack
GLOB sdist-make: /.../swiftstack-py-zipkin/setup.py
black create: /.../swiftstack-py-zipkin/.tox/black
black installdeps: black
WARNING: Discarding $PYTHONPATH from environment, to override specify PYTHONPATH in 'passenv' in your configuration.
black inst: /.../swiftstack-py-zipkin/.tox/.tmp/package/1/py_zipkin-0.18.7.zip
WARNING: Discarding $PYTHONPATH from environment, to override specify PYTHONPATH in 'passenv' in your configuration.
black installed: appdirs==1.4.3,attrs==19.3.0,black==19.10b0,Click==7.0,pathspec==0.7.0,ply==3.11,protobuf==3.11.3,py-zipkin==0.18.7,regex==2020.2.20,six==1.14.0,thriftpy2==0.4.10,toml==0.10.0,typed-ast==1.4.1
black run-test-pre: PYTHONHASHSEED='626615762'
black run-test: commands[0] | black . --target-version py27 --exclude setup.py
reformatted /.../swiftstack-py-zipkin/.tox/black/lib/python3.7/site-packages/attr/converters.pyi
reformatted /.../swiftstack-py-zipkin/.tox/black/bin/activate_this.py
...

After this patch:

rm -rf .tox
tox -eblack
GLOB sdist-make: /.../swiftstack-py-zipkin/setup.py
black create: /.../swiftstack-py-zipkin/.tox/black
black installdeps: black
WARNING: Discarding $PYTHONPATH from environment, to override specify PYTHONPATH in 'passenv' in your configuration.
black inst: /.../swiftstack-py-zipkin/.tox/.tmp/package/1/py_zipkin-0.18.7.zip
WARNING: Discarding $PYTHONPATH from environment, to override specify PYTHONPATH in 'passenv' in your configuration.
black installed: appdirs==1.4.3,attrs==19.3.0,black==19.10b0,Click==7.0,pathspec==0.7.0,ply==3.11,protobuf==3.11.3,py-zipkin==0.18.7,regex==2020.2.20,six==1.14.0,thriftpy2==0.4.10,toml==0.10.0,typed-ast==1.4.1
black run-test-pre: PYTHONHASHSEED='810247761'
black run-test: commands[0] | black . --target-version py27 --exclude '(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|\.svn|_build|buck-out|build|dist)/|/setup.py'
All done! ✨ 🍰 ✨
43 files left unchanged.