### PR TITLE
Fix V2_JSON encoding

### DIFF
--- a/py_zipkin/encoding/_encoders.py
+++ b/py_zipkin/encoding/_encoders.py
@@ -248,7 +248,7 @@ class _BaseJSONEncoder(IEncoder):
     def encode_queue(self, queue: List[Union[str, bytes]]) -> str:
         """Concatenates the list to a JSON list"""
         assert _is_str_list(queue)
-        return "[" + ",".join(queue) + "]"
+        return ("[" + ",".join(queue) + "]").encode()
 
 
 class JSONv1BinaryAnnotation(TypedDict):

--- a/tests/encoding/__init__test.py
+++ b/tests/encoding/__init__test.py
@@ -19,7 +19,6 @@ def test_detect_span_version_and_encoding(encoding):
 
     if encoding in [Encoding.V1_JSON, Encoding.V2_JSON]:
         assert type(spans) == old_type
-        spans = spans.encode()
         assert detect_span_version_and_encoding(spans) == encoding
 
 


### PR DESCRIPTION
_BaseJSONEncoder.encode_queue() needs to return a bytes object as the rest of the encoders do, not a string. Transport handlers expect this return type.