### PR TITLE
Include type stubs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ setup(
     package_data={
         '': ['*.thrift'],
         'py_zipkin': ['py.typed'],
+        'py_zipkin.thrift': ['*.pyi'],
+        'py_zipkin.encoding.protobuf': ['*.pyi'],
     },
     python_requires='>=3.6',
     install_requires=[


### PR DESCRIPTION
Type stub files need to be included in the dist as well.

## Validation

Locally built the package, ensuring the build output contains
```
...
copying py_zipkin/encoding/protobuf/zipkin_pb2.py -> py_zipkin-1.2.1/py_zipkin/encoding/protobuf
copying py_zipkin/encoding/protobuf/zipkin_pb2.pyi -> py_zipkin-1.2.1/py_zipkin/encoding/protobuf
...
copying py_zipkin/thrift/zipkinCore.pyi -> py_zipkin-1.2.1/py_zipkin/thrift
copying py_zipkin/thrift/zipkinCore.thrift -> py_zipkin-1.2.1/py_zipkin/thrift
...
```

## Action Items

- [x] Fix unrelated test/pre-commit failures (#176)
- [ ] Patch bump package version after merge