### PR TITLE
Update flake8 pre-commit repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
             setup.py|
             py_zipkin/encoding/protobuf/zipkin_pb2.pyi
           )$
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
     -   id: flake8


### PR DESCRIPTION
flake8 moved from gitlab to github

## Validation

pre-commit succeeds again.

## Action Items

- [ ] Fix unrelated test failures
- [ ] merge only