### PR TITLE
Don't crash when annotating exceptions that cannot be str()'d

### DIFF
--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -486,7 +486,12 @@ class zipkin_span(object):
 
         # Add the error annotation if an exception occurred
         if any((_exc_type, _exc_value, _exc_traceback)):
-            error_msg = u"{0}: {1}".format(_exc_type.__name__, _exc_value)
+            try:
+                error_msg = u"{0}: {1}".format(_exc_type.__name__, _exc_value)
+            except TypeError:
+                # This sometimes happens when an exception raises when calling
+                # __str__ on it.
+                error_msg = u"{0}: {1!r}".format(_exc_type.__name__, _exc_value)
             self.update_binary_annotations({ERROR_KEY: error_msg})
 
         # Logging context is only initialized for "root" spans of the local


### PR DESCRIPTION
Internal ticket: CORESERV-10834

While moving a large service to run under Python 3, we're starting to see a lot of errors like this from py_zipkin:

```
Traceback (most recent call last):
[...]
  File "./xxx.py", line 120, in xxx
    raise webob.exc.HTTPNotFound(GENERAL_ERRORS["NOT_FOUND"])
webob.exc.HTTPNotFound: <unprintable HTTPNotFound object>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
[...]
  File "./virtualenv_py3/lib/python3.7/site-packages/py_zipkin/zipkin.py", line 469, in __exit__
    self.stop(_exc_type, _exc_value, _exc_traceback)
  File "./virtualenv_py3/lib/python3.7/site-packages/py_zipkin/zipkin.py", line 489, in stop
    error_msg = u"{0}: {1}".format(_exc_type.__name__, _exc_value)
TypeError: __str__ returned non-string (type dict)
```

The problem here is that webob exceptions return the `GENERAL_ERRORS["NOT_FOUND"]` which was passed in to the constructor when calling `__str__` on them, but that is actually a dict that gets rendered to JSON when the response is eventually served to the user. Returning a dict from `__str__` causes a `TypeError` when py_zipkin tries to annotate the span with that format string and crashes the entire request. This wasn't an issue under Python 2 because the webob exceptions `__unicode__` method managed to convert the dict to a unicode object.

This is an annoying problem because py_zipkin isn't really wrong to assume it can call `__str__` on exceptions—that's a pretty reasonable assumption—but there's also no easy way for us to fix this besides updating the literal hundreds of views which are already doing this and changing them to some other way of passing down a JSON response in an error, which is a prohibitive amount of work.

I think a pragmatic approach here is to have py_zipkin fall back to using `__repr__` in cases where `__str__` fails rather than crashing the entire request.