### PR TITLE
Add back exports in py_zipkin.encoding

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+1.2.8 (2023-03-23)
+-------------------
+- Add back exports in py_zipkin.encoding
+- Fix mypy tests
+
 1.2.7 (2023-02-06)
 -------------------
 - Drop support for Python 3.6

--- a/py_zipkin/encoding/__init__.py
+++ b/py_zipkin/encoding/__init__.py
@@ -2,6 +2,11 @@ import json
 from typing import Optional
 from typing import Union
 
+from py_zipkin.encoding._decoders import get_decoder  # noqa: F401
+from py_zipkin.encoding._encoders import get_encoder  # noqa: F401
+from py_zipkin.encoding._helpers import create_endpoint  # noqa: F401
+from py_zipkin.encoding._helpers import Endpoint  # noqa: F401
+from py_zipkin.encoding._helpers import Span  # noqa: F401
 from py_zipkin.encoding._types import Encoding
 from py_zipkin.exception import ZipkinError
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '1.2.7'
+__version__ = '1.2.8'
 
 
 def read(f):


### PR DESCRIPTION
### Problem
Some of the functions were removed because they were no longer used in the file, but turns out they are exported and used outside the file.

### Solution
Add the exported functions back to the file.

### Testing
`make && make test`