### PR TITLE
Update protobuf init to swallow TypeError during import

### DIFF
--- a/py_zipkin/encoding/protobuf/__init__.py
+++ b/py_zipkin/encoding/protobuf/__init__.py
@@ -7,7 +7,7 @@ from py_zipkin.util import unsigned_hex_to_signed_int
 
 try:
     from py_zipkin.encoding.protobuf import zipkin_pb2
-except ImportError:  # pragma: no cover
+except (ImportError, TypeError):  # pragma: no cover
     zipkin_pb2 = None
 
 


### PR DESCRIPTION
When using py_zipkin, if the underlying environment somehow got a later version of protobuf (4.21.1 specifically), any instrumentation will run into the following error
```
18:20:54 ...some caller....:11: in <module>
18:20:54     from py_zipkin import request_helpers
18:20:54 .tox/py39/lib/python3.9/site-packages/py_zipkin/__init__.py:2: in <module>
18:20:54     from py_zipkin.encoding._types import Encoding  # noqa
18:20:54 .tox/py39/lib/python3.9/site-packages/py_zipkin/encoding/__init__.py:7: in <module>
18:20:54     from py_zipkin.encoding._encoders import get_encoder
18:20:54 .tox/py39/lib/python3.9/site-packages/py_zipkin/encoding/_encoders.py:7: in <module>
18:20:54     from py_zipkin.encoding import protobuf
18:20:54 .tox/py39/lib/python3.9/site-packages/py_zipkin/encoding/protobuf/__init__.py:9: in <module>
18:20:54     from py_zipkin.encoding.protobuf import zipkin_pb2
18:20:54 .tox/py39/lib/python3.9/site-packages/py_zipkin/encoding/protobuf/zipkin_pb2.py:32: in <module>
18:20:54     _descriptor.EnumValueDescriptor(
18:20:54 .tox/py39/lib/python3.9/site-packages/google/protobuf/descriptor.py:755: in __new__
18:20:54     _message.Message._CheckCalledFromGeneratedFile()
18:20:54 E   TypeError: Descriptors cannot not be created directly.
18:20:54 E   If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
18:20:54 E   If you cannot immediately regenerate your protos, some other possible workarounds are:
18:20:54 E    1. Downgrade the protobuf package to 3.20.x or lower.
18:20:54 E    2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```

More details about the protobuf issue can be found at https://github.com/protocolbuffers/protobuf/issues/10051

Interestingly, for our use case we don't even use protobuf for span encoding (we use the default V2_JSON). I also see currently there is already [logic](https://github.com/Yelp/py_zipkin/blob/master/py_zipkin/encoding/protobuf/__init__.py#L10) to handle `ImportError`. So it seems like the easiest solution is to leverage the `zipkin_pb2` flag and don't fail the entire library if the protobuf version is problematic.

There are alternatives such as rebuilding + releasing a new version with latest protobuf, or somehow not import protobuf at all if callers don't want to use it. But these seems more costly than the current PR