### PR TITLE
drop python 3.5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     rev: v2.34.0
     hooks:
     -   id: pyupgrade
-        args: ['--py3-plus']
+        args: ['--py36-plus']
 -   repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:

--- a/py_zipkin/encoding/_decoders.py
+++ b/py_zipkin/encoding/_decoders.py
@@ -31,10 +31,10 @@ def get_decoder(encoding):
     if encoding == Encoding.V1_THRIFT:
         return _V1ThriftDecoder()
     if encoding == Encoding.V1_JSON:
-        raise NotImplementedError("{} decoding not yet implemented".format(encoding))
+        raise NotImplementedError(f"{encoding} decoding not yet implemented")
     if encoding == Encoding.V2_JSON:
-        raise NotImplementedError("{} decoding not yet implemented".format(encoding))
-    raise ZipkinError("Unknown encoding: {}".format(encoding))
+        raise NotImplementedError(f"{encoding} decoding not yet implemented")
+    raise ZipkinError(f"Unknown encoding: {encoding}")
 
 
 class IDecoder:

--- a/py_zipkin/encoding/_encoders.py
+++ b/py_zipkin/encoding/_encoders.py
@@ -23,7 +23,7 @@ def get_encoder(encoding):
         return _V2JSONEncoder()
     if encoding == Encoding.V2_PROTO3:
         return _V2ProtobufEncoder()
-    raise ZipkinError("Unknown encoding: {}".format(encoding))
+    raise ZipkinError(f"Unknown encoding: {encoding}")
 
 
 class IEncoder:

--- a/py_zipkin/encoding/_helpers.py
+++ b/py_zipkin/encoding/_helpers.py
@@ -91,9 +91,7 @@ class Span:
         self.tags = tags or {}
 
         if not isinstance(kind, Kind):
-            raise ZipkinError(
-                "Invalid kind value {}. Must be of type Kind.".format(kind)
-            )
+            raise ZipkinError(f"Invalid kind value {kind}. Must be of type Kind.")
 
         if local_endpoint and not isinstance(local_endpoint, Endpoint):
             raise ZipkinError("Invalid local_endpoint value. Must be of type Endpoint.")

--- a/py_zipkin/transport.py
+++ b/py_zipkin/transport.py
@@ -91,7 +91,7 @@ class SimpleHTTPTransport(BaseTransportHandler):
 
     def send(self, payload):
         path, content_type = self._get_path_content_type(payload)
-        url = "http://{}:{}{}".format(self.address, self.port, path)
+        url = f"http://{self.address}:{self.port}{path}"
 
         req = Request(url, payload, {"Content-Type": content_type})
         response = urlopen(req)

--- a/py_zipkin/util.py
+++ b/py_zipkin/util.py
@@ -26,7 +26,7 @@ def generate_random_64bit_string():
 
     :returns: random 16-character string
     """
-    return "{:016x}".format(random.getrandbits(64))
+    return f"{random.getrandbits(64):016x}"
 
 
 def generate_random_128bit_string():
@@ -41,7 +41,7 @@ def generate_random_128bit_string():
     """
     t = int(time.time())
     lower_96 = random.getrandbits(96)
-    return "{:032x}".format((t << 96) | lower_96)
+    return f"{(t << 96) | lower_96:032x}"
 
 
 def unsigned_hex_to_signed_int(hex_string):

--- a/py_zipkin/zipkin.py
+++ b/py_zipkin/zipkin.py
@@ -487,11 +487,11 @@ class zipkin_span:
         # Add the error annotation if an exception occurred
         if any((_exc_type, _exc_value, _exc_traceback)):
             try:
-                error_msg = "{}: {}".format(_exc_type.__name__, _exc_value)
+                error_msg = f"{_exc_type.__name__}: {_exc_value}"
             except TypeError:
                 # This sometimes happens when an exception raises when calling
                 # __str__ on it.
-                error_msg = "{}: {!r}".format(_exc_type.__name__, _exc_value)
+                error_msg = f"{_exc_type.__name__}: {_exc_value!r}"
             self.update_binary_annotations({ERROR_KEY: error_msg})
 
         # Logging context is only initialized for "root" spans of the local
@@ -501,7 +501,7 @@ class zipkin_span:
             try:
                 self.logging_context.stop()
             except Exception as ex:
-                err_msg = "Error emitting zipkin trace. {}".format(repr(ex))
+                err_msg = f"Error emitting zipkin trace. {repr(ex)}"
                 log.error(err_msg)
             finally:
                 self.logging_context = None

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=('tests*', 'testing*', 'tools*')),
     package_data={'': ['*.thrift']},
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     install_requires=[
         'thriftpy2>=0.4.0',
     ],
@@ -37,8 +37,8 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pre-commit, py35, py36, py37, py38, pypy, black, flake8
+envlist = pre-commit, py36, py37, py38, pypy3, black, flake8
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
I thought about dropping python 3.6 as well, but that would require jumping through a bunch of hoops for supporting pypy3 still.