### PR TITLE
use https over unathenticated git protocol for installing pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 exclude: '^py_zipkin/encoding/protobuf/zipkin_pb2.py$'
 repos:
--   repo: git://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.5.0
     hooks:
     -   id: trailing-whitespace


### PR DESCRIPTION
https://jenkins-george.yelpcorp.com/job/mirrors-Yelp-py_zipkin/926/execution/node/99/log/

The unauthenticated git protocol on port 9418 is no longer supported.