### PR TITLE
use V2_JSON as default encoding

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+0.21.0 (2021-03-11)
+-------------------
+- The default encoding is now V2 JSON. If you want to keep the old
+  V1 thrift encoding you'll need to specify it.
+
+0.20.2 (2021-03-11)
+-------------------
+- Don't crash when annotating exceptions that cannot be str()'d
+
 0.20.1 (2020-10-27)
 -------------------
 - Support PRODUCER and CONSUMER spans

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -100,7 +100,7 @@ class zipkin_span(object):
         kind=None,
         timestamp=None,
         duration=None,
-        encoding=Encoding.V1_THRIFT,
+        encoding=Encoding.V2_JSON,
         _tracer=None,
     ):
         """Logs a zipkin span. If this is the root span, then a zipkin


### PR DESCRIPTION
Changes the default encoding from V1_THRIFT to V2_JSON