### PR TITLE
fix build

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
             setup.py|
             py_zipkin/encoding/protobuf/zipkin_pb2.pyi
           )$
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
     -   id: flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 # on python 3.6.0 (xenial)
 coverage<5
 mock<4  # mock 4.x dropped support for python 2.7
+mypy<0.982  # TODO fix failures
 mypy-protobuf
 ordereddict
 pytest

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     },
     python_requires='>=3.6',
     install_requires=[
-        'thriftpy2>=0.4.0',
+        'thriftpy2>=0.4.0,<0.4.14',
         'typing-extensions>=3.10.0.0',
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,6 @@ commands =
 basepython = python3.8
 deps =
     -rrequirements-dev.txt
-    mypy
 commands =
     mypy py_zipkin/
 


### PR DESCRIPTION
This
- max pins thriftpy2, as the newer versions break some tests
- max pins mypy as the newest version has new failures
- switches the flake8 repo to the github one from the now removed gitlab one