### PR TITLE
Pin protobuf version to avoid breaking changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     ],
     extras_require={
         ':python_version=="2.7"': ['enum34'],
-        'protobuf': 'protobuf >= 3.12.4',
+        'protobuf': 'protobuf>=3.12.4,<4',
     },
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
There is already a [PR](https://github.com/Yelp/py_zipkin/pull/163) opened with detailed explanation, however it will break the tests. Pinning the major version also should work. 
